### PR TITLE
Handle server.json package details in release workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,16 @@
 		"wikimedia/language/es2022"
 	],
 	"rules": {
+		"comma-dangle": "off",
 		"no-shadow": "off",
-		"es-x/no-hashbang": "off",
-		"comma-dangle": "off"
-	}
+		"es-x/no-hashbang": "off"
+	},
+	"overrides": [
+		{
+			"files": [ "scripts/**" ],
+			"rules": {
+				"security/detect-non-literal-fs-filename": "off"
+			}
+		}
+	]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,37 @@ jobs:
       - name: Run preversion checks
         run: npm run preversion
 
-      - name: Publish to NPM
+      - name: Build MCP Bundle
+        run: npm run bundle
+
+      - name: Update server.json (MCP Bundle)
+        run: node scripts/update-server-json-mcpb.cjs
+
+      - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_MCP_WRITE }}
 
-      - name: Sync version for MCP Registry
+      - name: Update server.json (npm)
+        run: node scripts/update-server-json-npm.cjs
+
+      - name: Commit and push server.json
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "Syncing version to: $VERSION"
-          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > tmp.json && mv tmp.json server.json
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add server.json
+          if git diff --staged --quiet; then
+            echo "No changes to server.json"
+          else
+            git commit -m "Sync package versions in server.json [skip ci]"
+            git push origin HEAD:master
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: '*.mcpb'
+          generate_release_notes: true
 
       - name: Install MCP Publisher
         run: |
@@ -44,12 +65,3 @@ jobs:
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
-
-      - name: Build MCP Bundle
-        run: npm run bundle
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: '*.mcpb'
-          generate_release_notes: true

--- a/scripts/bundle.cjs
+++ b/scripts/bundle.cjs
@@ -4,18 +4,21 @@
 const { execSync } = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
+const {
+	MCPB_FILE,
+	MANIFEST_FILE,
+	MANIFEST_JSON_PATH,
+	ROOT_DIR
+} = require( './constants.cjs' );
 
-const MCPB_FILE = 'MediaWiki-MCP-Server.mcpb';
-const MANIFEST_FILE = 'manifest.json';
-const MANIFEST_SRC = path.join( process.cwd(), 'mcpb', MANIFEST_FILE );
-const MANIFEST_DEST = path.join( process.cwd(), MANIFEST_FILE );
+const MANIFEST_DEST = path.join( ROOT_DIR, MANIFEST_FILE );
 
 function ensureManifest() {
 	if ( fs.existsSync( MANIFEST_DEST ) ) {
 		return false;
 	}
 	console.log( 'Copying manifest to root...' );
-	fs.copyFileSync( MANIFEST_SRC, MANIFEST_DEST );
+	fs.copyFileSync( MANIFEST_JSON_PATH, MANIFEST_DEST );
 	return true;
 }
 
