### PR TITLE
Add configurable change tag for MCP-originated actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 | `username` | No | Bot username (fallback when OAuth2 is not available) |
 | `password` | No | Bot password (fallback when OAuth2 is not available) |
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
+| `tags` | No | Change tag(s) applied to every write (must be registered on the wiki). Accepts a string or array of strings |
 
 ### Environment variable substitution
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 | `username` | No | Bot username (fallback when OAuth2 is not available) |
 | `password` | No | Bot password (fallback when OAuth2 is not available) |
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
-| `tags` | No | Change tag(s) applied to every write (must be registered on the wiki). Accepts a string or array of strings |
+| `tags` | No | Change tag(s) applied to every write. The tag must be created and activated on the wiki at `Special:Tags` before use; MediaWiki returns a `badtags` error otherwise. Accepts a string or array of strings |
 
 ### Environment variable substitution
 

--- a/config.example.json
+++ b/config.example.json
@@ -19,7 +19,8 @@
       "token": null,
       "username": null,
       "password": null,
-      "private": false
+      "private": false,
+      "tags": "mcp-server"
     }
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -20,7 +20,7 @@
       "username": null,
       "password": null,
       "private": false,
-      "tags": "mcp-server"
+      "tags": null
     }
   }
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -34,6 +34,13 @@ export interface WikiConfig {
 	 * $wgGroupPermissions['*']['read'] = false; in MediaWiki
 	 */
 	private?: boolean;
+	/**
+	 * Change tag(s) applied to every write action made through this MCP
+	 * server. The tag(s) must be registered and active on the wiki (see
+	 * Special:Tags on the target wiki). If the tag is not applicable to
+	 * the action, MediaWiki returns a badtags error and the write fails.
+	 */
+	tags?: string | string[];
 }
 
 export type PublicWikiConfig = Omit<WikiConfig, 'token' | 'username' | 'password'>;

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -40,7 +40,7 @@ export interface WikiConfig {
 	 * Special:Tags on the target wiki). If the tag is not applicable to
 	 * the action, MediaWiki returns a badtags error and the write fails.
 	 */
