### PR TITLE
Add delete-page tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | Name | Description | Permissions |
 |---|---|---|
 | `create-page` 🔐 | Create a new wiki page. | `Create, edit, and move pages` |
+| `delete-page` 🔐 | Delete a wiki page. | `Delete pages, revisions, and log entries` |
 | `get-file` | Returns the standard file object for a file page. | - |
 | `get-page` | Returns the standard page object for a wiki page. | - |
 | `get-page-history` | Returns information about the latest revisions to a wiki page. | - |

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiDeleteResponse } from 'mwn';
+/* eslint-enable n/no-missing-import */
+import { getMwn } from '../common/mwn.js';
+import { formatEditComment } from '../common/utils.js';
+
+export function deletePageTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'delete-page',
+		'Deletes a wiki page.',
+		{
+			title: z.string().describe( 'Wiki page title' ),
+			comment: z.string().describe( 'Reason for deleting the page' ).optional()
+		},
+		{
+			title: 'Delete page',
+			readOnlyHint: false,
+			destructiveHint: true
+		} as ToolAnnotations,
+		async (
+			{ title, comment }
+		) => handleDeletePageTool( server, title, comment )
+	);
+}
+
+async function handleDeletePageTool(
+	server: McpServer,
+	title: string,
+	comment?: string
+): Promise<CallToolResult> {
+	const elicitResult = await server.server.elicitInput( {
+		message: `Please confirm that you want to delete the page: ${ title }`,
+		requestedSchema: {
+			type: 'object',
+			properties: {}
+		}
+	} );
+
+	if ( elicitResult.action !== 'accept' ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: 'Page deletion cancelled by user.'
+				} as TextContent
+			]
+		};
+	}
+
+	let data: ApiDeleteResponse;
+	try {
+		const mwn = await getMwn();
+		data = await mwn.delete( title, formatEditComment( 'delete-page', comment ) );
+	} catch ( error ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Delete failed: ${ ( error as Error ).message }`
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
+	return {
+		content: deletePageToolResult( data )
+	};
+}
+
+function deletePageToolResult( data: ApiDeleteResponse ): TextContent[] {
+	return [
+		{
+			type: 'text',
+			text: `Page deleted successfully: ${ data.title }`
+		}
+	];
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { getFileTool } from './get-file.js';
 import { createPageTool } from './create-page.js';
 import { uploadFileTool } from './upload-file.js';
 import { uploadFileFromUrlTool } from './upload-file-from-url.js';
+import { deletePageTool } from './delete-page.js';
 
 const toolRegistrars = [
 	getPageTool,
@@ -21,7 +22,8 @@ const toolRegistrars = [
 	getFileTool,
 	createPageTool,
 	uploadFileTool,
-	uploadFileFromUrlTool
+	uploadFileFromUrlTool,
+	deletePageTool
 ];
 
 export function registerAllTools( server: McpServer ): RegisteredTool[] {


### PR DESCRIPTION
<img width="1009" height="230" alt="image" src="https://github.com/user-attachments/assets/b8d59b58-f063-4794-9608-59f46674aaca" />

Delete page is needed for the MCP client to undo results from `create-page`, `upload-file`, and `upload-file-from-url`.