### PR TITLE
Add parse-wikitext tool for previewing rendered output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `get-page` | Returns the standard page object for a wiki page. | - |
 | `get-page-history` | Returns information about the latest revisions to a wiki page. | - |
 | `get-revision` | Returns the standard revision object for a page. | - |
+| `parse-wikitext` | Renders wikitext and returns the HTML, parse warnings, wikilinks, templates, and external URLs without saving a page. | - |
 | `remove-wiki` | Removes a wiki resource. | - |
 | `search-page` | Search wiki page titles and contents for the provided search terms. | - |
 | `search-page-by-prefix` | Perform a prefix search for page titles. | - |

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { getRevisionTool } from './get-revision.js';
 import { undeletePageTool } from './undelete-page.js';
 import { getCategoryMembersTool } from './get-category-members.js';
 import { searchPageByPrefixTool } from './search-page-by-prefix.js';
+import { parseWikitextTool } from './parse-wikitext.js';
 
 const toolRegistrars = [
 	getPageTool,
@@ -35,7 +36,8 @@ const toolRegistrars = [
 	getRevisionTool,
 	undeletePageTool,
 	getCategoryMembersTool,
-	searchPageByPrefixTool
+	searchPageByPrefixTool,
+	parseWikitextTool
 ];
 
 export function registerAllTools( server: McpServer ): RegisteredTool[] {

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+import { getMwn } from '../common/mwn.js';
+
+const DEFAULT_TITLE = 'API';
+
+export function parseWikitextTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'parse-wikitext',
+		'Preview rendered wikitext without saving. Returns HTML, parse warnings, categories, links, templates, external links, and display title. Use this to verify sanitizer compliance, template expansion, and link resolution before committing an edit — or to test a wikitext combination that has no target page.',
+		{
+			wikitext: z.string().min( 1 ).describe( 'Wikitext source to render' ),
+			title: z.string().optional().describe(
+				'Page title context for magic words like {{PAGENAME}}. Defaults to "API".'
+			),
+			applyPreSaveTransform: z.boolean().optional().default( true ).describe(
+				'Apply pre-save transform (expand ~~~~ signatures, {{subst:}}, normalize whitespace). Matches editor "Show preview" behavior.'
+			)
+		},
+		{
+			title: 'Preview wikitext',
+			readOnlyHint: true,
+			destructiveHint: false
+		} as ToolAnnotations,
+		async ( { wikitext, title, applyPreSaveTransform } ) =>
+			handleParseWikitextTool( wikitext, title, applyPreSaveTransform )
+	);
+}
+
+export async function handleParseWikitextTool(
+	wikitext: string,
+	title: string | undefined,
+	applyPreSaveTransform: boolean
+): Promise<CallToolResult> {
+	try {
+		const mwn = await getMwn();
+		const response = await mwn.request( {
+			action: 'parse',
+			text: wikitext,
+			title: title ?? DEFAULT_TITLE,
+			pst: applyPreSaveTransform,
+			prop: 'text|parsewarnings',
+			formatversion: '2'
+		} );
+
+		const parse = response.parse ?? {};
+		const results: TextContent[] = [];
+
+		const warnings: string[] = Array.isArray( parse.parsewarnings ) ? parse.parsewarnings : [];
+		if ( warnings.length > 0 ) {
+			results.push( {
+				type: 'text',
+				text: `Parse warnings:\n${ warnings.map( ( w ) => `- ${ w }` ).join( '\n' ) }`
+			} );
+		}
+
+		const html: string = parse.text ?? '';
+		results.push( {
+			type: 'text',
+			text: `HTML:\n${ html }`
+		} );
+
+		return { content: results };
+	} catch ( error ) {
+		return {
+			content: [ {
+				type: 'text',
+				text: `Failed to preview wikitext: ${ ( error as Error ).message }`
+			} ],
+			isError: true
+		};
+	}
+}

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -7,10 +7,33 @@ import { getMwn } from '../common/mwn.js';
 
 const DEFAULT_TITLE = 'API';
 
+type CategoryItem = { category: string; hidden?: boolean };
+type LinkItem = { title: string; exists?: boolean };
+
+function formatCategory( item: CategoryItem ): string {
+	const suffix = item.hidden ? ' (hidden)' : '';
+	return `- Category:${ item.category }${ suffix }`;
+}
+
+function formatLinkLike( item: LinkItem ): string {
+	const suffix = item.exists === false ? ' (missing)' : '';
+	return `- ${ item.title }${ suffix }`;
+}
+
+function bulletSection( header: string, lines: string[] ): TextContent | null {
+	if ( lines.length === 0 ) {
+		return null;
+	}
+	return {
+		type: 'text',
+		text: `${ header }:\n${ lines.join( '\n' ) }`
+	};
+}
+
 export function parseWikitextTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'parse-wikitext',
