### PR TITLE
Support authentication via CSRF token

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,17 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 
 ### Tools
 
-> 🔐 **Requires OAuth 2.0 token in configuration:** Obtained via `Special:OAuthConsumerRegistration/propose/oauth2` provided by the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth). Select "This consumer is for use only by UserName"
-
-| Name | Description | 
-|---|---|
-| `create-page` 🔐 | Create a new wiki page. |
-| `get-file` | Returns the standard file object for a file page. |
-| `get-page` | Returns the standard page object for a wiki page. |
-| `get-page-history` | Returns information about the latest revisions to a wiki page. |
-| `search-page` | Search wiki page titles and contents for the provided search terms. |
-| `set-wiki` | Set the wiki to use for the current session. |
-| `update-page` 🔐 | Update an existing wiki page. |
-| `upload-file` 🔐 | Uploads a file to the wiki from the local disk. |
-| `upload-file-from-url` 🔐 | Uploads a file to the wiki from a web URL. |
+| Name | Description | Permissions |
+|---|---|---|
+| `create-page` 🔐 | Create a new wiki page. | `Create, edit, and move pages` |
+| `get-file` | Returns the standard file object for a file page. | - |
+| `get-page` | Returns the standard page object for a wiki page. | - |
+| `get-page-history` | Returns information about the latest revisions to a wiki page. | - |
+| `search-page` | Search wiki page titles and contents for the provided search terms. | - |
+| `set-wiki` | Set the wiki to use for the current session. | - |
+| `update-page` 🔐 | Update an existing wiki page. | `Edit existing pages` |
+| `upload-file` 🔐 | Uploads a file to the wiki from the local disk. | `Upload new files` |
+| `upload-file-from-url` 🔐 | Uploads a file to the wiki from a web URL. | `Upload, replace, and move files` |
 
 ### Environment variables
 | Name | Description | Default |
@@ -27,6 +25,71 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
+
+## Configuration
+
+Create a `config.json` file to configure wiki connections. Use the `config.example.json` as a starting point.
+
+### Basic structure
+
+```json
+{
+  "defaultWiki": "en.wikipedia.org",
+  "wikis": {
+    "en.wikipedia.org": {
+      "sitename": "Wikipedia",
+      "server": "https://en.wikipedia.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "token": null,
+      "username": null,
+      "password": null,
+      "private": false
+    }
+  }
+}
+```
+
+### Configuration fields
+
+| Field | Description |
+|---|---|
+| `defaultWiki` | The default wiki identifier to use (matches a key in `wikis`) |
+| `wikis` | Object containing wiki configurations, keyed by domain/identifier |
+
+### Wiki configuration fields
+
+| Field | Required | Description |
+|---|---|---|
+| `sitename` | Yes | Display name for the wiki |
+| `server` | Yes | Base URL of the wiki (e.g., `https://en.wikipedia.org`) |
+| `articlepath` | Yes | Path pattern for articles (typically `/wiki`) |
+| `scriptpath` | Yes | Path to MediaWiki scripts (typically `/w`) |
+| `token` | No | OAuth2 access token for authenticated operations (preferred) |
+| `username` | No | Bot username (fallback when OAuth2 is not available) |
+| `password` | No | Bot password (fallback when OAuth2 is not available) |
+| `private` | No | Whether the wiki requires authentication to read (default: `false`) |
+
+### Authentication setup
+
+For tools marked with 🔐, authentication is required.
+
+**Preferred method: OAuth2 Token**
+
+1. Navigate to `Special:OAuthConsumerRegistration/propose/oauth2` on your wiki
+2. Select "This consumer is for use only by [YourUsername]"
+3. Grant the necessary permissions
+4. After approval, you'll receive:
+   - Client ID
+   - Client Secret
+   - Access Token
+5. Add the `token` to your wiki configuration in `config.json`
+
+> **Note:** OAuth2 requires the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) to be installed on the wiki.
+
+**Fallback method: Username & Password**
+
+If OAuth2 is not available on your wiki, you can use bot credentials (from `Special:BotPasswords` ) instead of the OAuth2 token.
 
 ## Installation
 

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,8 @@
       "articlepath": "/wiki",
       "scriptpath": "/w",
       "token": null,
+      "username": null,
+      "password": null,
       "private": false
     },
     "localhost:8080": {
@@ -15,6 +17,8 @@
       "articlepath": "/wiki",
       "scriptpath": "/w",
       "token": null,
+      "username": null,
+      "password": null,
       "private": false
     }
   }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -23,6 +23,14 @@ export interface WikiConfig {
 	 */
 	token?: string | null;
 	/**
+	 * Username requested from Special:BotPasswords.
+	 */
+	username?: string | null;
+	/**
+	 * Password requested from Special:BotPasswords.
+	 */
+	password?: string | null;
+	/**
 	 * If the wiki always requires auth to access.
 	 * $wgGroupPermissions['*']['read'] = false; in MediaWiki
 	 */
@@ -111,6 +119,8 @@ export const oauthToken = (): string | null | undefined => {
 	const token = getCurrentWikiConfig().token;
 	return isTokenValid( token ) ? token : undefined;
 };
+export const username = (): string | null | undefined => getCurrentWikiConfig().username;
+export const password = (): string | null | undefined => getCurrentWikiConfig().password;
 export const privateWiki = (): boolean | undefined => getCurrentWikiConfig().private;
 export const siteName = (): string | undefined => getCurrentWikiConfig().sitename;
 

--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -1,5 +1,5 @@
 import { USER_AGENT } from '../server.js';
-import { scriptPath, wikiServer, oauthToken } from './config.js';
+import { scriptPath, wikiServer, oauthToken, username, password } from './config.js';
 import { Mwn } from 'mwn';
 
 let mwnInstance: Mwn | null = null;
@@ -9,9 +9,18 @@ export async function getMwn(): Promise<Mwn> {
 		return mwnInstance;
 	}
 
+	const token = oauthToken();
+	const user = username();
+	const pass = password();
+
+	const useOAuth = !!token;
+	const useUsernamePassword = !useOAuth && !!user && !!pass;
+
 	mwnInstance = await Mwn.init( {
 		apiUrl: `${ wikiServer() }${ scriptPath() }/api.php`,
-		OAuth2AccessToken: oauthToken() || undefined,
+		OAuth2AccessToken: useOAuth ? token : undefined,
+		username: useUsernamePassword ? user : undefined,
+		password: useUsernamePassword ? pass : undefined,
 		userAgent: USER_AGENT
 	} );
 


### PR DESCRIPTION
- Allow using cookie-based authentication with mwn
- Clean up authentication logic
- Update README and config to reflect latest changes

Closes: #20

Tested both OAuth2 and Username + Password editing on a public wiki.
However, I am unsure whether CSRF will work for a private wiki, that might require further testing.