### PR TITLE
Add exec credential source and fail-fast env-vars for config secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,38 @@ Config values support `${VAR_NAME}` syntax for referencing environment variables
 }
 ```
 
-If an environment variable is not set, the `${VAR_NAME}` reference is left as-is.
+**Behaviour when a referenced variable is not set:**
+
+- For secret fields (`token`, `username`, `password`): the server refuses to start with a clear error identifying the wiki, the field, and the unset variable. This fails fast so authentication problems surface at startup rather than as opaque later errors.
+- For non-secret fields: the `${VAR_NAME}` reference is left as-is.
+
+### Secret sources
+
+Secret fields (`token`, `username`, `password`) additionally accept a structured credential source that runs an external command at startup and uses its stdout as the secret value. This lets you fetch secrets from a password manager or secret store without putting them on disk:
+
+```json
+{
+  "defaultWiki": "my.wiki.org",
+  "wikis": {
+    "my.wiki.org": {
+      "sitename": "My Wiki",
+      "server": "https://my.wiki.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "token": {
+        "exec": {
+          "command": "op",
+          "args": ["read", "op://Private/my-wiki/oauth-token"]
+        }
+      }
+    }
+  }
+}
+```
+
+The command is invoked directly (no shell), with the `args` array passed verbatim. The trimmed stdout becomes the secret value. A 10-second timeout applies. If the command fails, times out, or produces no output, the server refuses to start and identifies the failing wiki and field; the secret value itself is never logged. Works with any CLI that prints a secret on stdout (`op`, `pass`, `secret-tool`, `bw`, Vault, custom shims, etc.).
+
+Plaintext secrets still work but produce a one-line stderr warning at startup, nudging you toward `${VAR}` or an `{exec: …}` object.
 
 ### Authentication setup
 

--- a/README.md
+++ b/README.md
@@ -143,14 +143,14 @@ Config values support `${VAR_NAME}` syntax for referencing environment variables
 }
 ```
 
-**Behaviour when a referenced variable is not set:**
+If a referenced variable is not set:
 
-- For secret fields (`token`, `username`, `password`): the server refuses to start with a clear error identifying the wiki, the field, and the unset variable. This fails fast so authentication problems surface at startup rather than as opaque later errors.
-- For non-secret fields: the `${VAR_NAME}` reference is left as-is.
+- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front instead of as confusing failures later.
+- **Non-secret fields**: the `${VAR_NAME}` text is kept as-is.
 
 ### Secret sources
 
-Secret fields (`token`, `username`, `password`) additionally accept a structured credential source that runs an external command at startup and uses its stdout as the secret value. This lets you fetch secrets from a password manager or secret store without putting them on disk:
+As an alternative to `${VAR_NAME}`, secret fields can run an external command at startup and use its output as the secret. This lets you fetch credentials from a password manager, keyring, or secret store without writing them to disk:
 
 ```json
 {
@@ -172,9 +172,15 @@ Secret fields (`token`, `username`, `password`) additionally accept a structured
 }
 ```
 
-The command is invoked directly (no shell), with the `args` array passed verbatim. The trimmed stdout becomes the secret value. A 10-second timeout applies. If the command fails, times out, or produces no output, the server refuses to start and identifies the failing wiki and field; the secret value itself is never logged. Works with any CLI that prints a secret on stdout (`op`, `pass`, `secret-tool`, `bw`, Vault, custom shims, etc.).
+The command runs directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies.
 
-Plaintext secrets still work but produce a one-line stderr warning at startup, nudging you toward `${VAR}` or an `{exec: …}` object.
+If the command fails, times out, or prints nothing, the server exits at startup. Error messages identify the failing wiki and field — the secret value itself is never logged.
+
+Any CLI that prints a credential to stdout works: 1Password's `op`, `pass`, `secret-tool`, Bitwarden's `bw`, HashiCorp Vault, or a custom script.
+
+### Plaintext secrets
+
+Plaintext credentials in `config.json` still work but print a one-line warning to stderr on startup. Prefer `${VAR}` or an `exec` source when possible.
 
 ### Authentication setup
 