-	tags?: string | string[];
+	tags?: string | string[] | null;
 }
 
 export type PublicWikiConfig = Omit<WikiConfig, 'token' | 'username' | 'password'>;

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -4,6 +4,7 @@ import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { getPageUrl, formatEditComment } from '../common/utils.js';
 
 export function createPageTool( server: McpServer ): RegisteredTool {
@@ -36,7 +37,15 @@ export async function handleCreatePageTool(
 	try {
 		const mwn = await getMwn();
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const options = contentModel === undefined ? {} : { contentmodel: contentModel as any };
+		const options: { contentmodel?: any; tags?: string | string[] } = {};
+		if ( contentModel !== undefined ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			options.contentmodel = contentModel as any;
+		}
+		const { config } = wikiService.getCurrent();
+		if ( config.tags !== undefined ) {
+			options.tags = config.tags;
+		}
 		const result = await mwn.create(
 			title, source,
 			formatEditComment( 'create-page', comment ),

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiEditPageParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
@@ -36,11 +37,9 @@ export async function handleCreatePageTool(
 ): Promise<CallToolResult> {
 	try {
 		const mwn = await getMwn();
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const options: { contentmodel?: any; tags?: string | string[] } = {};
+		const options: ApiEditPageParams = {};
 		if ( contentModel !== undefined ) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			options.contentmodel = contentModel as any;
+			options.contentmodel = contentModel as ApiEditPageParams[ 'contentmodel' ];
 		}
 		const { config } = wikiService.getCurrent();
 		if ( config.tags !== undefined ) {

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -42,7 +42,7 @@ export async function handleCreatePageTool(
 			options.contentmodel = contentModel as ApiEditPageParams[ 'contentmodel' ];
 		}
 		const { config } = wikiService.getCurrent();
-		if ( config.tags !== undefined ) {
+		if ( config.tags !== null && config.tags !== undefined ) {
 			options.tags = config.tags;
 		}
 		const result = await mwn.create(

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -37,7 +37,7 @@ export async function handleDeletePageTool(
 		const mwn = await getMwn();
 		const { config } = wikiService.getCurrent();
 		const options: ApiDeleteParams = {};
-		if ( config.tags !== undefined ) {
+		if ( config.tags !== null && config.tags !== undefined ) {
 			options.tags = config.tags;
 		}
 		data = await mwn.delete(

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiDeleteResponse } from 'mwn';
+import type { ApiDeleteParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
 
 export function deletePageTool( server: McpServer ): RegisteredTool {
@@ -26,14 +28,23 @@ export function deletePageTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleDeletePageTool(
+export async function handleDeletePageTool(
 	title: string,
 	comment?: string
 ): Promise<CallToolResult> {
 	let data: ApiDeleteResponse;
 	try {
 		const mwn = await getMwn();
-		data = await mwn.delete( title, formatEditComment( 'delete-page', comment ) );
+		const { config } = wikiService.getCurrent();
+		const options: ApiDeleteParams = {};
+		if ( config.tags !== undefined ) {
+			options.tags = config.tags;
+		}
+		data = await mwn.delete(
+			title,
+			formatEditComment( 'delete-page', comment ),
+			options
+		);
 	} catch ( error ) {
 		return {
 			content: [

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiUndeleteResponse } from 'mwn';
+import type { ApiUndeleteParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
 
 export function undeletePageTool( server: McpServer ): RegisteredTool {
@@ -26,14 +28,23 @@ export function undeletePageTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleUndeletePageTool(
+export async function handleUndeletePageTool(
 	title: string,
 	comment?: string
 ): Promise<CallToolResult> {
 	let data: ApiUndeleteResponse;
 	try {
 		const mwn = await getMwn();
-		data = await mwn.undelete( title, formatEditComment( 'undelete-page', comment ) );
+		const { config } = wikiService.getCurrent();
+		const options: ApiUndeleteParams = {};
+		if ( config.tags !== undefined ) {
+			options.tags = config.tags;
+		}
+		data = await mwn.undelete(
+			title,
+			formatEditComment( 'undelete-page', comment ),
+			options
+		);
 	} catch ( error ) {
 		return {
 			content: [

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -37,7 +37,7 @@ export async function handleUndeletePageTool(
 		const mwn = await getMwn();
 		const { config } = wikiService.getCurrent();
 		const options: ApiUndeleteParams = {};
-		if ( config.tags !== undefined ) {
+		if ( config.tags !== null && config.tags !== undefined ) {
 			options.tags = config.tags;
 		}
 		data = await mwn.undelete(

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -44,7 +44,7 @@ export async function handleUpdatePageTool(
 			options.baserevid = latestId;
 		}
 		const { config } = wikiService.getCurrent();
-		if ( config.tags !== undefined ) {
+		if ( config.tags !== null && config.tags !== undefined ) {
 			options.tags = config.tags;
 		}
 		const result = await mwn.save(

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -4,6 +4,7 @@ import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { getPageUrl, formatEditComment } from '../common/utils.js';
 
 export function updatePageTool( server: McpServer ): RegisteredTool {
@@ -37,9 +38,13 @@ export async function handleUpdatePageTool(
 		const mwn = await getMwn();
 		// nocreate: fail if the page does not exist, so a mis-typed
 		// title doesn't silently create a new page.
-		const options: { nocreate: true; baserevid?: number } = { nocreate: true };
+		const options: { nocreate: true; baserevid?: number; tags?: string | string[] } = { nocreate: true };
 		if ( latestId !== undefined ) {
 			options.baserevid = latestId;
+		}
+		const { config } = wikiService.getCurrent();
+		if ( config.tags !== undefined ) {
+			options.tags = config.tags;
 		}
 		const result = await mwn.save(
 			title, source,

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiEditPageParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
@@ -38,7 +39,7 @@ export async function handleUpdatePageTool(
 		const mwn = await getMwn();
 		// nocreate: fail if the page does not exist, so a mis-typed
 		// title doesn't silently create a new page.
-		const options: { nocreate: true; baserevid?: number; tags?: string | string[] } = { nocreate: true };
+		const options: ApiEditPageParams = { nocreate: true };
 		if ( latestId !== undefined ) {
 			options.baserevid = latestId;
 		}

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -76,7 +76,7 @@ function getApiUploadParams( comment?: string ): ApiUploadParams {
 		comment: formatEditComment( 'upload-file-from-url', comment )
 	};
 	const { config } = wikiService.getCurrent();
-	if ( config.tags !== undefined ) {
+	if ( config.tags !== null && config.tags !== undefined ) {
 		params.tags = config.tags;
 	}
 	return params;

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -6,6 +6,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
 
 export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
@@ -29,7 +30,7 @@ export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleUploadFileFromUrlTool(
+export async function handleUploadFileFromUrlTool(
 	url: string, title: string, text: string, comment?: string
 ): Promise< CallToolResult > {
 
@@ -71,9 +72,14 @@ async function handleUploadFileFromUrlTool(
 }
 
 function getApiUploadParams( comment?: string ): ApiUploadParams {
-	return {
+	const params: ApiUploadParams = {
 		comment: formatEditComment( 'upload-file-from-url', comment )
 	};
+	const { config } = wikiService.getCurrent();
+	if ( config.tags !== undefined ) {
+		params.tags = config.tags;
+	}
+	return params;
 }
 
 function uploadFileFromUrlToolResult( data: ApiUploadResponse ): TextContent[] {

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -6,6 +6,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
 
 export function uploadFileTool( server: McpServer ): RegisteredTool {
@@ -29,7 +30,7 @@ export function uploadFileTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleUploadFileTool(
+export async function handleUploadFileTool(
 	filepath: string, title: string, text: string, comment?: string
 ): Promise< CallToolResult > {
 
@@ -55,9 +56,14 @@ async function handleUploadFileTool(
 }
 
 function getApiUploadParams( comment?: string ): ApiUploadParams {
-	return {
+	const params: ApiUploadParams = {
 		comment: formatEditComment( 'upload-file', comment )
 	};
+	const { config } = wikiService.getCurrent();
+	if ( config.tags !== undefined ) {
+		params.tags = config.tags;
+	}
+	return params;
 }
 
 function uploadFileToolResult( data: ApiUploadResponse ): TextContent[] {

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -60,7 +60,7 @@ function getApiUploadParams( comment?: string ): ApiUploadParams {
 		comment: formatEditComment( 'upload-file', comment )
 	};
 	const { config } = wikiService.getCurrent();
-	if ( config.tags !== undefined ) {
+	if ( config.tags !== null && config.tags !== undefined ) {
 		params.tags = config.tags;
 	}
 	return params;

--- a/tests/tools/create-page.test.ts
+++ b/tests/tools/create-page.test.ts
@@ -12,6 +12,7 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 } ) );
 
 import { getMwn } from '../../src/common/mwn.js';
+import { wikiService } from '../../src/common/wikiService.js';
 
 describe( 'create-page', () => {
 	beforeEach( () => { vi.clearAllMocks(); } );
@@ -66,5 +67,49 @@ describe( 'create-page', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toContain( 'Page exists' );
+	} );
+
+	it( 'forwards configured tags to mwn.create()', async () => {
+		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
+			key: 'test-wiki',
+			config: {
+				server: 'https://test.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				tags: 'mcp-server'
+			}
+		} as ReturnType<typeof wikiService.getCurrent> );
+
+		const mock = createMockMwn( {
+			create: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 12, title: 'Tagged Page',
+				contentmodel: 'wikitext', oldrevid: 0, newrevid: 3,
+				newtimestamp: '2026-01-01T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleCreatePageTool } = await import( '../../src/tools/create-page.js' );
+		await handleCreatePageTool( 'Hello', 'Tagged Page', undefined, undefined );
+
+		const opts = mock.create.mock.calls[ 0 ][ 3 ];
+		expect( opts ).toHaveProperty( 'tags', 'mcp-server' );
+	} );
+
+	it( 'omits tags from options when not configured', async () => {
+		const mock = createMockMwn( {
+			create: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 13, title: 'Untagged Page',
+				contentmodel: 'wikitext', oldrevid: 0, newrevid: 4,
+				newtimestamp: '2026-01-01T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleCreatePageTool } = await import( '../../src/tools/create-page.js' );
+		await handleCreatePageTool( 'Hello', 'Untagged Page', undefined, undefined );
+
+		const opts = mock.create.mock.calls[ 0 ][ 3 ];
+		expect( opts ).not.toHaveProperty( 'tags' );
 	} );
 } );

--- a/tests/tools/create-page.test.ts
+++ b/tests/tools/create-page.test.ts
@@ -112,4 +112,31 @@ describe( 'create-page', () => {
 		const opts = mock.create.mock.calls[ 0 ][ 3 ];
 		expect( opts ).not.toHaveProperty( 'tags' );
 	} );
+
+	it( 'treats null tags as unset', async () => {
+		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
+			key: 'test-wiki',
+			config: {
+				server: 'https://test.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				tags: null
+			}
+		} as ReturnType<typeof wikiService.getCurrent> );
+
+		const mock = createMockMwn( {
+			create: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 14, title: 'Null Tagged Page',
+				contentmodel: 'wikitext', oldrevid: 0, newrevid: 5,
+				newtimestamp: '2026-01-01T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleCreatePageTool } = await import( '../../src/tools/create-page.js' );
+		await handleCreatePageTool( 'Hello', 'Null Tagged Page', undefined, undefined );
+
+		const opts = mock.create.mock.calls[ 0 ][ 3 ];
+		expect( opts ).not.toHaveProperty( 'tags' );
+	} );
 } );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -132,4 +132,31 @@ describe( 'update-page', () => {
 		const opts = mock.save.mock.calls[ 0 ][ 3 ];
 		expect( opts ).not.toHaveProperty( 'tags' );
 	} );
+
+	it( 'treats null tags as unset on save', async () => {
+		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
+			key: 'test-wiki',
+			config: {
+				server: 'https://test.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				tags: null
+			}
+		} as ReturnType<typeof wikiService.getCurrent> );
+
+		const mock = createMockMwn( {
+			save: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 9, title: 'Null Tagged',
+				contentmodel: 'wikitext', oldrevid: 70, newrevid: 71,
+				newtimestamp: '2026-01-02T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+		await handleUpdatePageTool( 'Null Tagged', 'content', undefined, 'summary' );
+
+		const opts = mock.save.mock.calls[ 0 ][ 3 ];
+		expect( opts ).not.toHaveProperty( 'tags' );
+	} );
 } );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -12,6 +12,7 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 } ) );
 
 import { getMwn } from '../../src/common/mwn.js';
+import { wikiService } from '../../src/common/wikiService.js';
 
 describe( 'update-page', () => {
 	beforeEach( () => { vi.clearAllMocks(); } );
@@ -86,5 +87,49 @@ describe( 'update-page', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toContain( 'doesn\'t exist' );
+	} );
+
+	it( 'forwards configured array tags to mwn.save()', async () => {
+		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
+			key: 'test-wiki',
+			config: {
+				server: 'https://test.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				tags: [ 'mcp-server', 'automated' ]
+			}
+		} as ReturnType<typeof wikiService.getCurrent> );
+
+		const mock = createMockMwn( {
+			save: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 7, title: 'Tagged Page',
+				contentmodel: 'wikitext', oldrevid: 50, newrevid: 51,
+				newtimestamp: '2026-01-02T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+		await handleUpdatePageTool( 'Tagged Page', 'content', 50, 'summary' );
+
+		const opts = mock.save.mock.calls[ 0 ][ 3 ];
+		expect( opts ).toHaveProperty( 'tags', [ 'mcp-server', 'automated' ] );
+	} );
+
+	it( 'omits tags from save options when not configured', async () => {
+		const mock = createMockMwn( {
+			save: vi.fn().mockResolvedValue( {
+				result: 'Success', pageid: 8, title: 'Untagged',
+				contentmodel: 'wikitext', oldrevid: 60, newrevid: 61,
+				newtimestamp: '2026-01-02T00:00:00Z'
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+		await handleUpdatePageTool( 'Untagged', 'content', undefined, 'summary' );
+
+		const opts = mock.save.mock.calls[ 0 ][ 3 ];
+		expect( opts ).not.toHaveProperty( 'tags' );
 	} );
 } );


### PR DESCRIPTION
## Summary

Closes #128.

- Adds an optional per-wiki `tags` field to `WikiConfig` (accepts `string` or `string[]`).
- Forwards the configured tag to every write tool: `create-page`, `update-page`, `delete-page`, `undelete-page`, `upload-file`, `upload-file-from-url`.
- No pre-validation: wiki admins must register the tag at `Special:Tags` on the target wiki. If missing or inapplicable, MediaWiki returns `badtags` and that error surfaces to the caller verbatim.
- Drive-by: exports the `handle*Tool` functions for `delete-page`, `undelete-page`, `upload-file`, and `upload-file-from-url` (AGENTS.md says handlers must be exported for testability; they weren't).
- Documents the field in `config.example.json` and the README wiki-config table.

## Test plan

- [x] Automated: 110 vitest cases pass. `create-page` tests cover the `string` shape plus the absent-tags path; `update-page` tests cover the `string[]` shape plus the absent-tags path. The four remaining write tools have no test files (pre-existing gap, not introduced here).
- [x] Manual via MCP Inspector against a local wiki with `"tags": "mcp-server"` configured and the `mcp-server` tag registered + active at Special:Tags:
  - [x] Create a page; confirm the revision carries the tag in page history.
  - [x] Update that page; confirm the new revision carries the tag.
  - [x] Delete the page; confirm `Special:Log/delete` entry carries the tag.
  - [x] Undelete the page; confirm the undelete log entry carries the tag.
  - [x] Upload a local file; confirm `Special:Log/upload` entry carries the tag.
  - [x] Upload from URL (if copy-uploads enabled); confirm the log entry carries the tag.
- [x] Sanity: with no `tags` configured, writes continue to work with no tag attached.
- [x] Sanity: with a misconfigured tag (not registered), writes fail with a clear `badtags` error.