### PR TITLE
Add get-pages tool for batched page fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `get-file` | Returns the standard file object for a file page. | - |
 | `get-page` | Returns the standard page object for a wiki page. | - |
 | `get-page-history` | Returns information about the latest revisions to a wiki page. | - |
+| `get-pages` | Returns multiple wiki pages in one call (up to 50). | - |
 | `get-revision` | Returns the standard revision object for a page. | - |
 | `remove-wiki` | Removes a wiki resource. | - |
 | `search-page` | Search wiki page titles and contents for the provided search terms. | - |

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -1,0 +1,253 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+import { getMwn } from '../common/mwn.js';
+import { getPageUrl } from '../common/utils.js';
+
+const MAX_TITLES = 50;
+
+export enum BatchContentFormat {
+	source = 'source',
+	none = 'none'
+}
+
+export function getPagesTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'get-pages',
+		`Fetches multiple wiki pages in one call. Use this instead of calling get-page repeatedly when you need a group of pages — e.g., reading a cluster of related articles, diffing a page family, or syncing pages to local storage. Accepts up to ${ MAX_TITLES } titles; missing pages are reported inline (not as errors). Use get-page for a single page or HTML output.`,
+		{
+			titles: z.array( z.string() ).describe( `Array of wiki page titles (1..${ MAX_TITLES })` ),
+			content: z.nativeEnum( BatchContentFormat ).optional().default( BatchContentFormat.source ).describe( 'Type of content to return; "none" returns metadata only' ),
+			metadata: z.boolean().optional().default( false ).describe( 'Whether to include metadata (page ID, revision info) in the response' ),
+			followRedirects: z.boolean().optional().default( true ).describe( 'Follow wiki redirects. When true (default), redirect targets are returned with a "Redirected from:" line in the metadata. Set false to fetch redirect pseudo-pages as-is (sync-fidelity).' )
+		},
+		{
+			title: 'Get pages',
+			readOnlyHint: true,
+			destructiveHint: false
+		} as ToolAnnotations,
+		async ( { titles, content, metadata, followRedirects } ) => handleGetPagesTool(
+			titles, content, metadata, followRedirects
+		)
+	);
+}
+
+interface PageRev {
+	revid?: number;
+	timestamp?: string;
+	contentmodel?: string;
+	content?: string;
+	slots?: {
+		main?: { contentmodel?: string; content?: string };
+	};
+}
+
+interface ApiPageLike {
+	pageid: number;
+	title: string;
+	missing?: boolean;
+	revisions?: PageRev[];
+}
+
+interface RedirectOrNormalizedEntry {
+	from: string;
+	to: string;
+}
+
+function buildMetadataLines(
+	page: ApiPageLike,
+	rev: PageRev | undefined,
+	redirectedFrom: string | undefined
+): string {
+	const lines = [
+		`Page ID: ${ page.pageid }`,
+		`Title: ${ page.title }`
+	];
+	if ( redirectedFrom !== undefined ) {
+		lines.push( `Redirected from: ${ redirectedFrom }` );
+	}
+	lines.push(
+		`Latest revision ID: ${ rev?.revid }`,
+		`Latest revision timestamp: ${ rev?.timestamp }`,
+		`Content model: ${ rev?.contentmodel }`,
+		`HTML URL: ${ getPageUrl( page.title ) }`
+	);
+	return lines.join( '\n' );
+}
+
+function resolveChain(
+	requested: string,
+	aliasTo: Map<string, string>,
+	redirectFrom: Set<string>
+): { resolved: string; viaRedirect: boolean } {
+	let cur = requested;
+	let viaRedirect = false;
+	const seen = new Set<string>();
+	while ( aliasTo.has( cur ) && !seen.has( cur ) ) {
+		seen.add( cur );
+		if ( redirectFrom.has( cur ) ) {
+			viaRedirect = true;
+		}
+		cur = aliasTo.get( cur )!;
+	}
+	return { resolved: cur, viaRedirect };
+}
+
+export async function handleGetPagesTool(
+	titles: string[],
+	content: BatchContentFormat,
+	metadata: boolean,
+	followRedirects: boolean = true
+): Promise<CallToolResult> {
+	if ( titles.length === 0 ) {
+		return {
+			content: [ { type: 'text', text: 'titles must contain at least one entry' } as TextContent ],
+			isError: true
+		};
+	}
+	if ( titles.length > MAX_TITLES ) {
+		return {
+			content: [ { type: 'text', text: `titles must contain at most ${ MAX_TITLES } entries` } as TextContent ],
+			isError: true
+		};
+	}
+	if ( content === BatchContentFormat.none && !metadata ) {
+		return {
+			content: [ { type: 'text', text: 'When content is set to "none", metadata must be true' } as TextContent ],
+			isError: true
+		};
+	}
+
+	try {
+		const mwn = await getMwn();
+		const needsSource = content === BatchContentFormat.source;
+		const rvprop = needsSource ?
+			'ids|timestamp|contentmodel|content' :
+			'ids|timestamp|contentmodel';
+
+		const byResolvedTitle = new Map<string, ApiPageLike>();
+		const aliasTo = new Map<string, string>();
+		const redirectFrom = new Set<string>();
+
+		if ( followRedirects ) {
+			const responses = await mwn.massQuery( {
+				action: 'query',
+				titles,
+				prop: 'revisions',
+				rvprop,
+				rvslots: 'main',
+				redirects: true,
+				formatversion: '2'
+			}, 'titles' );
+
+			for ( const response of responses ) {
+				const query = response?.query;
+				if ( !query ) {
+					continue;
+				}
+
+				const normalized: RedirectOrNormalizedEntry[] = query.normalized ?? [];
+				for ( const entry of normalized ) {
+					aliasTo.set( entry.from, entry.to );
+				}
+
+				const redirects: RedirectOrNormalizedEntry[] = query.redirects ?? [];
+				for ( const entry of redirects ) {
+					aliasTo.set( entry.from, entry.to );
+					redirectFrom.add( entry.from );
+				}
+
+				const pages = ( query.pages ?? [] ) as ApiPageLike[];
+				for ( const page of pages ) {
+					const revs = page.revisions;
+					if ( revs ) {
+						for ( const rev of revs ) {
+							if ( rev.slots?.main ) {
+								Object.assign( rev, rev.slots.main );
+							}
+						}
+					}
+					byResolvedTitle.set( page.title, page );
+				}
+			}
+		} else {
+			// redirects: false — mwn.read() defaults to following redirects, which
+			// replaces the requested title in the response with the redirect target
+			// and breaks our requested-title lookup. Emit the redirect pseudo-page
+			// as-is so callers can see (and sync) it.
+			const response = await mwn.read( titles, { rvprop, redirects: false } );
+			const pages: ApiPageLike[] = Array.isArray( response ) ? response : [ response ];
+			for ( const p of pages ) {
+				byResolvedTitle.set( p.title, p );
+			}
+		}
+
+		const results: TextContent[] = [];
+		// emitted is keyed by resolved title so redirect/normalization aliases
+		// collapse to one emission; missingSeen is keyed by requested title
+		// because misses have no resolved title to key on.
+		const emitted = new Set<string>();
+		const missing: string[] = [];
+		const missingSeen = new Set<string>();
+
+		for ( const requested of titles ) {
+			let resolvedTitle: string;
+			let viaRedirect: boolean;
+			if ( followRedirects ) {
+				const resolution = resolveChain( requested, aliasTo, redirectFrom );
+				resolvedTitle = resolution.resolved;
+				viaRedirect = resolution.viaRedirect;
+			} else {
+				resolvedTitle = requested;
+				viaRedirect = false;
+			}
+
+			const page = byResolvedTitle.get( resolvedTitle );
+
+			if ( !page || page.missing ) {
+				if ( !missingSeen.has( requested ) ) {
+					missingSeen.add( requested );
+					missing.push( requested );
+				}
+				continue;
+			}
+
+			if ( emitted.has( page.title ) ) {
+				continue;
+			}
+			emitted.add( page.title );
+
+			results.push( { type: 'text', text: `--- ${ requested } ---` } );
+
+			const rev = page.revisions?.[ 0 ];
+			if ( metadata ) {
+				results.push( {
+					type: 'text',
+					text: buildMetadataLines( page, rev, viaRedirect ? requested : undefined )
+				} );
+			}
+			if ( needsSource && rev?.content !== undefined ) {
+				results.push( {
+					type: 'text',
+					text: metadata ? `Source:\n${ rev.content }` : rev.content
+				} );
+			}
+		}
+
+		if ( missing.length > 0 ) {
+			results.push( { type: 'text', text: `Missing: ${ missing.join( ', ' ) }` } );
+		}
+
+		return { content: results };
+	} catch ( error ) {
+		return {
+			content: [ {
+				type: 'text',
+				text: `Failed to retrieve pages: ${ ( error as Error ).message }`
+			} as TextContent ],
+			isError: true
+		};
+	}
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,6 +3,7 @@ import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server
 /* eslint-enable n/no-missing-import */
 
 import { getPageTool } from './get-page.js';
+import { getPagesTool } from './get-pages.js';
 import { getPageHistoryTool } from './get-page-history.js';
 import { searchPageTool } from './search-page.js';
 import { setWikiTool } from './set-wiki.js';
@@ -21,6 +22,7 @@ import { searchPageByPrefixTool } from './search-page-by-prefix.js';
 
 const toolRegistrars = [
 	getPageTool,
+	getPagesTool,
 	getPageHistoryTool,
 	searchPageTool,
 	setWikiTool,

--- a/tests/helpers/mock-mwn.ts
+++ b/tests/helpers/mock-mwn.ts
@@ -11,6 +11,7 @@ export interface MockMwn {
 	uploadFromUrl: ReturnType<typeof vi.fn>;
 	request: ReturnType<typeof vi.fn>;
 	query: ReturnType<typeof vi.fn>;
+	massQuery: ReturnType<typeof vi.fn>;
 	getPagesByPrefix: ReturnType<typeof vi.fn>;
 	getCsrfToken: ReturnType<typeof vi.fn>;
 	Category: {
@@ -31,6 +32,7 @@ export function createMockMwn( overrides: Partial<MockMwn> = {} ): MockMwn {
 		uploadFromUrl: vi.fn(),
 		request: vi.fn(),
 		query: vi.fn(),
+		massQuery: vi.fn(),
 		getPagesByPrefix: vi.fn(),
 		getCsrfToken: vi.fn(),
 		Category: {

--- a/tests/tools/get-pages.test.ts
+++ b/tests/tools/get-pages.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+// Build a response page object shaped as mwn.massQuery returns
+// (formatversion=2, prop=revisions, rvslots=main). Slots still need flattening
+// by the handler.
+function massQueryPage( title: string, pageid: number, revid: number, content?: string ) {
+	return {
+		pageid,
+		title,
+		revisions: [ {
+			revid,
+			timestamp: '2026-04-01T00:00:00Z',
+			slots: {
+				main: {
+					contentmodel: 'wikitext',
+					...( content !== undefined ? { content } : {} )
+				}
+			}
+		} ]
+	};
+}
+
+function massQueryResponse( options: {
+	pages?: unknown[];
+	redirects?: Array<{ from: string; to: string }>;
+	normalized?: Array<{ from: string; to: string }>;
+} ): unknown[] {
+	return [ {
+		query: {
+			...( options.pages ? { pages: options.pages } : {} ),
+			...( options.redirects ? { redirects: options.redirects } : {} ),
+			...( options.normalized ? { normalized: options.normalized } : {} )
+		}
+	} ];
+}
+
+// For the followRedirects=false path, build the mwn.read-shaped page (flat
+// rev: no slots wrapping — mwn.read() already flattens for us).
+function readPage( title: string, pageid: number, revid: number, content?: string ) {
+	return {
+		pageid,
+		title,
+		revisions: [ {
+			revid,
+			timestamp: '2026-04-01T00:00:00Z',
+			contentmodel: 'wikitext',
+			...( content !== undefined ? { content } : {} )
+		} ]
+	};
+}
+
+describe( 'get-pages', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	describe( 'validation', () => {
+		it( 'empty titles array returns validation error', async () => {
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [], 'source', false );
+
+			expect( result.isError ).toBe( true );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'titles' );
+		} );
+
+		it( 'more than 50 titles returns validation error', async () => {
+			const titles = Array.from( { length: 51 }, ( _, i ) => `T${ i }` );
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( titles, 'source', false );
+
+			expect( result.isError ).toBe( true );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( '50' );
+		} );
+
+		it( 'content=none + metadata=false returns validation error', async () => {
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo' ], 'none', false );
+
+			expect( result.isError ).toBe( true );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'metadata must be true' );
+		} );
+	} );
+
+	describe( 'followRedirects=true (default, via massQuery)', () => {
+		it( 'returns 3 pages in input order with a single massQuery call', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [
+					massQueryPage( 'Module:Infobox/Person', 2, 102, 'B' ),
+					massQueryPage( 'Module:Infobox', 1, 101, 'A' ),
+					massQueryPage( 'Module:Infobox/Organization', 3, 103, 'C' )
+				]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool(
+				[ 'Module:Infobox', 'Module:Infobox/Person', 'Module:Infobox/Organization' ],
+				'source',
+				false,
+				true
+			);
+
+			expect( result.isError ).toBeUndefined();
+			expect( massQuery ).toHaveBeenCalledTimes( 1 );
+			expect( massQuery ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'query',
+					prop: 'revisions',
+					redirects: true,
+					formatversion: '2',
+					rvslots: 'main'
+				} ),
+				'titles'
+			);
+
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts.indexOf( '--- Module:Infobox ---' ) )
+				.toBeLessThan( texts.indexOf( '--- Module:Infobox/Person ---' ) );
+			expect( texts.indexOf( '--- Module:Infobox/Person ---' ) )
+				.toBeLessThan( texts.indexOf( '--- Module:Infobox/Organization ---' ) );
+			expect( texts ).toContain( 'A' );
+			expect( texts ).toContain( 'B' );
+			expect( texts ).toContain( 'C' );
+		} );
+
+		it( 'mixed found + missing: emits found pages + Missing block, no isError', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [
+					massQueryPage( 'Found1', 1, 101, 'X' ),
+					{ pageid: 0, title: 'NotReal', missing: true },
+					massQueryPage( 'Found2', 2, 102, 'Y' )
+				]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool(
+				[ 'Found1', 'NotReal', 'Found2' ], 'source', false, true
+			);
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- Found1 ---' );
+			expect( texts ).toContain( '--- Found2 ---' );
+			expect( texts ).toContain( 'Missing: NotReal' );
+			expect( texts ).not.toContain( '--- NotReal ---' );
+		} );
+
+		it( 'all missing: returns only Missing block, no isError', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [
+					{ pageid: 0, title: 'A', missing: true },
+					{ pageid: 0, title: 'B', missing: true }
+				]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'A', 'B' ], 'source', false, true );
+
+			expect( result.isError ).toBeUndefined();
+			expect( result.content ).toHaveLength( 1 );
+			expect( ( result.content[ 0 ] as any ).text ).toBe( 'Missing: A, B' );
+		} );
+
+		it( 'metadata=true emits a metadata block before source for each page', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [ massQueryPage( 'Foo', 1, 101, 'body' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo' ], 'source', true, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- Foo ---' );
+			expect( texts ).toContain( 'Page ID: 1' );
+			expect( texts ).toContain( 'Latest revision ID: 101' );
+			expect( texts ).toContain( 'Content model: wikitext' );
+			expect( texts ).toContain( 'Source:\nbody' );
+			expect( texts.indexOf( 'Page ID: 1' ) ).toBeLessThan( texts.indexOf( 'body' ) );
+			// No Redirected from line when there was no redirect.
+			expect( texts ).not.toContain( 'Redirected from' );
+		} );
+
+		it( 'content=none + metadata=true returns only metadata, no source', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [ massQueryPage( 'Foo', 1, 101 ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo' ], 'none', true, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( 'Page ID: 1' );
+			expect( result.content ).toHaveLength( 2 );
+		} );
+
+		it( 'duplicate input titles emit page once', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [ massQueryPage( 'Foo', 1, 101, 'body' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo', 'Foo' ], 'source', false, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			const matches = texts.match( /--- Foo ---/g ) ?? [];
+			expect( matches ).toHaveLength( 1 );
+		} );
+
+		it( 'mwn.massQuery throws → isError with wrapped message', async () => {
+			const massQuery = vi.fn().mockRejectedValue( new Error( 'API error' ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo' ], 'source', false, true );
+
+			expect( result.isError ).toBe( true );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'Failed to retrieve pages' );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'API error' );
+		} );
+
+		it( 'redirect followed: emits under requested header, Title shows target, Redirected from line present', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				redirects: [ { from: 'Src', to: 'Tgt' } ],
+				pages: [ massQueryPage( 'Tgt', 42, 9001, 'target body' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Src' ], 'source', true, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- Src ---' );
+			expect( texts ).toContain( 'Title: Tgt' );
+			expect( texts ).toContain( 'Redirected from: Src' );
+			expect( texts ).toContain( 'Source:\ntarget body' );
+		} );
+
+		it( 'normalization only: no Redirected from line', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				normalized: [ { from: 'foo', to: 'Foo' } ],
+				pages: [ massQueryPage( 'Foo', 1, 101, 'body' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'foo' ], 'source', true, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- foo ---' );
+			expect( texts ).toContain( 'Title: Foo' );
+			expect( texts ).not.toContain( 'Redirected from' );
+		} );
+
+		it( 'normalized-then-redirect chain: Redirected from shows the requested title', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				normalized: [ { from: 'main page', to: 'Main Page' } ],
+				redirects: [ { from: 'Main Page', to: 'Target' } ],
+				pages: [ massQueryPage( 'Target', 5, 500, 'target' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'main page' ], 'source', true, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- main page ---' );
+			expect( texts ).toContain( 'Title: Target' );
+			expect( texts ).toContain( 'Redirected from: main page' );
+		} );
+
+		it( 'redirect to missing target: requested title reported as missing', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				redirects: [ { from: 'BrokenRedirect', to: 'Ghost' } ],
+				pages: [ { pageid: 0, title: 'Ghost', missing: true } ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'BrokenRedirect' ], 'source', false, true );
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( 'Missing: BrokenRedirect' );
+			expect( texts ).not.toContain( '--- BrokenRedirect ---' );
+		} );
+
+		it( 'two requested titles redirect to same target: emit once', async () => {
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				redirects: [
+					{ from: 'Alias1', to: 'Target' },
+					{ from: 'Alias2', to: 'Target' }
+				],
+				pages: [ massQueryPage( 'Target', 1, 101, 'body' ) ]
+			} ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { massQuery } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool(
+				[ 'Alias1', 'Alias2' ], 'source', true, true
+			);
+
+			expect( result.isError ).toBeUndefined();
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			// Only the first one gets emitted under the resolved target.
+			const headerMatches = texts.match( /--- Alias[12] ---/g ) ?? [];
+			expect( headerMatches ).toHaveLength( 1 );
+			expect( headerMatches[ 0 ] ).toBe( '--- Alias1 ---' );
+		} );
+	} );
+
+	describe( 'followRedirects=false (via mwn.read)', () => {
+		it( 'passes redirects: false to mwn.read and emits pseudo-page wikitext under requested title', async () => {
+			const read = vi.fn().mockResolvedValue( [
+				readPage( 'Main Page', 7, 700, '#REDIRECT [[Target]]' )
+			] );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { read } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool(
+				[ 'Main Page' ], 'source', true, false
+			);
+
+			expect( result.isError ).toBeUndefined();
+			expect( read ).toHaveBeenCalledTimes( 1 );
+			expect( read ).toHaveBeenCalledWith(
+				[ 'Main Page' ],
+				expect.objectContaining( { redirects: false } )
+			);
+
+			const texts = result.content.map( ( c: any ) => c.text ).join( '\n' );
+			expect( texts ).toContain( '--- Main Page ---' );
+			expect( texts ).toContain( 'Title: Main Page' );
+			expect( texts ).not.toContain( 'Redirected from' );
+			expect( texts ).toContain( 'Source:\n#REDIRECT [[Target]]' );
+		} );
+
+		it( 'mwn.read throws → isError with wrapped message', async () => {
+			const read = vi.fn().mockRejectedValue( new Error( 'read error' ) );
+			vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { read } ) as any );
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Foo' ], 'source', false, false );
+
+			expect( result.isError ).toBe( true );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'Failed to retrieve pages' );
+			expect( ( result.content[ 0 ] as any ).text ).toContain( 'read error' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Closes #257 

Syncing related pages currently requires N serial `get-page` calls. This adds a `get-pages` tool that fetches up to 50 pages in a single batched API call, collapsing sync workflows (e.g. a `Module:Infobox` template family) from N round trips to 1.

- New `get-pages` tool: `titles: string[]` (1..50), `content: 'source' | 'none'` (default `source`), `metadata: boolean` (default `false`)
- Wraps `mwn.read(titles[], opts)` — no changes to `src/common/mwn.ts`
- HTML rejected at the Zod enum (use `get-page` for HTML output)
- Partial misses reported inline via trailing `Missing: <a>, <b>` block; never `isError`
- Duplicate / redirect-aliased titles emit once
- Metadata format matches `get-page`; source emission uses `Source:\n` prefix when metadata is on

## Test Plan

- [x] 11 new unit tests in `tests/tools/get-pages.test.ts` cover happy path, mixed found+missing, all-missing, metadata interaction, duplicate dedup, validation bounds (empty / >50 / none+no-metadata), mwn error wrapping, and single-object response shape
- [x] Full test suite: 55/55 pass (44 existing + 11 new)
- [x] `npm run build` clean
- [x] `npm run lint` clean (2 pre-existing warnings in `src/common/config.ts` unrelated)
- [x] MCP Inspector `tools/list` exposes `get-pages` with the expected schema
- [x] Integration sanity check against a live wiki (reviewer may run `npx @modelcontextprotocol/inspector --cli node dist/index.js --method tools/call --tool-name get-pages --tool-arg 'titles=["Main Page"]'`)