### PR TITLE
Bump @modelcontextprotocol/sdk requirement to 1.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"version": "node scripts/sync-version.cjs && git add server.json mcpb/manifest.json Dockerfile"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.22.0",
+		"@modelcontextprotocol/sdk": "^1.25.2",
 		"express": "^5.1.0",
 		"mwn": "^3.0.1",
 		"node-fetch": "^3.3.2",


### PR DESCRIPTION
Follow-up to https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/188