### PR TITLE
Implement upload file tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `search-page` | Search wiki page titles and contents for the provided search terms. |
 | `set-wiki` | Set the wiki to use for the current session. |
 | `update-page` 🔐 | Update an existing wiki page. |
+| `upload-file` 🔐 | Uploads a file to the wiki from the local disk. |
+| `upload-file-from-url` 🔐 | Uploads a file to the wiki from a web URL. |
 
 ### Environment variables
 | Name | Description | Default |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@modelcontextprotocol/sdk": "^1.11.3",
 				"express": "^5.1.0",
 				"mwn": "^3.0.1",
-				"node-fetch": "^3.3.2"
+				"node-fetch": "^3.3.2",
+				"types-mediawiki-api": "^2.0.0"
 			},
 			"bin": {
 				"mediawiki-mcp-server": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.3",
 				"express": "^5.1.0",
+				"mwn": "^3.0.1",
 				"node-fetch": "^3.3.2"
 			},
 			"bin": {
@@ -506,6 +507,12 @@
 				"@types/send": "*"
 			}
 		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"license": "MIT"
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.44.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
@@ -845,7 +852,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -888,8 +894,18 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+			"integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
+				"proxy-from-env": "^1.1.0"
+			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1074,7 +1090,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -1145,7 +1160,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -1158,14 +1172,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
@@ -1362,7 +1374,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -1491,7 +1502,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -2726,11 +2736,30 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
 			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -2954,7 +2983,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -2976,7 +3004,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -3422,7 +3449,6 @@
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -3432,7 +3458,6 @@
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "1.52.0"
@@ -3471,6 +3496,31 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/mwn": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mwn/-/mwn-3.0.1.tgz",
+			"integrity": "sha512-FuANXsGtDbkRYd4c2we7veVasX6eicCIzX/bKS7mrR/3c1FlPDZKSsSSIuDhWOx008OCoTFyL8j4ayekx0rvyQ==",
+			"license": "LGPL-3.0-or-later",
+			"dependencies": {
+				"@types/node": "^14.18.63",
+				"@types/tough-cookie": "^4.0.5",
+				"axios": "^1.8.3",
+				"chalk": "^4.1.2",
+				"form-data": "^4.0.2",
+				"oauth-1.0a": "^2.2.6",
+				"tough-cookie": "^4.1.4",
+				"types-mediawiki-api": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/mwn/node_modules/@types/node": {
+			"version": "14.18.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
 			"license": "MIT"
 		},
 		"node_modules/natural-compare": {
@@ -3569,6 +3619,12 @@
 			"funding": {
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
+		},
+		"node_modules/oauth-1.0a": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+			"integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==",
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -3825,6 +3881,24 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3848,6 +3922,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -4062,6 +4142,12 @@
 			"engines": {
 				"node": ">=0.10.5"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"license": "MIT"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
@@ -4524,7 +4610,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -4583,6 +4668,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tree-kill": {
@@ -4676,6 +4776,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/types-mediawiki-api": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/types-mediawiki-api/-/types-mediawiki-api-2.0.0.tgz",
+			"integrity": "sha512-JeAm+5vD0Fe131UBt8ihJyRtXQlO4Zj180mOE3fcsdBLchqn1+ZfWBvJhBknd+hMalJ2H4DmsTzmbtDRB/sSYQ==",
+			"license": "GPL-3.0-or-later"
+		},
 		"node_modules/typescript": {
 			"version": "5.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -4696,6 +4802,15 @@
 			"integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -4755,6 +4870,16 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"@modelcontextprotocol/sdk": "^1.11.3",
 		"express": "^5.1.0",
 		"mwn": "^3.0.1",
-		"node-fetch": "^3.3.2"
+		"node-fetch": "^3.3.2",
+		"types-mediawiki-api": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/express": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.11.3",
 		"express": "^5.1.0",
+		"mwn": "^3.0.1",
 		"node-fetch": "^3.3.2"
 	},
 	"devDependencies": {

--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -1,0 +1,11 @@
+import { USER_AGENT } from '../server.js';
+import { scriptPath, wikiServer, oauthToken } from './config.js';
+import { Mwn } from 'mwn';
+
+export async function getMwn(): Promise<Mwn> {
+	return await Mwn.init( {
+		apiUrl: `${ wikiServer() }${ scriptPath() }/api.php`,
+		OAuth2AccessToken: oauthToken() || undefined,
+		userAgent: USER_AGENT
+	} );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,8 @@ import { setWikiTool } from './set-wiki.js';
 import { updatePageTool } from './update-page.js';
 import { getFileTool } from './get-file.js';
 import { createPageTool } from './create-page.js';
+import { uploadFileTool } from './upload-file.js';
+import { uploadFileFromUrlTool } from './upload-file-from-url.js';
 
 const toolRegistrars = [
 	getPageTool,
@@ -17,7 +19,9 @@ const toolRegistrars = [
 	setWikiTool,
 	updatePageTool,
 	getFileTool,
-	createPageTool
+	createPageTool,
+	uploadFileTool,
+	uploadFileFromUrlTool
 ];
 
 export function registerAllTools( server: McpServer ): RegisteredTool[] {

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiUploadParams } from 'types-mediawiki-api';
+/* eslint-enable n/no-missing-import */
+import type { ApiUploadResponse } from 'mwn';
+import { getMwn } from '../common/mwn.js';
+import { formatEditComment } from '../common/utils.js';
+
+export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'upload-file-from-url',
+		'Uploads a file to the wiki from a web URL.',
+		{
+			url: z.string().url().describe( 'URL of the file to upload' ),
+			title: z.string().describe( 'File title' ),
+			text: z.string().describe( 'Wikitext on the file page' ),
+			comment: z.string().describe( 'Reason for uploading the file' ).optional()
+		},
+		{
+			title: 'Upload file from URL',
+			readOnlyHint: false,
+			destructiveHint: true
+		} as ToolAnnotations,
+		async (
+			{ url, title, text, comment }
+		) => handleUploadFileFromUrlTool( url, title, text, comment )
+	);
+}
+
+async function handleUploadFileFromUrlTool(
+	url: string, title: string, text: string, comment?: string
+): Promise< CallToolResult > {
+
+	let data: ApiUploadResponse | null = null;
+	try {
+		const mwn = await getMwn();
+		data = await mwn.uploadFromUrl( url, title, text, getApiUploadParams( comment ) );
+	} catch ( error ) {
+		const errorMessage = ( error as Error ).message;
+
+		// Prevent the LLM from attempting to find an existing image on the wiki
+		// after failing to upload by URL.
+		if ( errorMessage.includes( 'copyuploaddisabled' ) ) {
+			return {
+				content: [
+					{
+						type: 'text',
+						text: 'Upload failed: Upload by URL is disabled for this wiki. Please download the image from the URL to the local disk first, then use the upload-file tool to upload it from the local file path.'
+					} as TextContent
+				],
+				isError: true
+			};
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Upload failed: ${ ( error as Error ).message }`
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
+	if ( data === null ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: 'Upload failed: No response data received from the API'
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
+	return {
+		content: uploadFileFromUrlToolResult( data )
+	};
+}
+
+function getApiUploadParams( comment?: string ): ApiUploadParams {
+	return {
+		comment: formatEditComment( 'upload-file-from-url', comment )
+	};
+}
+
+function uploadFileFromUrlToolResult( data: ApiUploadResponse ): TextContent[] {
+	const result: TextContent[] = [
+		{
+			type: 'text',
+			text: 'File uploaded successfully from URL'
+		}
+	];
+
+	result.push( {
+		type: 'text',
+		text: `Upload details: ${ JSON.stringify( data, null, 2 ) }`
+	} );
+
+	return result;
+}

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiUploadParams } from 'types-mediawiki-api';
+/* eslint-enable n/no-missing-import */
+import type { ApiUploadResponse } from 'mwn';
+import { getMwn } from '../common/mwn.js';
+import { formatEditComment } from '../common/utils.js';
+
+export function uploadFileTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'upload-file',
+		'Uploads a file to the wiki from the local disk.',
+		{
+			filepath: z.string().describe( 'File path on the local disk' ),
+			title: z.string().describe( 'File title' ),
+			text: z.string().describe( 'Wikitext on the file page' ),
+			comment: z.string().describe( 'Reason for uploading the file' ).optional()
+		},
+		{
+			title: 'Upload file',
+			readOnlyHint: false,
+			destructiveHint: true
+		} as ToolAnnotations,
+		async (
+			{ filepath, title, text, comment }
+		) => handleUploadFileTool( filepath, title, text, comment )
+	);
+}
+
+async function handleUploadFileTool(
+	filepath: string, title: string, text: string, comment?: string
+): Promise< CallToolResult > {
+
+	let data: ApiUploadResponse | null = null;
+	try {
+		const mwn = await getMwn();
+		data = await mwn.upload( filepath, title, text, getApiUploadParams( comment ) );
+	} catch ( error ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Upload failed: ${ ( error as Error ).message }`
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
+	if ( data === null ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: 'Upload failed: No response data received from the API'
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
+	return {
+		content: uploadFileToolResult( data )
+	};
+}
+
+function getApiUploadParams( comment?: string ): ApiUploadParams {
+	return {
+		comment: formatEditComment( 'upload-file', comment )
+	};
+}
+
+function uploadFileToolResult( data: ApiUploadResponse ): TextContent[] {
+	const result: TextContent[] = [
+		{
+			type: 'text',
+			text: 'File uploaded successfully'
+		}
+	];
+
+	result.push( {
+		type: 'text',
+		text: `Upload details: ${ JSON.stringify( data, null, 2 ) }`
+	} );
+
+	return result;
+}


### PR DESCRIPTION
Key changes:
- Add `upload-file` tool for local file upload
- Add `upload-file-from-url` tool for uploading by URL. If the wiki disabled `$wgAllowCopyUploads` (which is default), instructs the LLM to workaround that.
- Add `mwn` and `types-mediawiki-api` as dependencies

Tested with the following prompt:
```
Use the MediaWiki MCP server to edit the page (PAGENAME) on (WIKI URL) to include an image of a cat
```