### PR TITLE
Let MediaWiki auto-detect content model on page creation

### DIFF
--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -14,7 +14,7 @@ export function createPageTool( server: McpServer ): RegisteredTool {
 			source: z.string().describe( 'Page content in the format specified by the contentModel parameter' ),
 			title: z.string().describe( 'Wiki page title' ),
 			comment: z.string().optional().describe( 'Reason for creating the page' ),
-			contentModel: z.string().optional().default( 'wikitext' ).describe( 'Type of content on the page' )
+			contentModel: z.string().optional().describe( 'Type of content on the page. If omitted, MediaWiki picks the default for the title\'s namespace.' )
 		},
 		{
 			title: 'Create page',
@@ -35,11 +35,12 @@ export async function handleCreatePageTool(
 ): Promise<CallToolResult> {
 	try {
 		const mwn = await getMwn();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const options = contentModel === undefined ? {} : { contentmodel: contentModel as any };
 		const result = await mwn.create(
 			title, source,
 			formatEditComment( 'create-page', comment ),
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			{ contentmodel: contentModel as any }
+			options
 		);
 
 		return {

--- a/tests/tools/create-page.test.ts
+++ b/tests/tools/create-page.test.ts
@@ -38,6 +38,23 @@ describe( 'create-page', () => {
 		);
 	} );
 
+	it( 'omits contentmodel when not provided, letting MediaWiki auto-detect by namespace', async () => {
+		const mock = createMockMwn( {
+			create: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 11, title: 'Module:Foo',
+				contentmodel: 'Scribunto', oldrevid: 0, newrevid: 2,
+				newtimestamp: '2026-01-01T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleCreatePageTool } = await import( '../../src/tools/create-page.js' );
+		await handleCreatePageTool( '-- lua', 'Module:Foo', undefined, undefined );
+
+		const opts = mock.create.mock.calls[ 0 ][ 3 ];
+		expect( opts ).not.toHaveProperty( 'contentmodel' );
+	} );
+
 	it( 'returns error on failure', async () => {
 		const mock = createMockMwn( {
 			create: vi.fn().mockRejectedValue( new Error( 'Page exists' ) )


### PR DESCRIPTION
## Summary
- Fixes #260 — `create-page` silently produced broken `Module:` pages (and other namespace-specific content models) because it always forwarded `contentmodel=wikitext` to `mwn.create`.
- Removes the zod `.default('wikitext')` on `contentModel` and only forwards `contentmodel` to the API when the caller explicitly provides one, so MediaWiki's `Title::getContentModel()` assigns the correct default per namespace (Scribunto for `Module:`, javascript/css/json for `MediaWiki:` subpages, etc.).
- Adds a regression test asserting `mwn.create` is called without `contentmodel` when the caller omits it.

## Verification
Created two `Module:` pages on test.pro.wiki via `mwn.create` directly:

| `contentmodel` opt | Resulting content model |
|---|---|
| *(omitted — new behavior)* | `Scribunto` ✅ |
| `'wikitext'` (old buggy default) | `wikitext` ❌ |

Same mechanism fixes `MediaWiki:*.js/.css/.json` and any namespace an extension registers.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 44/44 pass (includes new regression test)
- [x] `npm run build` — clean
- [x] Manual: create a `Module:` page via the MCP tool without passing `contentModel`, invoke it with `{{#invoke:}}`, confirm it loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)