### PR TITLE
Support local env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 
 | Name | Description |
 |---|---|
-| `get-page-history` | Returns information about the latest revisions to a wiki page.
+| `get-page-history` | Returns information about the latest revisions to a wiki page. |
 | `get-page` | Returns the standard page object for a wiki page. |
 | `search-page` | Search wiki page titles and contents for the provided search terms. |
 | `set-wiki` | Set the wiki to use for the current session. |
+
+### Environment variables
+
+| Name | Description |
+|---|---|
+| `WIKI_SERVER` | Domain of the wiki (e.g. `https://en.wikipedia.org`) |
+| `ARTICLE_PATH` | Article path of the wiki (e.g. `/wiki`) |
+| `SCRIPT_PATH` | Script path of the wiki (e.g. `/w`) |
+| `OAUTH_TOKEN` | OAuth token from the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) |
 
 ## Setup
 
@@ -21,7 +30,6 @@ make install
 ```
 
 ## Development
-
 
 ### [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -2,12 +2,15 @@ interface AppConfig {
 	WIKI_SERVER: string;
 	ARTICLE_PATH: string;
 	SCRIPT_PATH: string;
+	OAUTH_TOKEN?: string;
 }
 
+// TODO: Need better handling for OAUTH_TOKEN since it will be different for each wiki.
 const defaultConfig: AppConfig = {
-	WIKI_SERVER: 'https://en.wikipedia.org',
-	ARTICLE_PATH: '/wiki',
-	SCRIPT_PATH: '/w'
+	WIKI_SERVER: process.env.WIKI_SERVER || 'https://en.wikipedia.org',
+	ARTICLE_PATH: process.env.ARTICLE_PATH || '/wiki',
+	SCRIPT_PATH: process.env.SCRIPT_PATH || '/w',
+	OAUTH_TOKEN: process.env.OAUTH_TOKEN || undefined
 };
 
 let currentConfig: AppConfig = { ...defaultConfig };


### PR DESCRIPTION
Related: #8

This somewhat implements #8 but we need consider how we approach multi-wiki handling:

1. Disable the `set-wiki` tool entirely if the config are set.
2. Allow the `set-wiki` tool to access the config to find the right config (e.g. OAuth token) for the current wiki. To do that, we need to consider how are we saving the config as an environmental variable
