### PR TITLE
More correctness fixes for the REST-to-mwn migration

### DIFF
--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -1,45 +1,60 @@
 import { USER_AGENT } from '../server.js';
 import { wikiService } from './wikiService.js';
+import type { WikiConfig } from './config.js';
 import { Mwn, MwnOptions } from 'mwn';
 
-const mwnInstances = new Map<string, Mwn>();
+// Cache the Promise, not the resolved instance, so concurrent first-calls
+// for the same wiki share a single login / getSiteInfo round-trip.
+const mwnInstances = new Map<string, Promise<Mwn>>();
 
-export async function getMwn(): Promise<Mwn> {
-	const { key, config } = wikiService.getCurrent();
+export async function getMwn( wikiKey?: string ): Promise<Mwn> {
+	let key: string;
+	let config: Readonly<WikiConfig> | undefined;
 
-	const existing = mwnInstances.get( key );
-	if ( existing ) {
-		return existing;
+	if ( wikiKey !== undefined ) {
+		key = wikiKey;
+		config = wikiService.get( wikiKey );
+		if ( !config ) {
+			throw new Error( `Wiki "${ wikiKey }" not found` );
+		}
+	} else {
+		( { key, config } = wikiService.getCurrent() );
 	}
 
-	const {
-		server,
-		scriptpath,
-		token,
-		username,
-		password
-	} = config;
+	let pending = mwnInstances.get( key );
+	if ( !pending ) {
+		pending = createMwnInstance( config );
+		mwnInstances.set( key, pending );
+		// On failure, remove from cache so the next call retries rather than
+		// permanently caching the rejected Promise.
+		pending.catch( () => {
+			mwnInstances.delete( key );
+		} );
+	}
+	return pending;
+}
+
+async function createMwnInstance( config: Readonly<WikiConfig> ): Promise<Mwn> {
+	const { server, scriptpath, token, username, password } = config;
 
 	const options: MwnOptions = {
 		apiUrl: `${ server }${ scriptpath }/api.php`,
 		userAgent: USER_AGENT
 	};
 
-	let instance: Mwn;
-
 	if ( token ) {
 		options.OAuth2AccessToken = token;
-		instance = await Mwn.init( options );
-	} else if ( username && password ) {
-		options.username = username;
-		options.password = password;
-		instance = await Mwn.init( options );
-	} else {
-		instance = new Mwn( options );
-		await instance.getSiteInfo();
+		return Mwn.init( options );
 	}
 
-	mwnInstances.set( key, instance );
+	if ( username && password ) {
+		options.username = username;
+		options.password = password;
+		return Mwn.init( options );
+	}
+
+	const instance = new Mwn( options );
+	await instance.getSiteInfo();
 	return instance;
 }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -68,7 +68,11 @@ export async function fetchPageHtml( url: string ): Promise<string | null> {
 
 export function getPageUrl( title: string ): string {
 	const { server, articlepath } = wikiService.getCurrent().config;
-	return `${ server }${ articlepath }/${ encodeURIComponent( title ) }`;
+	// MediaWiki convention: spaces become underscores. encodeURI preserves
+	// '/' (subpages) and ':' (namespace prefixes) while encoding spaces and
+	// non-ASCII characters. Characters disallowed in MW titles ('#', '?',
+	// '|', '[', ']', etc.) cannot reach this function via a real page title.
+	return `${ server }${ articlepath }/${ encodeURI( title.replace( / /g, '_' ) ) }`;
 }
 
 export function formatEditComment( tool: string, comment?: string ): string {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -7,6 +7,41 @@ import { wikiService } from '../common/wikiService.js';
 import { WIKI_RESOURCE_URI_PREFIX } from '../common/constants.js';
 import { getMwn } from '../common/mwn.js';
 
+type LicenseInfo = { url: string; title: string };
+
+const licenseCache = new Map<string, LicenseInfo>();
+
+export function removeLicenseCache( wikiKey: string ): void {
+	licenseCache.delete( wikiKey );
+}
+
+async function getLicenseInfo( wikiKey: string ): Promise<LicenseInfo | undefined> {
+	const cached = licenseCache.get( wikiKey );
+	if ( cached ) {
+		return cached;
+	}
+
+	try {
+		const mwn = await getMwn( wikiKey );
+		const response = await mwn.request( {
+			action: 'query',
+			meta: 'siteinfo',
+			siprop: 'rightsinfo',
+			formatversion: '2'
+		} );
+
+		const rightsInfo = response.query?.rightsinfo;
+		if ( rightsInfo?.url && rightsInfo.text ) {
+			const info: LicenseInfo = { url: rightsInfo.url, title: rightsInfo.text };
+			licenseCache.set( wikiKey, info );
+			return info;
+		}
+	} catch {
+		// Graceful fallback if mwn is not initialized or the request fails.
+	}
+	return undefined;
+}
+
 export function registerAllResources( server: McpServer ): void {
 	const resourceTemplate = new ResourceTemplate(
 		`${ WIKI_RESOURCE_URI_PREFIX }{wikiKey}`,
@@ -39,24 +74,9 @@ export function registerAllResources( server: McpServer ): void {
 		const sanitized = wikiService.sanitize( wikiConfig );
 		const result: Record<string, unknown> = { ...sanitized };
 
-		try {
-			const mwn = await getMwn();
-			const response = await mwn.request( {
-				action: 'query',
-				meta: 'siteinfo',
-				siprop: 'rightsinfo',
-				formatversion: '2'
-			} );
-
-			const rightsInfo = response.query?.rightsinfo;
-			if ( rightsInfo ) {
-				result.license = {
-					url: rightsInfo.url,
-					title: rightsInfo.text
-				};
-			}
-		} catch {
-			// Graceful fallback if mwn is not initialized
+		const license = await getLicenseInfo( wikiKey );
+		if ( license ) {
+			result.license = license;
 		}
 
 		return {

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -54,19 +54,20 @@ export async function handleGetPageHistoryTool(
 			prop: 'revisions',
 			titles: title,
 			rvprop: 'ids|timestamp|user|userid|comment|size|flags',
-			// Fetch one extra when a boundary is set, since rvendid/rvstartid
-			// are inclusive and we filter the boundary out below.
+			// Fetch one extra when a boundary is set, since rvstartid is
+			// inclusive and we filter the boundary out below.
 			rvlimit: PAGE_HISTORY_LIMIT + ( boundaryId ? 1 : 0 ),
 			formatversion: '2'
 		};
 
-		if ( olderThan ) {
-			params.rvendid = olderThan;
-		}
-
-		if ( newerThan ) {
-			params.rvstartid = newerThan;
-			params.rvdir = 'newer';
+		// Both olderThan and newerThan use rvstartid (the enumeration anchor);
+		// they differ only in direction. Default rvdir=older walks newest →
+		// oldest, so olderThan needs no rvdir override.
+		if ( boundaryId ) {
+			params.rvstartid = boundaryId;
+			if ( newerThan ) {
+				params.rvdir = 'newer';
+			}
 		}
 
 		if ( filter ) {
@@ -75,10 +76,21 @@ export async function handleGetPageHistoryTool(
 
 		const response = await mwn.request( params );
 		const page = response.query?.pages?.[ 0 ] as ApiPage | undefined;
+
+		if ( page?.missing ) {
+			return {
+				content: [ {
+					type: 'text',
+					text: `Page "${ title }" not found`
+				} as TextContent ],
+				isError: true
+			};
+		}
+
 		const revisions: ApiRevision[] = page?.revisions ?? [];
 
-		// rvendid/rvstartid are inclusive — filter out the boundary revision
-		// to preserve the exclusive semantics of olderThan/newerThan, and cap
+		// rvstartid is inclusive — filter out the boundary revision to
+		// preserve the exclusive semantics of olderThan/newerThan, and cap
 		// the result in case the boundary was absent from the window.
 		const filteredRevisions = boundaryId ?
 			revisions.filter( ( rev ) => rev.revid !== boundaryId ).slice( 0, PAGE_HISTORY_LIMIT ) :

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -36,7 +36,7 @@ function buildRevisionMetadata(
 		text: [
 			`Revision ID: ${ rev.revid }`,
 			`Page ID: ${ page.pageid }`,
-			`Page Title: ${ page.title }`,
+			`Title: ${ page.title }`,
 			`User ID: ${ rev.userid }`,
 			`User Name: ${ rev.user }`,
 			`Timestamp: ${ rev.timestamp }`,

--- a/src/tools/remove-wiki.ts
+++ b/src/tools/remove-wiki.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { wikiService } from '../common/wikiService.js';
 import { removeMwnInstance } from '../common/mwn.js';
+import { removeLicenseCache } from '../resources/index.js';
 import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wikiResource.js';
 
 export function removeWikiTool( server: McpServer ): RegisteredTool {
@@ -50,6 +51,7 @@ async function handleRemoveWikiTool( server: McpServer, uri: string ): Promise<C
 		wikiService.remove( wikiKey );
 		server.sendResourceListChanged();
 		removeMwnInstance( wikiKey );
+		removeLicenseCache( wikiKey );
 
 		return {
 			content: [ {

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -38,7 +38,9 @@ export async function handleUpdatePageTool(
 		const result = await mwn.save(
 			title, source,
 			formatEditComment( 'update-page', comment ),
-			{ baserevid: latestId }
+			// nocreate: fail if the page does not exist, so a mis-typed
+			// title doesn't silently create a new page.
+			{ baserevid: latestId, nocreate: true }
 		);
 
 		return {

--- a/tests/common/mwn.test.ts
+++ b/tests/common/mwn.test.ts
@@ -86,6 +86,52 @@ describe( 'mwn instance management', () => {
 		expect( mockConstructor ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'returns the original cached instance after switching away and back', async () => {
+		mockGetSiteInfo.mockResolvedValue( undefined );
+
+		const firstA = await getMwn();
+
+		currentWikiKey = 'wiki-b';
+		currentWikiConfig = {
+			server: 'https://wiki-b.example.com',
+			scriptpath: '/w'
+		};
+		await getMwn();
+
+		currentWikiKey = 'wiki-a';
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w'
+		};
+		const secondA = await getMwn();
+
+		expect( secondA ).toBe( firstA );
+		expect( mockConstructor ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'deduplicates concurrent first-calls for the same wiki', async () => {
+		mockGetSiteInfo.mockResolvedValue( undefined );
+
+		const [ first, second ] = await Promise.all( [ getMwn(), getMwn() ] );
+
+		expect( first ).toBe( second );
+		expect( mockConstructor ).toHaveBeenCalledOnce();
+		expect( mockGetSiteInfo ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'removes a failed instance from the cache so the next call retries', async () => {
+		mockGetSiteInfo
+			.mockRejectedValueOnce( new Error( 'transient failure' ) )
+			.mockResolvedValueOnce( undefined );
+
+		await expect( getMwn() ).rejects.toThrow( 'transient failure' );
+
+		// Next call should retry (not return the cached rejected Promise).
+		const retry = await getMwn();
+		expect( retry ).toBeDefined();
+		expect( mockConstructor ).toHaveBeenCalledTimes( 2 );
+	} );
+
 	it( 'removeMwnInstance clears the correct entry', async () => {
 		mockGetSiteInfo.mockResolvedValue( undefined );
 

--- a/tests/tools/get-page-history.test.ts
+++ b/tests/tools/get-page-history.test.ts
@@ -45,7 +45,7 @@ describe( 'get-page-history', () => {
 		expect( result.content[ 0 ].text ).not.toContain( 'Delta' );
 	} );
 
-	it( 'maps olderThan to rvendid and skips boundary revision', async () => {
+	it( 'maps olderThan to rvstartid (default rvdir=older) and skips boundary revision', async () => {
 		const mock = createMockMwn( {
 			request: vi.fn().mockResolvedValue( {
 				query: { pages: [ { revisions: [
@@ -59,9 +59,10 @@ describe( 'get-page-history', () => {
 		const { handleGetPageHistoryTool } = await import( '../../src/tools/get-page-history.js' );
 		const result = await handleGetPageHistoryTool( 'Test Page', 100 );
 
-		expect( mock.request ).toHaveBeenCalledWith(
-			expect.objectContaining( { rvendid: 100 } )
-		);
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( { rvstartid: 100 } );
+		expect( call.rvdir ).toBeUndefined();
+		expect( call.rvendid ).toBeUndefined();
 		// Should skip the boundary revision (100)
 		expect( result.content.length ).toBe( 1 );
 		expect( result.content[ 0 ].text ).toContain( 'Revision ID: 99' );
@@ -102,6 +103,21 @@ describe( 'get-page-history', () => {
 		);
 	} );
 
+	it( 'returns isError when the page does not exist', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { missing: true, title: 'Nonexistent' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageHistoryTool } = await import( '../../src/tools/get-page-history.js' );
+		const result = await handleGetPageHistoryTool( 'Nonexistent' );
+
+		expect( result.isError ).toBe( true );
+		expect( result.content[ 0 ].text ).toContain( 'not found' );
+	} );
+
 	it( 'handles empty results', async () => {
 		const mock = createMockMwn( {
 			request: vi.fn().mockResolvedValue( {
@@ -137,7 +153,7 @@ describe( 'get-page-history', () => {
 		const result = await handleGetPageHistoryTool( 'Test Page', 100 );
 
 		expect( mock.request ).toHaveBeenCalledWith(
-			expect.objectContaining( { rvlimit: 21 } )
+			expect.objectContaining( { rvlimit: 21, rvstartid: 100 } )
 		);
 		expect( result.content.length ).toBe( 20 );
 		expect( result.content[ 0 ].text ).toContain( 'Revision ID: 99' );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -34,7 +34,7 @@ describe( 'update-page', () => {
 		expect( mock.save ).toHaveBeenCalledWith(
 			'My Page', 'Updated content',
 			expect.stringContaining( 'edit summary' ),
-			expect.objectContaining( { baserevid: 41 } )
+			expect.objectContaining( { baserevid: 41, nocreate: true } )
 		);
 	} );
 
@@ -49,5 +49,18 @@ describe( 'update-page', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toContain( 'Edit conflict' );
+	} );
+
+	it( 'surfaces the missingtitle error from mwn when page does not exist', async () => {
+		const mock = createMockMwn( {
+			save: vi.fn().mockRejectedValue( new Error( 'The page you specified doesn\'t exist.' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+		const result = await handleUpdatePageTool( 'Does Not Exist', 'content', 1 );
+
+		expect( result.isError ).toBe( true );
+		expect( result.content[ 0 ].text ).toContain( 'doesn\'t exist' );
 	} );
 } );


### PR DESCRIPTION
Follow-up to #256 — a deeper review of #235 surfaced a few more issues. Same pattern as #256: targeted at `rest-to-mwn-migration` so they can be folded into that PR before it lands on master.

## Critical

### 1. `get-page-history`: `olderThan` returns revisions *newer* than the boundary

`olderThan` was mapped to `rvendid`. With default `rvdir=older` (newest→oldest iteration), `rvendid` means "stop when you reach this revision" — so `rvendid=X` returns revisions **from newest down to X inclusive**. After filtering the boundary out, callers got revisions **newer** than X — the opposite of what `olderThan` promises.

The existing unit test passed because its mock returned a hand-crafted `[{revid:100},{revid:99}]` regardless of which params were sent — it verified transport, not semantics.

**Fix:** both `olderThan` and `newerThan` now set `rvstartid` (the enumeration anchor), and only `newerThan` also sets `rvdir: 'newer'`. The existing test is updated to assert `rvstartid` and forbid `rvendid`/`rvdir`.

### 2. Wiki resource license comes from the CURRENT wiki, not the requested wiki

`src/resources/index.ts` called `getMwn()`, which unconditionally returns the current wiki's mwn instance. Reading `mcp://wikis/wiki-b` while current is `wiki-a` returned wiki-b's metadata glued to wiki-a's license. Silent data corruption.

**Fix:** `getMwn()` now takes an optional `wikiKey` param; the resources handler passes it through so the license is fetched from the right wiki.

## Important

### 3. `getMwn()` concurrency race

Two concurrent first-calls for a new wiki both saw an empty cache, both constructed instances, both logged in (double auth requests), last one wrote to the map.

**Fix:** cache the `Promise<Mwn>`, not the resolved `Mwn`. Rejected Promises are evicted from the cache so the next call retries. Covered by two new tests: concurrent-dedup and failure-retry.

### 4. `get-page-history` doesn't distinguish missing pages

Nonexistent pages fell through to the "No revisions found for page" branch with `isError` unset, masking a 404-equivalent as success.

**Fix:** explicit `page.missing` check → `isError: true`, "Page not found". New test added.

### 5. `update-page` can silently create a new page

`mwn.save()` calls `action=edit`, which creates-or-updates by default. A mis-typed title would silently create a new page instead of erroring.

**Fix:** pass `nocreate: true` to mwn.save. Existing test updated to assert it; new test asserts the error is surfaced.

### 7. License info re-fetched on every resource read

**Fix:** per-wiki cache; invalidate via `removeLicenseCache( wikiKey )` wired into `remove-wiki`.

## Minor

### 8. `getPageUrl()` encoded `/` as `%2F` in subpage titles

`encodeURIComponent('Parent/Child')` → `Parent%2FChild`. MW redirects this transparently but it's ugly and adds a redirect hop.

**Fix:** `encodeURI(title.replace(/ /g, '_'))` — preserves `/` and `:`, encodes spaces and non-ASCII.

### 11. Round-trip cache test

Added a test asserting that after switching away from `wiki-a` to `wiki-b` and back, the ORIGINAL `wiki-a` instance is returned (not a fresh one).

### 12. `get-revision`: `Page Title:` → `Title:`

Every other tool's metadata output uses `Title:`. Aligning for consistency. Note: this is a response-shape change — document alongside the other response changes in #235's PR body.

## Test + lint + build

- 43/43 tests pass (was 38 — added 5)
- `npm run lint` clean (pre-existing `config.ts` warnings only, unrelated)
- `npm run build` clean

CI again won't run automatically since `.github/workflows/ci.yml` is scoped to `pull_request: branches: [master]`.

Marked as draft — fold into #235 however you prefer.

_Written by Claude Code, Opus 4.7. Result of a follow-up review of #235 with @alistair3149._