### PR TITLE
Add MCPJam inspector for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ dev:
 inspector:
   @(sleep 2 && printf "\n💡 Tip: Replace 0.0.0.0 with localhost in the URL for MCP Inspector. The browser won't open automatically.\n") &
 	docker run -it --rm -p 127.0.0.1:6274:6274 -p 127.0.0.1:6277:6277 -v "$(CURDIR)":/home/node/app -w /home/node/app -u node -e HOST=0.0.0.0 node:$(NODE_VERSION) npm run inspector
+
+mcpjam:
+	docker run -it --rm -p 127.0.0.1:6274:6274 -p 127.0.0.1:6277:6277 -v "$(CURDIR)":/home/node/app -w /home/node/app -u node -e HOST=0.0.0.0 node:$(NODE_VERSION) npm run mcpjam

--- a/README.md
+++ b/README.md
@@ -255,16 +255,29 @@ You should end up with something like the below in your `.claude.json` config:
 
 ## Development
 
-> 🐋 **Develop with Docker:** Replace the `npm run` part of the command with `make`, and `:` with `-` (e.g. `make dev-inspector`).
+> 🐋 **Develop with Docker:** Replace the `npm run` part of the command with `make` (e.g. `make inspector`).
+
 
 ### [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
 
-To start the development server and the MCP Inspector:
+Test and debug the MCP server without a MCP client and LLM.
+
+To start the development server and the MCP Inspector together:
 ```sh
-npm run dev:inspector
+npm run inspector
 ```
 
 The command will build and start the MCP Proxy server locally at `6277` and the MCP Inspector client UI at `http://localhost:6274`.
+
+
+### [MCPJam Inspector](https://github.com/MCPJam/inspector)
+
+Test and debug the MCP server, with a built-in MCP client and support for different LLMs.
+
+To start the development server and the MCP Inspector together:
+```sh
+npm run mcpjam
+```
 
 ### Test with MCP clients
 
@@ -272,10 +285,10 @@ To enable your MCP client to use this MediaWiki MCP Server for local development
 
 1. [Install](#installation) the MCP server on your MCP client.
 2. Change the `command` and `args` values as shown in the [`mcp.json`](mcp.json) file (or [`mcp.docker.json`](mcp.docker.json) if you prefer to run the MCP server in Docker).
-3. Run the watch command so that the source will be compiled whenever there is a change:
+3. Run the `dev` command so that the source will be compiled whenever there is a change:
 
 	```sh
-	npm run watch
+	npm run dev
 	```
 
 ### Release process

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"dev": "tsc --watch",
 		"inspector": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
 		"inspector:http": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
+		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"version": "node scripts/sync-version.cjs && git add server.json"
 	},
 	"dependencies": {


### PR DESCRIPTION
Simplifies the development and testing workflow by adding [MCPJam Inspector](https://github.com/MCPJam/inspector):
- Running `npm run mcpjam` now automatically boots the MCP server and sets up a complete client environment. Developers no longer need to manually configure both parts, drastically speeding up initial setup.
- MCPJam inspector includes built-in functionality for testing prompts and LLM interactions with various models. This allows testers and developers to perform immediate model verification without relying on external MCP client.