### PR TITLE
Make latestId optional on update-page

### DIFF
--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -10,7 +10,7 @@ import { ContentFormat } from '../common/contentFormat.js';
 export function getPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-page',
-		'Returns a wiki page. Use metadata=true to retrieve the revision ID required by update-page. Set content="none" to fetch only metadata without content.',
+		'Returns a wiki page. Use metadata=true to retrieve the revision ID, which can optionally be passed to update-page for edit-conflict detection. Set content="none" to fetch only metadata without content.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			content: z.nativeEnum( ContentFormat ).optional().default( ContentFormat.source ).describe( 'Type of content to return' ),

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -9,11 +9,11 @@ import { getPageUrl, formatEditComment } from '../common/utils.js';
 export function updatePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'update-page',
-		'Updates a wiki page. Replaces the existing content of a page with the provided content',
+		'Updates a wiki page. Replaces the existing content of a page with the provided content. Optionally pass latestId (from get-page with metadata=true) to enable edit-conflict detection.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			source: z.string().describe( 'Page content in the same content model of the existing page' ),
-			latestId: z.number().int().positive().describe( 'Revision ID used as the base for the new source' ),
+			latestId: z.number().int().positive().optional().describe( 'Optional base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
 			comment: z.string().optional().describe( 'Summary of the edit' )
 		},
 		{
@@ -30,17 +30,21 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 export async function handleUpdatePageTool(
 	title: string,
 	source: string,
-	latestId: number,
+	latestId?: number,
 	comment?: string
 ): Promise<CallToolResult> {
 	try {
 		const mwn = await getMwn();
+		// nocreate: fail if the page does not exist, so a mis-typed
+		// title doesn't silently create a new page.
+		const options: { nocreate: true; baserevid?: number } = { nocreate: true };
+		if ( latestId !== undefined ) {
+			options.baserevid = latestId;
+		}
 		const result = await mwn.save(
 			title, source,
 			formatEditComment( 'update-page', comment ),
-			// nocreate: fail if the page does not exist, so a mis-typed
-			// title doesn't silently create a new page.
-			{ baserevid: latestId, nocreate: true }
+			options
 		);
 
 		return {

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -38,6 +38,30 @@ describe( 'update-page', () => {
 		);
 	} );
 
+	it( 'calls mwn.save() without baserevid when latestId is omitted', async () => {
+		const mock = createMockMwn( {
+			save: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 5, title: 'My Page',
+				contentmodel: 'wikitext', oldrevid: 41, newrevid: 42,
+				newtimestamp: '2026-01-02T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+		const result = await handleUpdatePageTool( 'My Page', 'Updated content', undefined, 'edit summary' );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toContain( 'Page updated successfully' );
+		expect( mock.save ).toHaveBeenCalledWith(
+			'My Page', 'Updated content',
+			expect.stringContaining( 'edit summary' ),
+			expect.objectContaining( { nocreate: true } )
+		);
+		const options = mock.save.mock.calls[ 0 ][ 3 ];
+		expect( options ).not.toHaveProperty( 'baserevid' );
+	} );
+
 	it( 'returns error on failure', async () => {
 		const mock = createMockMwn( {
 			save: vi.fn().mockRejectedValue( new Error( 'Edit conflict' ) )


### PR DESCRIPTION
## Summary
- Widen `update-page`'s `latestId` parameter to optional; when omitted, `mwn.save()` is called without `baserevid`, matching the MediaWiki Action API default.
- Removes the mandatory pre-read for workflows where the caller is the source of truth (e.g. local-repo → wiki deploys) — a 4-file deploy drops from 8 calls to 4.
- Updates `update-page` and `get-page` tool descriptions so an LLM consumer understands that the revision ID is now optional and only needed for opt-in edit-conflict detection.

Fixes #259

## Test plan
- [x] `npm test` — 8 suites, 45 tests, all passing (includes the new `calls mwn.save() without baserevid when latestId is omitted` case that pins the absence of the `baserevid` key).
- [x] `npm run lint` — clean (2 pre-existing warnings in `config.ts`, unrelated).
- [x] Manual MCP Inspector smoke test against test.pro.wiki:
  - **Without `latestId`:** `update-page` on `MCP Smoke Test 259` succeeded; revid bumped 2369 → 2370.
  - **With stale `latestId=2369`:** same page, same tool, returned `Failed to update page: editconflict: Edit conflict.` — confirming MediaWiki's conflict detection still fires when the caller opts into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)