### PR TITLE
Clean up existing development commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update build watch test lint run dev
+.PHONY: install update build test lint run start dev dev-inspector
 
 NODE_VERSION := 22
 
@@ -13,9 +13,6 @@ update:
 build:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run build
 
-watch:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run watch
-
 test:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run test
 
@@ -23,7 +20,10 @@ lint:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run lint
 
 start:
-	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) node dist/index.js
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run start
 
 dev:
-	-docker run -it --rm -p 127.0.0.1:6274:6274 -p 127.0.0.1:6277:6277 -v "$(CURDIR)":/home/node/app -w /home/node/app -u node -e CLIENT_PORT=6274 node:$(NODE_VERSION) npm run dev
+	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:$(NODE_VERSION) npm run dev
+
+dev-inspector:
+	-docker run -it --rm -p 127.0.0.1:6274:6274 -p 127.0.0.1:6277:6277 -v "$(CURDIR)":/home/node/app -w /home/node/app -u node -e CLIENT_PORT=6274 node:$(NODE_VERSION) npm run dev:inspector

--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ You should end up with something like the below in your `.claude.json` config:
 
 ## Development
 
-> 🐋 **Develop with Docker:** Replace the `npm run` part of the command with `make` (e.g. `make dev`).
+> 🐋 **Develop with Docker:** Replace the `npm run` part of the command with `make`, and `:` with `-` (e.g. `make dev-inspector`).
 
 ### [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
 
 To start the development server and the MCP Inspector:
 ```sh
-npm run dev
+npm run dev:inspector
 ```
 
 The command will build and start the MCP Proxy server locally at `6277` and the MCP Inspector client UI at `http://localhost:6274`.

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
 		"node": ">=18"
 	},
 	"scripts": {
+		"start": "node dist/index.js",
+		"start:http": "MCP_TRANSPORT=http node dist/index.js",
 		"build": "tsc",
-		"watch": "tsc --watch",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"lint": "eslint --cache src/**/*",
-		"start": "node dist/index.js",
-		"start:streamableHttp": "MCP_TRANSPORT=http node dist/index.js",
-		"dev": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
-		"dev:streamableHttp": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
+		"dev": "tsc --watch",
+		"dev:inspector": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
+		"dev:inspector:http": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
 		"version": "node scripts/sync-version.cjs && git add server.json"
 	},
 	"dependencies": {


### PR DESCRIPTION
- Shorten `streamableHttp` to `http` for consistency
- Rename the `watch` command to `dev` to match other Node projects
- Rename `dev` command to `dev:inspector` for clearer reference