### PR TITLE
Remove redundant null checks in API handling logic

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -52,7 +52,7 @@ async function fetchCore(
 export async function makeApiRequest<T>(
 	url: string,
 	params?: Record<string, string>
-): Promise<T | null> {
+): Promise<T> {
 	const response = await fetchCore( url, {
 		params,
 		headers: { Accept: 'application/json' }
@@ -64,7 +64,7 @@ export async function makeRestGetRequest<T>(
 	path: string,
 	params?: Record<string, string>,
 	needAuth: boolean = false
-): Promise<T | null> {
+): Promise<T> {
 	const headers: Record<string, string> = {
 		Accept: 'application/json'
 	};
@@ -83,7 +83,7 @@ export async function makeRestPutRequest<T>(
 	path: string,
 	body: Record<string, unknown>,
 	needAuth: boolean = false
-): Promise<T | null> {
+): Promise<T> {
 	const headers: Record<string, string> = {
 		Accept: 'application/json',
 		'Content-Type': 'application/json'
@@ -104,7 +104,7 @@ export async function makeRestPostRequest<T>(
 	path: string,
 	body?: Record<string, unknown>,
 	needAuth: boolean = false
-): Promise<T | null> {
+): Promise<T> {
 	const headers: Record<string, string> = {
 		Accept: 'application/json',
 		'Content-Type': 'application/json'

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -33,7 +33,7 @@ async function handleCreatePageTool(
 	comment?: string,
 	contentModel?: string
 ): Promise<CallToolResult> {
-	let data: MwRestApiPageObject | null = null;
+	let data: MwRestApiPageObject;
 
 	try {
 		data = await makeRestPostRequest<MwRestApiPageObject>( '/v1/page', {
@@ -47,15 +47,6 @@ async function handleCreatePageTool(
 		return {
 			content: [
 				{ type: 'text', text: `Failed to create page: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{ type: 'text', text: 'Failed to create page: No data returned from API' } as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/get-file.ts
+++ b/src/tools/get-file.ts
@@ -23,22 +23,13 @@ export function getFileTool( server: McpServer ): RegisteredTool {
 }
 
 async function handleGetFileTool( title: string ): Promise< CallToolResult > {
-	let data: MwRestApiFileObject | null = null;
+	let data: MwRestApiFileObject;
 	try {
 		data = await makeRestGetRequest<MwRestApiFileObject>( `/v1/file/${ encodeURIComponent( title ) }` );
 	} catch ( error ) {
 		return {
 			content: [
 				{ type: 'text', text: `Failed to retrieve file data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{ type: 'text', text: 'Failed to retrieve file data: No data returned from API' } as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -44,7 +44,7 @@ async function handleGetPageHistoryTool(
 		params.filter = filter;
 	}
 
-	let data: MwRestApiGetPageHistoryResponse | null = null;
+	let data: MwRestApiGetPageHistoryResponse;
 	try {
 		data = await makeRestGetRequest<MwRestApiGetPageHistoryResponse>(
 			`/v1/page/${ encodeURIComponent( title ) }/history`,
@@ -54,18 +54,6 @@ async function handleGetPageHistoryTool(
 		return {
 			content: [
 				{ type: 'text', text: `Failed to retrieve page history: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: 'Failed to retrieve page data: No data returned from API'
-				} as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -43,7 +43,7 @@ async function handleGetPageTool( title: string, content: ContentFormat ): Promi
 			break;
 	}
 
-	let data: MwRestApiPageObject | null = null;
+	let data: MwRestApiPageObject;
 
 	try {
 		data = await makeRestGetRequest<MwRestApiPageObject>( `/v1/page/${ encodeURIComponent( title ) }${ subEndpoint }` );
@@ -51,15 +51,6 @@ async function handleGetPageTool( title: string, content: ContentFormat ): Promi
 		return {
 			content: [
 				{ type: 'text', text: `Failed to retrieve page data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{ type: 'text', text: 'Failed to retrieve page data: No data returned from API' } as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -28,7 +28,7 @@ export function searchPageTool( server: McpServer ): RegisteredTool {
 }
 
 async function handleSearchPageTool( query: string, limit?: number ): Promise< CallToolResult > {
-	let data: MwRestApiSearchPageResponse | null = null;
+	let data: MwRestApiSearchPageResponse;
 	try {
 		data = await makeRestGetRequest<MwRestApiSearchPageResponse>(
 			'/v1/search/page',
@@ -38,15 +38,6 @@ async function handleSearchPageTool( query: string, limit?: number ): Promise< C
 		return {
 			content: [
 				{ type: 'text', text: `Failed to retrieve search data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{ type: 'text', text: 'Failed to retrieve search data: No data returned from API' } as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -33,7 +33,7 @@ async function handleUpdatePageTool(
 	latestId: number,
 	comment?: string
 ): Promise<CallToolResult> {
-	let data: MwRestApiPageObject | null = null;
+	let data: MwRestApiPageObject;
 	try {
 		data = await makeRestPutRequest<MwRestApiPageObject>( `/v1/page/${ encodeURIComponent( title ) }`, {
 			source: source,
@@ -44,15 +44,6 @@ async function handleUpdatePageTool(
 		return {
 			content: [
 				{ type: 'text', text: `Failed to update page: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{ type: 'text', text: 'Failed to update page: No data returned from API' } as TextContent
 			],
 			isError: true
 		};

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -33,7 +33,7 @@ async function handleUploadFileFromUrlTool(
 	url: string, title: string, text: string, comment?: string
 ): Promise< CallToolResult > {
 
-	let data: ApiUploadResponse | null = null;
+	let data: ApiUploadResponse;
 	try {
 		const mwn = await getMwn();
 		data = await mwn.uploadFromUrl( url, title, text, getApiUploadParams( comment ) );
@@ -59,18 +59,6 @@ async function handleUploadFileFromUrlTool(
 				{
 					type: 'text',
 					text: `Upload failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: 'Upload failed: No response data received from the API'
 				} as TextContent
 			],
 			isError: true

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -33,7 +33,7 @@ async function handleUploadFileTool(
 	filepath: string, title: string, text: string, comment?: string
 ): Promise< CallToolResult > {
 
-	let data: ApiUploadResponse | null = null;
+	let data: ApiUploadResponse;
 	try {
 		const mwn = await getMwn();
 		data = await mwn.upload( filepath, title, text, getApiUploadParams( comment ) );
@@ -43,18 +43,6 @@ async function handleUploadFileTool(
 				{
 					type: 'text',
 					text: `Upload failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
-	}
-
-	if ( data === null ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: 'Upload failed: No response data received from the API'
 				} as TextContent
 			],
 			isError: true


### PR DESCRIPTION
`data` is always assigned so the code is unreachable