-		'Preview rendered wikitext without saving. Returns HTML, parse warnings, categories, links, templates, external links, and display title. Use this to verify sanitizer compliance, template expansion, and link resolution before committing an edit — or to test a wikitext combination that has no target page.',
+		'Render or preview wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Use this before create-page or update-page to dry-run a planned edit, or on standalone wikitext (template combinations, sanitizer checks) with no target page.',
 		{
 			wikitext: z.string().min( 1 ).describe( 'Wikitext source to render' ),
 			title: z.string().optional().describe(
@@ -25,8 +48,9 @@ export function parseWikitextTool( server: McpServer ): RegisteredTool {
 			readOnlyHint: true,
 			destructiveHint: false
 		} as ToolAnnotations,
-		async ( { wikitext, title, applyPreSaveTransform } ) =>
+		async ( { wikitext, title, applyPreSaveTransform } ) => (
 			handleParseWikitextTool( wikitext, title, applyPreSaveTransform )
+		)
 	);
 }
 
@@ -42,7 +66,7 @@ export async function handleParseWikitextTool(
 			text: wikitext,
 			title: title ?? DEFAULT_TITLE,
 			pst: applyPreSaveTransform,
-			prop: 'text|parsewarnings',
+			prop: 'text|parsewarnings|categories|links|templates|externallinks|displaytitle',
 			formatversion: '2'
 		} );
 
@@ -62,6 +86,44 @@ export async function handleParseWikitextTool(
 			type: 'text',
 			text: `HTML:\n${ html }`
 		} );
+
+		const effectiveTitle = title ?? DEFAULT_TITLE;
+		const displayTitle: string | undefined = parse.displaytitle;
+		if ( typeof displayTitle === 'string' && displayTitle !== effectiveTitle ) {
+			results.push( {
+				type: 'text',
+				text: `Display title: ${ displayTitle }`
+			} );
+		}
+
+		const categories: CategoryItem[] = Array.isArray( parse.categories ) ?
+			parse.categories : [];
+		const categoriesBlock = bulletSection( 'Categories', categories.map( formatCategory ) );
+		if ( categoriesBlock ) {
+			results.push( categoriesBlock );
+		}
+
+		const links: LinkItem[] = Array.isArray( parse.links ) ? parse.links : [];
+		const linksBlock = bulletSection( 'Links', links.map( formatLinkLike ) );
+		if ( linksBlock ) {
+			results.push( linksBlock );
+		}
+
+		const templates: LinkItem[] = Array.isArray( parse.templates ) ? parse.templates : [];
+		const templatesBlock = bulletSection( 'Templates', templates.map( formatLinkLike ) );
+		if ( templatesBlock ) {
+			results.push( templatesBlock );
+		}
+
+		const externallinks: string[] = Array.isArray( parse.externallinks ) ?
+			parse.externallinks : [];
+		const externalsBlock = bulletSection(
+			'External links',
+			externallinks.map( ( url ) => `- ${ url }` )
+		);
+		if ( externalsBlock ) {
+			results.push( externalsBlock );
+		}
 
 		return { content: results };
 	} catch ( error ) {

--- a/tests/tools/parse-wikitext.test.ts
+++ b/tests/tools/parse-wikitext.test.ts
@@ -123,4 +123,186 @@ describe( 'parse-wikitext', () => {
 			'Failed to preview wikitext: Network down'
 		);
 	} );