--- a/config.example.json
+++ b/config.example.json
@@ -22,6 +22,19 @@
       "password": null,
       "private": false,
       "tags": null
+    },
+    "my.wiki.org": {
+      "sitename": "Example wiki using a secret source",
+      "server": "https://my.wiki.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "token": {
+        "exec": {
+          "command": "op",
+          "args": ["read", "op://Private/my-wiki/oauth-token"]
+        }
+      },
+      "private": false
     }
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -22,19 +22,6 @@
       "password": null,
       "private": false,
       "tags": null
-    },
-    "my.wiki.org": {
-      "sitename": "Example wiki using a secret source",
-      "server": "https://my.wiki.org",
-      "articlepath": "/wiki",
-      "scriptpath": "/w",
-      "token": {
-        "exec": {
-          "command": "op",
-          "args": ["read", "op://Private/my-wiki/oauth-token"]
-        }
-      },
-      "private": false
     }
   }
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { execFileSync } from 'child_process';
 
 export interface WikiConfig {
 	/**
@@ -136,9 +137,86 @@ function resolveSecretField(
 		}
 		return raw;
 	}
+	if ( typeof raw === 'object' && !Array.isArray( raw ) ) {
+		return runExec( raw, wikiKey, fieldName );
+	}
 	throw new Error(
-		`Config error: wikis.${ wikiKey }.${ fieldName } must be a string or null`
+		`Config error: wikis.${ wikiKey }.${ fieldName } must be a string, null, or an {exec: …} object`
 	);
+}
+
+function runExec( raw: unknown, wikiKey: string, fieldName: SecretFieldName ): string {
+	const path = `wikis.${ wikiKey }.${ fieldName }`;
+	if ( typeof raw !== 'object' || raw === null ) {
+		throw new Error(
+			`Config error: ${ path } must be a string, null, or an {exec: …} object`
+		);
+	}
+	const src = raw as { exec?: unknown };
+	if ( typeof src.exec !== 'object' || src.exec === null || Array.isArray( src.exec ) ) {
+		throw new Error(
+			`Config error: ${ path } must be a string, null, or an {exec: …} object`
+		);
+	}
+	const exec = src.exec as { command?: unknown; args?: unknown };
+	if ( typeof exec.command !== 'string' || exec.command === '' ) {
+		throw new Error( `Config error: ${ path }.exec.command must be a non-empty string` );
+	}
+	if (
+		exec.args !== undefined &&
+		(
+			!Array.isArray( exec.args ) ||
+			!exec.args.every( ( a ) => typeof a === 'string' )
+		)
+	) {
+		throw new Error( `Config error: ${ path }.exec.args must be an array of strings` );
+	}
+	const command = exec.command;
+	const args = ( exec.args as string[] | undefined ) ?? [];
+
+	let stdout: string;
+	try {
+		stdout = execFileSync( command, args, {
+			timeout: 10_000,
+			encoding: 'utf-8',
+			stdio: [ 'ignore', 'pipe', 'pipe' ]
+		} );
+	} catch ( err: unknown ) {
+		const e = err as NodeJS.ErrnoException & {
+			signal?: string;
+			status?: number | null;
+			stderr?: Buffer | string;
+		};
+		if ( e.code === 'ENOENT' ) {
+			throw new Error(
+				`Config error: failed to fetch ${ path }: command "${ command }" not found`
+			);
+		}
+		if ( e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT' ) {
+			throw new Error(
+				`Config error: failed to fetch ${ path }: command "${ command }" timed out after 10s`
+			);
+		}
+		if ( typeof e.status === 'number' && e.status !== 0 ) {
+			const stderrText = e.stderr ?
+				( Buffer.isBuffer( e.stderr ) ? e.stderr.toString( 'utf-8' ) : e.stderr ).slice( 0, 200 ) :
+				'';
+			throw new Error(
+				`Config error: failed to fetch ${ path }: command "${ command }" exited with status ${ e.status }. stderr: ${ stderrText }`
+			);
+		}
+		throw new Error(
+			`Config error: failed to fetch ${ path }: ${ e.message ?? 'unknown error' }`
+		);
+	}
+
+	const trimmed = stdout.replace( /\r?\n+$/, '' );
+	if ( trimmed === '' ) {
+		throw new Error(
+			`Config error: failed to fetch ${ path }: command "${ command }" produced no output`
+		);
+	}
+	return trimmed;
 }
 
 function resolveWiki( raw: unknown, wikiKey: string ): WikiConfig {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -129,6 +129,11 @@ function resolveSecretField(
 			}
 			return substituted;
 		}
+		if ( raw !== '' ) {
+			process.stderr.write(
+				`warning: wikis.${ wikiKey }.${ fieldName } contains a plaintext credential. Prefer \${VAR} or an {exec: …} object. See README.\n`
+			);
+		}
 		return raw;
 	}
 	throw new Error(

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -76,6 +76,10 @@ export const defaultConfig: Config = {
 		}
 	}
 };
+
+const SECRET_FIELDS = [ 'token', 'username', 'password' ] as const;
+type SecretFieldName = typeof SECRET_FIELDS[ number ];
+
 const configPath = process.env.CONFIG || 'config.json';
 
 function replaceEnvVars( value: string ): string {
@@ -102,11 +106,71 @@ function replaceEnvVarsInObject( obj: unknown ): unknown {
 	return obj;
 }
 
+function resolveSecretField(
+	raw: unknown,
+	wikiKey: string,
+	fieldName: SecretFieldName
+): string | null | undefined {
+	if ( raw === null || raw === undefined ) {
+		return raw;
+	}
+	if ( typeof raw === 'string' ) {
+		if ( raw.includes( '${' ) ) {
+			const substituted = replaceEnvVars( raw );
+			const unresolved = substituted.match( /\$\{([^}]+)\}/ );
+			if ( unresolved ) {
+				throw new Error(
+					`Config error: environment variable "${ unresolved[ 1 ] }" referenced by wikis.${ wikiKey }.${ fieldName } is not set`
+				);
+			}
+			return substituted;
+		}
+		return raw;
+	}
+	throw new Error(
+		`Config error: wikis.${ wikiKey }.${ fieldName } must be a string or null`
+	);
+}
+
+function resolveWiki( raw: unknown, wikiKey: string ): WikiConfig {
+	if ( typeof raw !== 'object' || raw === null || Array.isArray( raw ) ) {
+		throw new Error( `Config error: wikis.${ wikiKey } must be an object` );
+	}
+	const src = raw as Record<string, unknown>;
+	const resolved: Record<string, unknown> = {};
+	for ( const [ fieldKey, fieldValue ] of Object.entries( src ) ) {
+		if ( ( SECRET_FIELDS as readonly string[] ).includes( fieldKey ) ) {
+			resolved[ fieldKey ] = resolveSecretField( fieldValue, wikiKey, fieldKey as SecretFieldName );
+		} else {
+			resolved[ fieldKey ] = replaceEnvVarsInObject( fieldValue );
+		}
+	}
+	return resolved as unknown as WikiConfig;
+}
+
+function resolveConfig( parsed: unknown ): Config {
+	if ( typeof parsed !== 'object' || parsed === null || Array.isArray( parsed ) ) {
+		throw new Error( 'Config error: config.json must be an object' );
+	}
+	const p = parsed as Record<string, unknown>;
+	const defaultWiki = typeof p.defaultWiki === 'string' ? replaceEnvVars( p.defaultWiki ) : '';
+	const allowWikiManagement = typeof p.allowWikiManagement === 'boolean' ? p.allowWikiManagement : undefined;
+	const rawWikis = p.wikis;
+	if ( typeof rawWikis !== 'object' || rawWikis === null || Array.isArray( rawWikis ) ) {
+		return { defaultWiki, wikis: {}, allowWikiManagement };
+	}
+	const wikis: Record<string, WikiConfig> = {};
+	for ( const [ key, rawWiki ] of Object.entries( rawWikis ) ) {
+		wikis[ key ] = resolveWiki( rawWiki, key );
+	}
+	return { defaultWiki, wikis, allowWikiManagement };
+}
+
 export function loadConfigFromFile(): Config {
 	if ( !fs.existsSync( configPath ) ) {
 		return defaultConfig;
 	}
 	const rawData = fs.readFileSync( configPath, 'utf-8' );
 	const parsed = JSON.parse( rawData );
-	return replaceEnvVarsInObject( parsed ) as Config;
+	return resolveConfig( parsed );
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -80,6 +80,10 @@ export const defaultConfig: Config = {
 const SECRET_FIELDS = [ 'token', 'username', 'password' ] as const;
 type SecretFieldName = typeof SECRET_FIELDS[ number ];
 
+function isSecretField( name: string ): name is SecretFieldName {
+	return ( SECRET_FIELDS as readonly string[] ).includes( name );
+}
+
 const configPath = process.env.CONFIG || 'config.json';
 
 function replaceEnvVars( value: string ): string {
@@ -139,8 +143,8 @@ function resolveWiki( raw: unknown, wikiKey: string ): WikiConfig {
 	const src = raw as Record<string, unknown>;
 	const resolved: Record<string, unknown> = {};
 	for ( const [ fieldKey, fieldValue ] of Object.entries( src ) ) {
-		if ( ( SECRET_FIELDS as readonly string[] ).includes( fieldKey ) ) {
-			resolved[ fieldKey ] = resolveSecretField( fieldValue, wikiKey, fieldKey as SecretFieldName );
+		if ( isSecretField( fieldKey ) ) {
+			resolved[ fieldKey ] = resolveSecretField( fieldValue, wikiKey, fieldKey );
 		} else {
 			resolved[ fieldKey ] = replaceEnvVarsInObject( fieldValue );
 		}

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock( 'fs' );
+vi.mock( 'child_process' );
+
+const setConfigFile = ( cfg: unknown ) => {
+	vi.mocked( fs.existsSync ).mockReturnValue( true );
+	vi.mocked( fs.readFileSync ).mockReturnValue( JSON.stringify( cfg ) );
+};
+
+const baseWiki = {
+	sitename: 'Test Wiki',
+	server: 'https://test.wiki',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+	private: false
+};
+
+describe( 'loadConfigFromFile', () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach( () => {
+		vi.resetModules();
+		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	} );
+
+	describe( 'no config file', () => {
+		it( 'returns defaultConfig when config.json does not exist', async () => {
+			vi.mocked( fs.existsSync ).mockReturnValue( false );
+			const { loadConfigFromFile, defaultConfig } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile() ).toEqual( defaultConfig );
+		} );
+	} );
+
+	describe( '${VAR} substitution in secret fields', () => {
+		it( 'resolves ${VAR} when the variable is set', async () => {
+			vi.stubEnv( 'MY_TOKEN', 'resolved-token' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: '${MY_TOKEN}' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.token ).toBe( 'resolved-token' );
+		} );
+
+		it( 'throws when ${VAR} in a secret field is not set', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: '${MISSING_VAR}' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: environment variable "MISSING_VAR" referenced by wikis.w.token is not set'
+			);
+		} );
+
+		it( 'throws for username and password too', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, username: '${NOPE_U}' } }
+			} );
+			const { loadConfigFromFile: loadU } = await import( '../../src/common/config.js' );
+			expect( () => loadU() ).toThrow(
+				'referenced by wikis.w.username'
+			);
+
+			vi.resetModules();
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, password: '${NOPE_P}' } }
+			} );
+			const { loadConfigFromFile: loadP } = await import( '../../src/common/config.js' );
+			expect( () => loadP() ).toThrow(
+				'referenced by wikis.w.password'
+			);
+		} );
+
+		it( 'leaves unresolved ${VAR} in non-secret fields as-is', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, sitename: '${NOT_SET}', token: null } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.sitename ).toBe( '${NOT_SET}' );
+		} );
+	} );
+
+	describe( 'allowWikiManagement', () => {
+		it( 'preserves allowWikiManagement: false through the loader', async () => {
+			setConfigFile( {
+				allowWikiManagement: false,
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().allowWikiManagement ).toBe( false );
+		} );
+	} );
+
+	describe( 'passthrough cases', () => {
+		it( 'passes through null secret fields unchanged', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.token ).toBeNull();
+		} );
+
+		it( 'passes through plaintext secrets unchanged (warning comes in a later task)', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: 'plain-secret' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.token ).toBe( 'plain-secret' );
+		} );
+	} );
+} );

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
+import { execFileSync } from 'child_process';
 
 vi.mock( 'fs' );
+vi.mock( 'child_process' );
 
 const setConfigFile = ( cfg: unknown ) => {
 	vi.mocked( fs.existsSync ).mockReturnValue( true );
@@ -189,6 +191,200 @@ describe( 'loadConfigFromFile', () => {
 			expect( output ).toContain( 'wikis.a.token' );
 			expect( output ).toContain( 'wikis.a.password' );
 			expect( output ).toContain( 'wikis.b.username' );
+		} );
+	} );
+
+	describe( 'exec credential source', () => {
+		const SENTINEL = 'SENTINEL-NEVER-LEAK';
+
+		it( 'resolves secret from trimmed stdout of the exec command', async () => {
+			vi.mocked( execFileSync ).mockReturnValue( 'resolved-secret\n' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: {
+					w: {
+						...baseWiki,
+						token: { exec: { command: 'op', args: [ 'read', 'op://vault/token' ] } }
+					}
+				}
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.token ).toBe( 'resolved-secret' );
+			expect( vi.mocked( execFileSync ) ).toHaveBeenCalledWith(
+				'op',
+				[ 'read', 'op://vault/token' ],
+				{ timeout: 10000, encoding: 'utf-8', stdio: [ 'ignore', 'pipe', 'pipe' ] }
+			);
+		} );
+
+		it( 'calls execFileSync with [] when args is omitted', async () => {
+			vi.mocked( execFileSync ).mockReturnValue( 'secret' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: {
+					w: { ...baseWiki, token: { exec: { command: 'my-helper' } } }
+				}
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+			expect( vi.mocked( execFileSync ) ).toHaveBeenCalledWith(
+				'my-helper',
+				[],
+				expect.any( Object )
+			);
+		} );
+
+		it( 'throws when exec.command is missing or empty', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: '' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: wikis.w.token.exec.command must be a non-empty string'
+			);
+		} );
+
+		it( 'throws when exec.args is not a string array', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: {
+					w: { ...baseWiki, token: { exec: { command: 'op', args: [ 1, 2 ] } } }
+				}
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: wikis.w.token.exec.args must be an array of strings'
+			);
+		} );
+
+		it( 'maps ENOENT to a clear error', async () => {
+			vi.mocked( execFileSync ).mockImplementation( () => {
+				const e = new Error( 'spawn op ENOENT' ) as NodeJS.ErrnoException;
+				e.code = 'ENOENT';
+				throw e;
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: failed to fetch wikis.w.token: command "op" not found'
+			);
+		} );
+
+		it( 'maps timeout (SIGTERM) to a clear error', async () => {
+			vi.mocked( execFileSync ).mockImplementation( () => {
+				const e = new Error( 'timed out' ) as NodeJS.ErrnoException & { signal?: string };
+				e.signal = 'SIGTERM';
+				throw e;
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'slow' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: failed to fetch wikis.w.token: command "slow" timed out after 10s'
+			);
+		} );
+
+		it( 'maps non-zero exit to a clear error with truncated stderr', async () => {
+			vi.mocked( execFileSync ).mockImplementation( () => {
+				const e = new Error( 'command failed' ) as NodeJS.ErrnoException & {
+					status?: number;
+					stderr?: Buffer;
+				};
+				e.status = 1;
+				e.stderr = Buffer.from( 'auth required' );
+				throw e;
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: failed to fetch wikis.w.token: command "op" exited with status 1. stderr: auth required'
+			);
+		} );
+
+		it( 'truncates long stderr to 200 chars', async () => {
+			const longStderr = 'X'.repeat( 500 );
+			vi.mocked( execFileSync ).mockImplementation( () => {
+				const e = new Error( 'fail' ) as NodeJS.ErrnoException & {
+					status?: number;
+					stderr?: Buffer;
+				};
+				e.status = 2;
+				e.stderr = Buffer.from( longStderr );
+				throw e;
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			try {
+				loadConfigFromFile();
+				expect.fail( 'should have thrown' );
+			} catch ( err ) {
+				const msg = ( err as Error ).message;
+				expect( msg ).toContain( 'exited with status 2' );
+				// Count Xs in message: should be ≤200
+				expect( ( msg.match( /X/g ) ?? [] ).length ).toBeLessThanOrEqual( 200 );
+			}
+		} );
+
+		it( 'throws when stdout is empty after trim', async () => {
+			vi.mocked( execFileSync ).mockReturnValue( '\n\n' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: failed to fetch wikis.w.token: command "op" produced no output'
+			);
+		} );
+
+		it( 'throws for a malformed object in a secret field', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { wrong: 'shape' } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: wikis.w.token must be a string, null, or an {exec: …} object'
+			);
+		} );
+
+		it( 'never leaks subprocess stdout in error messages', async () => {
+			// If the subprocess printed the real secret on stdout and then errored,
+			// the error path must not reach into stdout for the message — only stderr.
+			vi.mocked( execFileSync ).mockImplementation( () => {
+				const e = new Error( 'command failed' ) as NodeJS.ErrnoException & {
+					status?: number;
+					stderr?: Buffer;
+					stdout?: Buffer;
+				};
+				e.status = 1;
+				e.stderr = Buffer.from( 'auth needed' );
+				e.stdout = Buffer.from( SENTINEL );
+				throw e;
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow( /exited with status 1/ );
+			try {
+				loadConfigFromFile();
+			} catch ( err ) {
+				expect( ( err as Error ).message ).not.toContain( SENTINEL );
+			}
 		} );
 	} );
 } );

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -17,8 +17,11 @@ const baseWiki = {
 };
 
 describe( 'loadConfigFromFile', () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
 	beforeEach( () => {
 		vi.resetModules();
+		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
 	} );
 
 	afterEach( () => {
@@ -116,6 +119,76 @@ describe( 'loadConfigFromFile', () => {
 			} );
 			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
 			expect( loadConfigFromFile().wikis.w.token ).toBe( 'plain-secret' );
+		} );
+	} );
+
+	describe( 'plaintext warnings', () => {
+		it( 'warns when a secret field is a plaintext literal', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: 'plain-secret-SENTINEL' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+
+			const output = stderrSpy.mock.calls.map( ( c ) => String( c[ 0 ] ) ).join( '' );
+			expect( output ).toContain( 'wikis.w.token' );
+			expect( output ).toContain( 'plaintext credential' );
+			expect( output ).not.toContain( 'plain-secret-SENTINEL' );
+		} );
+
+		it( 'does not warn for resolved ${VAR} secrets', async () => {
+			vi.stubEnv( 'SAFE_TOKEN', 'resolved' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: '${SAFE_TOKEN}' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+
+			const output = stderrSpy.mock.calls.map( ( c ) => String( c[ 0 ] ) ).join( '' );
+			expect( output ).not.toContain( 'plaintext credential' );
+		} );
+
+		it( 'does not warn for null secrets', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null, username: null, password: null } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+
+			const output = stderrSpy.mock.calls.map( ( c ) => String( c[ 0 ] ) ).join( '' );
+			expect( output ).not.toContain( 'plaintext credential' );
+		} );
+
+		it( 'does not warn for empty-string secrets', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: '' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+
+			const output = stderrSpy.mock.calls.map( ( c ) => String( c[ 0 ] ) ).join( '' );
+			expect( output ).not.toContain( 'plaintext credential' );
+		} );
+
+		it( 'warns once per offending field across multiple wikis', async () => {
+			setConfigFile( {
+				defaultWiki: 'a',
+				wikis: {
+					a: { ...baseWiki, token: 'xxxxxxx', password: 'yyyyyyy' },
+					b: { ...baseWiki, username: 'zzzzzzz' }
+				}
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			loadConfigFromFile();
+
+			const output = stderrSpy.mock.calls.map( ( c ) => String( c[ 0 ] ) ).join( '' );
+			expect( output ).toContain( 'wikis.a.token' );
+			expect( output ).toContain( 'wikis.a.password' );
+			expect( output ).toContain( 'wikis.b.username' );
 		} );
 	} );
 } );

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock( 'fs' );
-vi.mock( 'child_process' );
 
 const setConfigFile = ( cfg: unknown ) => {
 	vi.mocked( fs.existsSync ).mockReturnValue( true );
@@ -18,11 +17,8 @@ const baseWiki = {
 };
 
 describe( 'loadConfigFromFile', () => {
-	let stderrSpy: ReturnType<typeof vi.spyOn>;
-
 	beforeEach( () => {
 		vi.resetModules();
-		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
## Summary
- Add `{ exec: { command, args } }` credential source for `token`/`username`/`password` in `config.json` — runs an external CLI at startup via `execFileSync` (no shell, 10s timeout) and uses trimmed stdout as the secret value. Error messages name `wikis.<key>.<field>` and never include subprocess stdout.
- Fail fast on unresolved `${VAR}` refs in secret fields. Previously silent; now throws `Config error: environment variable "<NAME>" referenced by wikis.<key>.<field> is not set` at startup. Non-secret fields keep lenient passthrough.
- Emit a one-line stderr warning when a secret field contains a plaintext literal. Server still starts.
- README: rewrite the env-var substitution section and add a new "Secret sources" subsection with a worked `op read` example. `config.example.json` gains a third wiki demonstrating the exec form.

## Behaviour changes
- Configs with an unresolved `${VAR}` in `token`/`username`/`password` now fail at startup with a clear error (previously: silent passthrough + opaque downstream auth error).
- Plaintext credentials still work but produce a one-line stderr warning on load.
- No change to the `WikiConfig` shape seen by consumers; `src/common/wikiService.ts` and `src/common/mwn.ts` are untouched.

## Test Plan
- [x] `npm test` — 67 tests pass (was 44), including a sentinel-based leak-guard for exec stdout
- [x] `npm run build` clean
- [x] `npm run lint` clean (only the pre-existing `security/detect-non-literal-fs-filename` warnings)
- [x] Manual smoke: config with `"token": "${SET_VAR}"` → loads; with `"${UNSET_VAR}"` → fails at startup with named error
- [x] Manual smoke: config with `{ exec: { command: "echo", args: ["secret"] } }` → resolves to `"secret"`
- [x] Manual smoke: config with plaintext `"token": "foo"` → warning on stderr, server still starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)