### PR TITLE
Refactor get-page and get-revision tool parameters

### DIFF
--- a/src/common/mwRestApiContentFormat.ts
+++ b/src/common/mwRestApiContentFormat.ts
@@ -1,19 +1,15 @@
 export enum ContentFormat {
 	source = 'source',
 	html = 'html',
-	metadata = 'metadata',
-	sourceAndMetadata = 'sourceAndMetadata',
-	htmlAndMetadata = 'htmlAndMetadata'
+	none = 'none'
 }
 
 export function getSubEndpoint( content: ContentFormat ): string {
 	switch ( content ) {
-		case ContentFormat.metadata:
+		case ContentFormat.none:
 			return '/bare';
-		case ContentFormat.sourceAndMetadata:
 		case ContentFormat.source:
 			return '';
-		case ContentFormat.htmlAndMetadata:
 		case ContentFormat.html:
 			return '/with_html';
 	}


### PR DESCRIPTION
From https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/126#discussion_r2478233237

Instead of overloading the content parameter, add a new boolean parameter for including them metadata. That removes the need of the explicit prompt in the tool description.

<img width="432" height="586" alt="image" src="https://github.com/user-attachments/assets/94141365-7661-413b-95d5-e387fd635ab0" />