+
+	it( 'formats categories with (hidden) suffix', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					categories: [
+						{ sortkey: '', category: 'Foo' },
+						{ sortkey: '', category: 'Hidden', hidden: true }
+					]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		const categoriesBlock = result.content.find( ( c ) => c.text?.startsWith( 'Categories:' ) );
+		expect( categoriesBlock?.text ).toBe(
+			'Categories:\n- Category:Foo\n- Category:Hidden (hidden)'
+		);
+	} );
+
+	it( 'formats links with (missing) suffix for red links', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					links: [
+						{ ns: 0, title: 'Foo', exists: true },
+						{ ns: 0, title: 'RedLink', exists: false }
+					]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		const linksBlock = result.content.find( ( c ) => c.text?.startsWith( 'Links:' ) );
+		expect( linksBlock?.text ).toBe( 'Links:\n- Foo\n- RedLink (missing)' );
+	} );
+
+	it( 'formats templates with (missing) suffix', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					templates: [
+						{ ns: 10, title: 'Template:Infobox', exists: true },
+						{ ns: 10, title: 'Template:Broken', exists: false }
+					]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		const templatesBlock = result.content.find( ( c ) => c.text?.startsWith( 'Templates:' ) );
+		expect( templatesBlock?.text ).toBe(
+			'Templates:\n- Template:Infobox\n- Template:Broken (missing)'
+		);
+	} );
+
+	it( 'formats external links as simple bullet list', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					externallinks: [ 'https://example.org', 'https://example.com/page' ]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		const externalsBlock = result.content.find( ( c ) => c.text?.startsWith( 'External links:' ) );
+		expect( externalsBlock?.text ).toBe(
+			'External links:\n- https://example.org\n- https://example.com/page'
+		);
+	} );
+
+	it( 'includes display title only when it differs from the input title', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					displaytitle: '<i>Custom Display</i>'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', 'Custom Title', true );
+
+		const dtBlock = result.content.find( ( c ) => c.text?.startsWith( 'Display title:' ) );
+		expect( dtBlock?.text ).toBe( 'Display title: <i>Custom Display</i>' );
+	} );
+
+	it( 'skips display title when it matches the input title', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					displaytitle: 'API'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( result.content.some( ( c ) => c.text?.startsWith( 'Display title:' ) ) ).toBe( false );
+	} );
+
+	it( 'skips empty sections entirely', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [],
+					categories: [],
+					links: [],
+					templates: [],
+					externallinks: [],
+					displaytitle: 'API'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( result.content.length ).toBe( 1 );
+		expect( result.content[ 0 ].text ).toBe( 'HTML:\n<p>x</p>' );
+	} );
+
+	it( 'emits sections in order: warnings, HTML, displaytitle, categories, links, templates, externallinks', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>x</p>',
+					parsewarnings: [ 'warn' ],
+					categories: [ { sortkey: '', category: 'Foo' } ],
+					links: [ { ns: 0, title: 'L', exists: true } ],
+					templates: [ { ns: 10, title: 'Template:T', exists: true } ],
+					externallinks: [ 'https://example.org' ],
+					displaytitle: '<i>Different</i>'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', 'Plain', true );
+
+		const prefixes = result.content.map( ( c ) => c.text!.split( ':' )[ 0 ] + ':' );
+		expect( prefixes ).toEqual( [
+			'Parse warnings:',
+			'HTML:',
+			'Display title:',
+			'Categories:',
+			'Links:',
+			'Templates:',
+			'External links:'
+		] );
+	} );
 } );

--- a/tests/tools/parse-wikitext.test.ts
+++ b/tests/tools/parse-wikitext.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+describe( 'parse-wikitext', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns HTML block for parsed wikitext', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: { text: '<p>Hello</p>', parsewarnings: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( "'''Hello'''", undefined, true );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toBe( 'HTML:\n<p>Hello</p>' );
+	} );
+
+	it( 'places parse warnings as the first block', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: '<p>Body</p>',
+					parsewarnings: [ 'Unclosed tag', 'Bad template' ]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'anything', undefined, true );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toBe(
+			'Parse warnings:\n- Unclosed tag\n- Bad template'
+		);
+		expect( result.content[ 1 ].text ).toBe( 'HTML:\n<p>Body</p>' );
+	} );
+
+	it( "defaults title to 'API' when omitted", async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: { text: '<p>x</p>', parsewarnings: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( mock.request ).toHaveBeenCalledWith( expect.objectContaining( {
+			action: 'parse',
+			text: 'x',
+			title: 'API',
+			pst: true,
+			formatversion: '2'
+		} ) );
+	} );
+
+	it( 'passes provided title through to the API call', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: { text: '<p>x</p>', parsewarnings: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		await handleParseWikitextTool( 'x', 'Custom Title', true );
+
+		expect( mock.request ).toHaveBeenCalledWith( expect.objectContaining( {
+			title: 'Custom Title'
+		} ) );
+	} );
+
+	it( 'passes applyPreSaveTransform=false through as pst: false', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: { text: '<p>x</p>', parsewarnings: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		await handleParseWikitextTool( 'x', undefined, false );
+
+		expect( mock.request ).toHaveBeenCalledWith( expect.objectContaining( {
+			pst: false
+		} ) );
+	} );
+
+	it( 'wraps mwn errors as isError with message', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockRejectedValue( new Error( 'Network down' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( result.isError ).toBe( true );
+		expect( result.content[ 0 ].text ).toBe(
+			'Failed to preview wikitext: Network down'
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

Adds a new `parse-wikitext` MCP tool that exposes MediaWiki's `action=parse` with the `text=` parameter, so callers can preview rendered wikitext without saving a page.

- Returns HTML, parse warnings (placed first so they aren't buried in long HTML), categories, links, templates, external links, and display title
- Red links and missing templates are marked `(missing)`; hidden categories marked `(hidden)`; empty sections skipped
- Defaults to editor-authentic behavior: pre-save transform applied, title context defaults to `API` when omitted

Closes #262.

## Test plan

- [x] `npm test` — 58 tests passing (44 existing + 14 new)
- [x] `npm run lint` — no new warnings from the new code
- [x] `npm run build` — clean
- [x] Smoke via MCP Inspector against a local wiki: `npx @modelcontextprotocol/inspector --cli node dist/index.js --method tools/call --tool-name parse-wikitext --tool-arg 'wikitext=<header>Test</header>{{DoesNotExist}}'` — verify warnings block surfaces the sanitizer violation and templates block lists `Template:DoesNotExist (missing)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)