@@ -37,9 +40,10 @@ function cleanBundle() {
 }
 
 function removeBundleArtifact() {
-	if ( fs.existsSync( MCPB_FILE ) ) {
+	const bundlePath = path.join( ROOT_DIR, MCPB_FILE );
+	if ( fs.existsSync( bundlePath ) ) {
 		console.log( `Cleaning up ${ MCPB_FILE }...` );
-		fs.unlinkSync( MCPB_FILE );
+		fs.unlinkSync( bundlePath );
 	}
 }
 

--- a/scripts/constants.cjs
+++ b/scripts/constants.cjs
@@ -1,0 +1,18 @@
+'use strict';
+
+const path = require( 'path' );
+
+const ROOT_DIR = path.resolve( __dirname, '..' );
+const MCPB_FILE = 'MediaWiki-MCP-Server.mcpb';
+const MANIFEST_FILE = 'manifest.json';
+
+module.exports = {
+	ROOT_DIR,
+	MCPB_FILE,
+	MANIFEST_FILE,
+	PACKAGE_JSON_PATH: path.join( ROOT_DIR, 'package.json' ),
+	SERVER_JSON_PATH: path.join( ROOT_DIR, 'server.json' ),
+	MANIFEST_JSON_PATH: path.join( ROOT_DIR, 'mcpb', MANIFEST_FILE ),
+	DOCKERFILE_PATH: path.join( ROOT_DIR, 'Dockerfile' ),
+	MCPB_BUNDLE_PATH: path.join( ROOT_DIR, MCPB_FILE )
+};

--- a/scripts/sync-version.cjs
+++ b/scripts/sync-version.cjs
@@ -2,25 +2,22 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
+const {
+	PACKAGE_JSON_PATH,
+	SERVER_JSON_PATH,
+	MANIFEST_JSON_PATH,
+	DOCKERFILE_PATH
+} = require( './constants.cjs' );
 
-const packageJsonPath = path.join( __dirname, '../package.json' );
-const serverJsonPath = path.join( __dirname, '../server.json' );
-const manifestJsonPath = path.join( __dirname, '../mcpb/manifest.json' );
-const dockerfilePath = path.join( __dirname, '../Dockerfile' );
-
-const packageJson = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
-const serverJson = JSON.parse( fs.readFileSync( serverJsonPath, 'utf8' ) );
-const manifestJson = JSON.parse( fs.readFileSync( manifestJsonPath, 'utf8' ) );
-let dockerfile = fs.readFileSync( dockerfilePath, 'utf8' );
+const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
+const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
+const manifestJson = JSON.parse( fs.readFileSync( MANIFEST_JSON_PATH, 'utf8' ) );
+let dockerfile = fs.readFileSync( DOCKERFILE_PATH, 'utf8' );
 
 const version = packageJson.version;
 
 // Update server.json
 serverJson.version = version;
-if ( serverJson.packages && serverJson.packages[ 0 ] ) {
-	serverJson.packages[ 0 ].version = version;
-}
 
 // Update manifest.json
 manifestJson.version = version;
@@ -29,9 +26,9 @@ manifestJson.version = version;
 const versionRegex = /(org\.opencontainers\.image\.version=")[^"]*(")/;
 dockerfile = dockerfile.replace( versionRegex, `$1${ version }$2` );
 
-fs.writeFileSync( serverJsonPath, JSON.stringify( serverJson, null, 2 ) + '\n' );
-fs.writeFileSync( manifestJsonPath, JSON.stringify( manifestJson, null, 2 ) + '\n' );
-fs.writeFileSync( dockerfilePath, dockerfile );
+fs.writeFileSync( SERVER_JSON_PATH, JSON.stringify( serverJson, null, 2 ) + '\n' );
+fs.writeFileSync( MANIFEST_JSON_PATH, JSON.stringify( manifestJson, null, 2 ) + '\n' );
+fs.writeFileSync( DOCKERFILE_PATH, dockerfile );
 
 console.log( `✓ Updated server.json to version ${ version }` );
 console.log( `✓ Updated manifest.json to version ${ version }` );

--- a/scripts/update-server-json-mcpb.cjs
+++ b/scripts/update-server-json-mcpb.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require( 'fs' );
+const crypto = require( 'crypto' );
+const {
+	PACKAGE_JSON_PATH,
+	SERVER_JSON_PATH,
+	MCPB_BUNDLE_PATH,
+	MCPB_FILE
+} = require( './constants.cjs' );
+
+function getFileSha256( filePath ) {
+	const fileBuffer = fs.readFileSync( filePath );
+	const hashSum = crypto.createHash( 'sha256' );
+	hashSum.update( fileBuffer );
+	return hashSum.digest( 'hex' );
+}
+
+function main() {
+	console.log( 'Updating server.json with MCP bundle details...' );
+
+	if ( !fs.existsSync( MCPB_BUNDLE_PATH ) ) {
+		console.error( 'Error: Bundle file not found at ' + MCPB_BUNDLE_PATH );
+		throw new Error( 'Bundle file not found at ' + MCPB_BUNDLE_PATH );
+	}
+
+	const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
+	const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
+
+	const version = packageJson.version;
+	const sha256 = getFileSha256( MCPB_BUNDLE_PATH );
+	const downloadUrl = `https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases/download/v${ version }/${ MCPB_FILE }`;
+
+	console.log( `Version: ${ version }` );
+	console.log( `Bundle SHA256: ${ sha256 }` );
+	console.log( `Download URL: ${ downloadUrl }` );
+
+	if ( serverJson.packages ) {
+		const mcpbPackage = serverJson.packages.find( ( p ) => p.registryType === 'mcpb' );
+		if ( mcpbPackage ) {
+			mcpbPackage.fileSha256 = sha256;
+			mcpbPackage.identifier = downloadUrl;
+		}
+	}
+
+	fs.writeFileSync( SERVER_JSON_PATH, JSON.stringify( serverJson, null, 2 ) + '\n' );
+	console.log( '✓ Updated server.json with bundle details successfully' );
+}
+
+main();

--- a/scripts/update-server-json-npm.cjs
+++ b/scripts/update-server-json-npm.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require( 'fs' );
+const {
+	PACKAGE_JSON_PATH,
+	SERVER_JSON_PATH
+} = require( './constants.cjs' );
+
+function main() {
+	console.log( 'Updating server.json with npm package version...' );
+
+	const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
+	const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
+
+	const version = packageJson.version;
+	console.log( `Version: ${ version }` );
+
+	serverJson.version = version;
+
+	if ( serverJson.packages ) {
+		const npmPackage = serverJson.packages.find( ( p ) => p.registryType === 'npm' );
+		if ( npmPackage ) {
+			npmPackage.version = version;
+		}
+	}
+
+	fs.writeFileSync( SERVER_JSON_PATH, JSON.stringify( serverJson, null, 2 ) + '\n' );
+	console.log( '✓ Updated server.json with npm version successfully' );
+}
+
+main();

--- a/scripts/validate-server-json.cjs
+++ b/scripts/validate-server-json.cjs
@@ -4,12 +4,11 @@
 const fs = require( 'fs' );
 const Ajv = require( 'ajv' );
 const addFormats = require( 'ajv-formats' );
-const path = require( 'path' );
+const { SERVER_JSON_PATH } = require( './constants.cjs' );
 
 ( async () => {
 	console.log( '\nValidating server.json...' );
-	const serverJsonPath = path.join( process.cwd(), 'server.json' );
-	const serverJson = JSON.parse( fs.readFileSync( serverJsonPath, 'utf8' ) );
+	const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
 
 	const schemaUrl = serverJson.$schema;
 	if ( !schemaUrl ) {

--- a/server.json
+++ b/server.json
@@ -38,13 +38,12 @@
           "format": "number",
           "default": "3000"
         }
-      ],
-      "version": "0.6.4"
+      ]
     },
     {
       "registryType": "npm",
       "identifier": "@professional-wiki/mediawiki-mcp-server",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
- Optimize the order of release workflow steps
- Update server.json with npm package and mcbp info after publish
- Consolidate constants used in scripts
- Disable `security/detect-non-literal-fs-filename` for scripts
- Fix incorrect npm package version
- Remove unnessecary `version` key for mcpb