### PR TITLE
Improve tool parameter validations and definitions

### DIFF
--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -13,8 +13,8 @@ export function createPageTool( server: McpServer ): RegisteredTool {
 		{
 			source: z.string().describe( 'Page content in the format specified by the contentModel parameter' ),
 			title: z.string().describe( 'Wiki page title' ),
-			comment: z.string().describe( 'Reason for creating the page' ).optional(),
-			contentModel: z.string().describe( 'Type of content on the page. Defaults to "wikitext"' ).optional()
+			comment: z.string().optional().describe( 'Reason for creating the page' ),
+			contentModel: z.string().optional().default( 'wikitext' ).describe( 'Type of content on the page' )
 		},
 		{
 			title: 'Create page',

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -13,7 +13,7 @@ export function deletePageTool( server: McpServer ): RegisteredTool {
 		'Deletes a wiki page.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			comment: z.string().describe( 'Reason for deleting the page' ).optional()
+			comment: z.string().optional().describe( 'Reason for deleting the page' )
 		},
 		{
 			title: 'Delete page',

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -19,8 +19,8 @@ export function getCategoryMembersTool( server: McpServer ): RegisteredTool {
 		'Gets all members in the category. Returns only page IDs, namespaces, and titles.',
 		{
 			category: z.string().describe( 'Category name' ),
-			types: z.array( z.nativeEnum( CategoryMemberType ) ).describe( 'Types of members to include' ).optional(),
-			namespaces: z.array( z.number().int() ).describe( 'Namespace IDs to filter by' ).optional()
+			types: z.array( z.nativeEnum( CategoryMemberType ) ).optional().describe( 'Types of members to include' ),
+			namespaces: z.array( z.number().int().nonnegative() ).optional().describe( 'Namespace IDs to filter by' )
 		},
 		{
 			title: 'Get category members',

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -12,9 +12,9 @@ export function getPageHistoryTool( server: McpServer ): RegisteredTool {
 		'Returns information about the latest revisions to a wiki page, in segments of 20 revisions, starting with the latest revision. The response includes API routes for the next oldest, next newest, and latest revision segments.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			olderThan: z.number().describe( 'The ID of the oldest revision to return' ).optional(),
-			newerThan: z.number().describe( 'The ID of the newest revision to return' ).optional(),
-			filter: z.string().describe( 'Filter that returns only revisions with certain tags. Only support one filter per request.' ).optional()
+			olderThan: z.number().int().positive().optional().describe( 'Revision ID of the oldest revision to return' ),
+			newerThan: z.number().int().positive().optional().describe( 'Revision ID of the newest revision to return' ),
+			filter: z.string().optional().describe( 'Filter that returns only revisions with certain tags. Only support one filter per request.' )
 		},
 		{
 			title: 'Get page history',

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -13,8 +13,8 @@ export function getPageTool( server: McpServer ): RegisteredTool {
 		'Returns a wiki page.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			content: z.nativeEnum( ContentFormat ).describe( 'Type of content to return' ).optional().default( ContentFormat.source ),
-			metadata: z.boolean().describe( 'Whether to include metadata (page ID, revision info, license) in the response' ).optional().default( false )
+			content: z.nativeEnum( ContentFormat ).optional().default( ContentFormat.source ).describe( 'Type of content to return' ),
+			metadata: z.boolean().optional().default( false ).describe( 'Whether to include metadata (page ID, revision info, license) in the response' )
 		},
 		{
 			title: 'Get page',

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -12,7 +12,7 @@ export function getRevisionTool( server: McpServer ): RegisteredTool {
 		'get-revision',
 		'Returns a revision of a wiki page.',
 		{
-			revisionId: z.number().describe( 'Revision ID' ),
+			revisionId: z.number().int().positive().describe( 'Revision ID' ),
 			content: z.nativeEnum( ContentFormat ).describe( 'Type of content to return' ).optional().default( ContentFormat.source ),
 			metadata: z.boolean().describe( 'Whether to include metadata (revision ID, page ID, page title, user ID, user name, timestamp, comment, size, delta, minor, HTML URL) in the response' ).optional().default( false )
 		},

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -16,7 +16,7 @@ export function searchPageTool( server: McpServer ): RegisteredTool {
 		'Search wiki page titles and contents for the provided search terms, and returns matching pages.',
 		{
 			query: z.string().describe( 'Search terms' ),
-			limit: z.number().describe( 'Maximum number of search results to return (1-100)' ).min( 1 ).max( 100 ).optional()
+			limit: z.number().int().min( 1 ).max( 100 ).optional().describe( 'Maximum number of search results to return' )
 		},
 		{
 			title: 'Search page',

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -13,7 +13,7 @@ export function undeletePageTool( server: McpServer ): RegisteredTool {
 		'Undeletes a wiki page.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			comment: z.string().describe( 'Reason for undeleting the page' ).optional()
+			comment: z.string().optional().describe( 'Reason for undeleting the page' )
 		},
 		{
 			title: 'Undelete page',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -13,8 +13,8 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			source: z.string().describe( 'Page content in the same content model of the existing page' ),
-			latestId: z.number().describe( 'Identifier for the revision used as the base for the new source' ),
-			comment: z.string().describe( 'Summary of the edit' ).optional()
+			latestId: z.number().int().positive().describe( 'Revision ID used as the base for the new source' ),
+			comment: z.string().optional().describe( 'Summary of the edit' )
 		},
 		{
 			title: 'Update page',

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -16,7 +16,7 @@ export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 			url: z.string().url().describe( 'URL of the file to upload' ),
 			title: z.string().describe( 'File title' ),
 			text: z.string().describe( 'Wikitext on the file page' ),
-			comment: z.string().describe( 'Reason for uploading the file' ).optional()
+			comment: z.string().optional().describe( 'Reason for uploading the file' )
 		},
 		{
 			title: 'Upload file from URL',

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -16,7 +16,7 @@ export function uploadFileTool( server: McpServer ): RegisteredTool {
 			filepath: z.string().describe( 'File path on the local disk' ),
 			title: z.string().describe( 'File title' ),
 			text: z.string().describe( 'Wikitext on the file page' ),
-			comment: z.string().describe( 'Reason for uploading the file' ).optional()
+			comment: z.string().optional().describe( 'Reason for uploading the file' )
 		},
 		{
 			title: 'Upload file',


### PR DESCRIPTION
From https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/135#discussion_r2498946006

- Use `int()` and `positive()` constraints when applicable
- Move `description()` to the end of the definition
- Use `default()` in favor of default text in description