### PR TITLE
Add metadata instructions for get-page tool

### DIFF
--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -10,7 +10,7 @@ import { ContentFormat, getSubEndpoint } from '../common/mwRestApiContentFormat.
 export function getPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-page',
-		'Returns a wiki page.',
+		'Returns a wiki page. Use metadata=true to retrieve the revision ID required by update-page. Set content="none" to fetch only metadata without content.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			content: z.nativeEnum( ContentFormat ).optional().default( ContentFormat.source ).describe( 'Type of content to return' ),


### PR DESCRIPTION
Fixes: #143

PR #127 introduced a regression where the LLM can fail to retrieve the correct revision ID that is used by other tools, such as `update-page`.