### PR TITLE
Per-wiki readOnly config and hosted deployment recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 | `username` | No | Bot username (fallback when OAuth2 is not available) |
 | `password` | No | Bot password (fallback when OAuth2 is not available) |
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
+| `readOnly` | No | When `true`, hides the six 🔐 write tools from `tools/list` while this wiki is active. Pairs with `allowWikiManagement: false` for a [hosted read-only endpoint](docs/deployment.md). Default: `false` |
 | `tags` | No | Change tag(s) to apply to every write (string or array). The tag must exist and be active at `Special:Tags` — see [docs/configuration.md](docs/configuration.md#change-tags-tags) for details. |
 
 > Environment variable substitution (`${VAR}`), secret sources that read from a password manager, and the plaintext-warning behavior are covered in [docs/configuration.md](docs/configuration.md).
 
 ## Authentication
 
-Tools marked 🔐 require authentication.
+Tools marked 🔐 require authentication. They are also hidden from `tools/list` when the active wiki has `readOnly: true` — see [Deployment](#deployment).
 
 ### OAuth2 (preferred)
 
@@ -257,6 +258,10 @@ You should end up with something like the below in your `.claude.json` config:
 },
 ```
 </details>
+
+## Deployment
+
+Running the server as a remote HTTP endpoint for other users has its own configuration requirements — see [docs/deployment.md](docs/deployment.md).
 
 ## Contributing
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,45 @@
+# Deployment
+
+> **Experimental — work in progress.** The only supported hosted shape today is **single-wiki, read-only** — one wiki entry, `readOnly: true`, anonymous access. Writable and multi-wiki hosted deployments are on the roadmap but not yet safe to run. Do not expose a single MCP server to mutually untrusted users.
+
+The server can run as a remote HTTP endpoint for clients that only accept URLs (e.g. hosted LLM chat products).
+
+## Environment
+
+- `MCP_TRANSPORT=http` — switch to the StreamableHTTP transport (the Dockerfile sets this by default).
+- `PORT` — the port to listen on (defaults to `3000` locally and `8080` in the Docker image).
+
+## Required configuration
+
+```json
+{
+  "allowWikiManagement": false,
+  "defaultWiki": "example.org",
+  "wikis": {
+    "example.org": {
+      "sitename": "Example Wiki",
+      "server": "https://example.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "readOnly": true
+    }
+  }
+}
+```
+
+Exactly one wiki entry, `readOnly: true`, `allowWikiManagement: false`. Together these disable `add-wiki` and `remove-wiki`, and hide the six write tools (`create-page`, `update-page`, `delete-page`, `undelete-page`, `upload-file`, `upload-file-from-url`) from `tools/list`. The result is an anonymous, read-only MCP interface.
+
+Do not configure `token`, `username`, or `password`. The server has no per-caller authentication; credentials in the config become shared across every caller that reaches the endpoint — almost always the wrong behaviour for a public deployment.
+
+Place the server behind a reverse proxy that terminates TLS and applies rate limiting. Cloudflare, nginx, and Caddy all work well.
+
+## Docker
+
+Build and run the image locally:
+
+```bash
+docker build -t mediawiki-mcp-server .
+docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" mediawiki-mcp-server
+```
+
+The image sets `MCP_TRANSPORT=http` and `PORT=8080`, runs as a non-root user, and exposes `/health` for orchestration probes. No image is published to a registry; build from source.

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -36,6 +36,13 @@ export interface WikiConfig {
 	 */
 	private?: boolean;
 	/**
+	 * When true, the six write tools (create-page, update-page,
+	 * delete-page, undelete-page, upload-file, upload-file-from-url)
+	 * are hidden from tools/list while this wiki is the active wiki.
+	 * Defaults to false.
+	 */
+	readOnly?: boolean;
+	/**
 	 * Change tag(s) applied to every write action made through this MCP
 	 * server. The tag(s) must be registered and active on the wiki (see
 	 * Special:Tags on the target wiki). If the tag is not applicable to
@@ -231,6 +238,11 @@ function resolveWiki( raw: unknown, wikiKey: string ): WikiConfig {
 		} else {
 			resolved[ fieldKey ] = replaceEnvVarsInObject( fieldValue );
 		}
+	}
+	if ( resolved.readOnly !== undefined && typeof resolved.readOnly !== 'boolean' ) {
+		throw new Error(
+			`Config error: wikis.${ wikiKey }.readOnly must be a boolean`
+		);
 	}
 	return resolved as unknown as WikiConfig;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,12 @@
 /* eslint-disable n/no-missing-import */
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 /* eslint-enable n/no-missing-import */
 import { createRequire } from 'node:module';
+import { wikiService } from './common/wikiService.js';
+import type { WikiConfig } from './common/config.js';
 import { registerAllTools } from './tools/index.js';
 import { registerAllResources } from './resources/index.js';
+import { reconcileToolsForActiveWiki } from './tools/reconcile.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
 const packageInfo = createRequire( import.meta.url )( '../package.json' ) as { version: string };
@@ -21,13 +24,26 @@ export const createServer = (): McpServer => {
 			capabilities: {
 				resources: {
 					listChanged: true
+				},
+				tools: {
+					listChanged: true
 				}
 			}
 		}
 	);
 
-	registerAllTools( server );
+	const tools = new Map<string, RegisteredTool>();
+	const reconcile = ( wiki: Readonly<WikiConfig> ): void => {
+		reconcileToolsForActiveWiki( tools, wiki );
+	};
+
+	const registered = registerAllTools( server, reconcile );
+	for ( const [ name, tool ] of registered ) {
+		tools.set( name, tool );
+	}
 	registerAllResources( server );
+
+	reconcile( wikiService.getCurrent().config );
 
 	return server;
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -26,44 +26,51 @@ import { comparePagesTool } from './compare-pages.js';
 
 type ToolRegistrar = ( server: McpServer ) => RegisteredTool;
 
-const toolRegistrars: ToolRegistrar[] = [
-	getPageTool,
-	getPagesTool,
-	getPageHistoryTool,
-	searchPageTool,
-	setWikiTool,
-	addWikiTool,
-	removeWikiTool,
-	updatePageTool,
-	getFileTool,
-	createPageTool,
-	uploadFileTool,
-	uploadFileFromUrlTool,
-	deletePageTool,
-	getRevisionTool,
-	undeletePageTool,
-	getCategoryMembersTool,
-	searchPageByPrefixTool,
-	parseWikitextTool,
-	comparePagesTool
+// set-wiki is registered separately in registerAllTools because its
+// signature will take additional arguments in a subsequent change.
+const toolRegistrars: [ string, ToolRegistrar ][] = [
+	[ 'get-page', getPageTool ],
+	[ 'get-pages', getPagesTool ],
+	[ 'get-page-history', getPageHistoryTool ],
+	[ 'search-page', searchPageTool ],
+	[ 'add-wiki', addWikiTool ],
+	[ 'remove-wiki', removeWikiTool ],
+	[ 'update-page', updatePageTool ],
+	[ 'get-file', getFileTool ],
+	[ 'create-page', createPageTool ],
+	[ 'upload-file', uploadFileTool ],
+	[ 'upload-file-from-url', uploadFileFromUrlTool ],
+	[ 'delete-page', deletePageTool ],
+	[ 'get-revision', getRevisionTool ],
+	[ 'undelete-page', undeletePageTool ],
+	[ 'get-category-members', getCategoryMembersTool ],
+	[ 'search-page-by-prefix', searchPageByPrefixTool ],
+	[ 'parse-wikitext', parseWikitextTool ],
+	[ 'compare-pages', comparePagesTool ]
 ];
 
 const wikiManagementRegistrars: Set<ToolRegistrar> = new Set( [ addWikiTool, removeWikiTool ] );
 
-export function registerAllTools( server: McpServer ): RegisteredTool[] {
-	const registered: RegisteredTool[] = [];
+export function registerAllTools( server: McpServer ): Map<string, RegisteredTool> {
+	const registered = new Map<string, RegisteredTool>();
 	const allowManagement = wikiService.isWikiManagementAllowed();
 
-	for ( const registrar of toolRegistrars ) {
+	for ( const [ name, registrar ] of toolRegistrars ) {
 		try {
 			const tool = registrar( server );
 			if ( !allowManagement && wikiManagementRegistrars.has( registrar ) ) {
 				tool.disable();
 			}
-			registered.push( tool );
+			registered.set( name, tool );
 		} catch ( error ) {
 			console.error( `Error registering tool: ${ ( error as Error ).message }` );
 		}
+	}
+
+	try {
+		registered.set( 'set-wiki', setWikiTool( server ) );
+	} catch ( error ) {
+		console.error( `Error registering tool: ${ ( error as Error ).message }` );
 	}
 
 	return registered;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,7 +8,7 @@ import { getPageTool } from './get-page.js';
 import { getPagesTool } from './get-pages.js';
 import { getPageHistoryTool } from './get-page-history.js';
 import { searchPageTool } from './search-page.js';
-import { setWikiTool } from './set-wiki.js';
+import { setWikiTool, type OnActiveWikiChanged } from './set-wiki.js';
 import { addWikiTool } from './add-wiki.js';
 import { removeWikiTool } from './remove-wiki.js';
 import { updatePageTool } from './update-page.js';
@@ -51,7 +51,10 @@ const toolRegistrars: [ string, ToolRegistrar ][] = [
 
 const wikiManagementRegistrars: Set<ToolRegistrar> = new Set( [ addWikiTool, removeWikiTool ] );
 
-export function registerAllTools( server: McpServer ): Map<string, RegisteredTool> {
+export function registerAllTools(
+	server: McpServer,
+	onActiveWikiChanged: OnActiveWikiChanged
+): Map<string, RegisteredTool> {
 	const registered = new Map<string, RegisteredTool>();
 	const allowManagement = wikiService.isWikiManagementAllowed();
 
@@ -68,7 +71,7 @@ export function registerAllTools( server: McpServer ): Map<string, RegisteredToo
 	}
 
 	try {
-		registered.set( 'set-wiki', setWikiTool( server ) );
+		registered.set( 'set-wiki', setWikiTool( server, onActiveWikiChanged ) );
 	} catch ( error ) {
 		console.error( `Error registering tool: ${ ( error as Error ).message }` );
 	}

--- a/src/tools/reconcile.ts
+++ b/src/tools/reconcile.ts
@@ -1,0 +1,39 @@
+/* eslint-disable n/no-missing-import */
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+/* eslint-enable n/no-missing-import */
+import type { WikiConfig } from '../common/config.js';
+
+const WRITE_TOOL_NAMES: readonly string[] = [
+	'create-page',
+	'update-page',
+	'delete-page',
+	'undelete-page',
+	'upload-file',
+	'upload-file-from-url'
+];
+
+export function reconcileToolsForActiveWiki(
+	tools: Map<string, RegisteredTool>,
+	activeWiki: Readonly<WikiConfig>
+): void {
+	applyReadOnlyRule( tools, activeWiki );
+	// Future rules (e.g. extension-gating) are added here.
+}
+
+function applyReadOnlyRule(
+	tools: Map<string, RegisteredTool>,
+	activeWiki: Readonly<WikiConfig>
+): void {
+	const shouldBeEnabled = !activeWiki.readOnly;
+	for ( const name of WRITE_TOOL_NAMES ) {
+		const tool = tools.get( name );
+		if ( !tool ) {
+			continue;
+		}
+		if ( shouldBeEnabled && !tool.enabled ) {
+			tool.enable();
+		} else if ( !shouldBeEnabled && tool.enabled ) {
+			tool.disable();
+		}
+	}
+}

--- a/src/tools/set-wiki.ts
+++ b/src/tools/set-wiki.ts
@@ -4,9 +4,15 @@ import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { wikiService } from '../common/wikiService.js';
+import type { WikiConfig } from '../common/config.js';
 import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wikiResource.js';
 
-export function setWikiTool( server: McpServer ): RegisteredTool {
+export type OnActiveWikiChanged = ( activeWiki: Readonly<WikiConfig> ) => void;
+
+export function setWikiTool(
+	server: McpServer,
+	onActiveWikiChanged: OnActiveWikiChanged
+): RegisteredTool {
 	return server.tool(
 		'set-wiki',
 		'Selects the wiki to use for subsequent tool calls in this session. Required before interacting with a wiki that is not the configured default; the active wiki is consulted by every page, file, search, and history tool. Returns the new active wiki\'s sitename and server URL.',
@@ -20,11 +26,14 @@ export function setWikiTool( server: McpServer ): RegisteredTool {
 			idempotentHint: true,
 			openWorldHint: false
 		} as ToolAnnotations,
-		( { uri } ) => handleSetWikiTool( uri )
+		( { uri } ) => handleSetWikiTool( uri, onActiveWikiChanged )
 	);
 }
 
-async function handleSetWikiTool( uri: string ): Promise<CallToolResult> {
+async function handleSetWikiTool(
+	uri: string,
+	onActiveWikiChanged: OnActiveWikiChanged
+): Promise<CallToolResult> {
 	try {
 		const { wikiKey } = parseWikiResourceUri( uri );
 
@@ -41,6 +50,7 @@ async function handleSetWikiTool( uri: string ): Promise<CallToolResult> {
 		wikiService.setCurrent( wikiKey );
 
 		const newConfig = wikiService.getCurrent().config;
+		onActiveWikiChanged( newConfig );
 		return {
 			content: [ {
 				type: 'text',

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -104,6 +104,46 @@ describe( 'loadConfigFromFile', () => {
 		} );
 	} );
 
+	describe( 'per-wiki readOnly', () => {
+		it( 'preserves readOnly: true through the loader', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null, readOnly: true } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.readOnly ).toBe( true );
+		} );
+
+		it( 'preserves readOnly: false through the loader', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null, readOnly: false } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.readOnly ).toBe( false );
+		} );
+
+		it( 'leaves readOnly undefined when the field is absent', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().wikis.w.readOnly ).toBeUndefined();
+		} );
+
+		it( 'throws when readOnly is not a boolean', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: null, readOnly: 'yes' } }
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow(
+				'Config error: wikis.w.readOnly must be a boolean'
+			);
+		} );
+	} );
+
 	describe( 'passthrough cases', () => {
 		it( 'passes through null secret fields unchanged', async () => {
 			setConfigFile( {

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -2,21 +2,76 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 /* eslint-disable n/no-missing-import */
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 /* eslint-enable n/no-missing-import */
+import type { WikiConfig } from '../../src/common/config.js';
+import { reconcileToolsForActiveWiki } from '../../src/tools/reconcile.js';
+
+const wikiA: WikiConfig = {
+	sitename: 'Writeable',
+	server: 'https://a.example',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+	readOnly: false
+};
+
+const wikiB: WikiConfig = {
+	sitename: 'Read Only',
+	server: 'https://b.example',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+	readOnly: true
+};
+
+const wikiStore: { current: WikiConfig; byKey: Record<string, WikiConfig> } = {
+	current: wikiA,
+	byKey: { a: wikiA, b: wikiB }
+};
 
 vi.mock( '../../src/common/wikiService.js', () => ( {
 	wikiService: {
-		isWikiManagementAllowed: vi.fn()
+		isWikiManagementAllowed: vi.fn(),
+		getAll: vi.fn( () => wikiStore.byKey ),
+		get: vi.fn( ( key: string ) => wikiStore.byKey[ key ] ),
+		getCurrent: vi.fn( () => ( {
+			key: Object.keys( wikiStore.byKey ).find( ( k ) => wikiStore.byKey[ k ] === wikiStore.current ) ?? 'a',
+			config: wikiStore.current
+		} ) ),
+		setCurrent: vi.fn( ( key: string ) => {
+			if ( !wikiStore.byKey[ key ] ) {
+				throw new Error( `Wiki "${ key }" not found` );
+			}
+			wikiStore.current = wikiStore.byKey[ key ];
+		} ),
+		sanitize: vi.fn( ( c: WikiConfig ) => c )
 	}
 } ) );
 
 import { wikiService } from '../../src/common/wikiService.js';
 import { registerAllTools } from '../../src/tools/index.js';
 
+const WRITE_TOOLS = [
+	'create-page',
+	'update-page',
+	'delete-page',
+	'undelete-page',
+	'upload-file',
+	'upload-file-from-url'
+];
+
 async function connectClientAndServer(): Promise<{ client: Client; server: McpServer }> {
-	const server = new McpServer( { name: 'test', version: '0.0.0' } );
-	registerAllTools( server );
+	const server = new McpServer(
+		{ name: 'test', version: '0.0.0' },
+		{ capabilities: { tools: { listChanged: true } } }
+	);
+	const tools = new Map<string, RegisteredTool>();
+	const reconcile = ( wiki: Readonly<WikiConfig> ) => reconcileToolsForActiveWiki( tools, wiki );
+	const registered = registerAllTools( server, reconcile );
+	for ( const [ name, tool ] of registered ) {
+		tools.set( name, tool );
+	}
+	reconcile( wikiService.getCurrent().config );
+
 	const client = new Client( { name: 'test-client', version: '0.0.0' } );
 	const [ clientTransport, serverTransport ] = InMemoryTransport.createLinkedPair();
 	await Promise.all( [
@@ -26,9 +81,10 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 	return { client, server };
 }
 
-describe( 'registerAllTools', () => {
+describe( 'registerAllTools — wiki management gating', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
+		wikiStore.current = wikiA;
 	} );
 
 	it( 'lists add-wiki and remove-wiki when wiki management is allowed', async () => {
@@ -68,5 +124,87 @@ describe( 'registerAllTools', () => {
 		expect( result.isError ).toBe( true );
 		const content = result.content as Array<{ type: string; text: string }>;
 		expect( content[ 0 ].text ).toMatch( /Tool add-wiki disabled/ );
+	} );
+} );
+
+describe( 'registerAllTools — per-wiki readOnly', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( wikiService.isWikiManagementAllowed ).mockReturnValue( true );
+		wikiStore.current = wikiA;
+	} );
+
+	it( 'includes write tools when the default wiki is writeable', async () => {
+		wikiStore.current = wikiA;
+		const { client } = await connectClientAndServer();
+
+		const { tools } = await client.listTools();
+		const names = tools.map( ( t ) => t.name );
+
+		for ( const w of WRITE_TOOLS ) {
+			expect( names ).toContain( w );
+		}
+	} );
+
+	it( 'omits write tools when the default wiki is readOnly', async () => {
+		wikiStore.current = wikiB;
+		const { client } = await connectClientAndServer();
+
+		const { tools } = await client.listTools();
+		const names = tools.map( ( t ) => t.name );
+
+		for ( const w of WRITE_TOOLS ) {
+			expect( names ).not.toContain( w );
+		}
+		expect( names ).toContain( 'get-page' );
+		expect( names ).toContain( 'set-wiki' );
+	} );
+
+	it( 'hides write tools after set-wiki switches to a readOnly wiki', async () => {
+		wikiStore.current = wikiA;
+		const { client } = await connectClientAndServer();
+
+		await client.callTool( {
+			name: 'set-wiki',
+			arguments: { uri: 'mcp://wikis/b' }
+		} );
+
+		const { tools } = await client.listTools();
+		const names = tools.map( ( t ) => t.name );
+
+		for ( const w of WRITE_TOOLS ) {
+			expect( names ).not.toContain( w );
+		}
+	} );
+
+	it( 'restores write tools after set-wiki switches back to a writeable wiki', async () => {
+		wikiStore.current = wikiB;
+		const { client } = await connectClientAndServer();
+
+		await client.callTool( {
+			name: 'set-wiki',
+			arguments: { uri: 'mcp://wikis/a' }
+		} );
+
+		const { tools } = await client.listTools();
+		const names = tools.map( ( t ) => t.name );
+
+		for ( const w of WRITE_TOOLS ) {
+			expect( names ).toContain( w );
+		}
+	} );
+
+	it( 'rejects a write tool call with a disabled error when the active wiki is readOnly', async () => {
+		wikiStore.current = wikiB;
+		const { client } = await connectClientAndServer();
+
+		const result = await client.callTool( {
+			name: 'create-page',
+			arguments: { title: 'Test', source: 'test' }
+		} );
+
+		expect( result.isError ).toBe( true );
+		const content = result.content as Array<{ type: string; text: string }>;
+		expect( content[ 0 ].text ).toMatch( /Tool create-page disabled/ );
 	} );
 } );

--- a/tests/tools/reconcile.test.ts
+++ b/tests/tools/reconcile.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+/* eslint-disable n/no-missing-import */
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+/* eslint-enable n/no-missing-import */
+import type { WikiConfig } from '../../src/common/config.js';
+import { reconcileToolsForActiveWiki } from '../../src/tools/reconcile.js';
+
+const WRITE_TOOL_NAMES = [
+	'create-page',
+	'update-page',
+	'delete-page',
+	'undelete-page',
+	'upload-file',
+	'upload-file-from-url'
+];
+
+const NON_WRITE_TOOL_NAMES = [ 'get-page', 'search-page', 'set-wiki' ];
+
+interface MockTool {
+	enabled: boolean;
+	enable: ReturnType<typeof vi.fn>;
+	disable: ReturnType<typeof vi.fn>;
+}
+
+function makeMockTool( initiallyEnabled: boolean ): MockTool {
+	const tool: MockTool = {
+		enabled: initiallyEnabled,
+		enable: vi.fn( () => {
+			tool.enabled = true;
+		} ),
+		disable: vi.fn( () => {
+			tool.enabled = false;
+		} )
+	};
+	return tool;
+}
+
+function makeToolMap( initiallyEnabled: boolean ): {
+	tools: Map<string, RegisteredTool>;
+	mocks: Map<string, MockTool>;
+} {
+	const mocks = new Map<string, MockTool>();
+	const tools = new Map<string, RegisteredTool>();
+	for ( const name of [ ...WRITE_TOOL_NAMES, ...NON_WRITE_TOOL_NAMES ] ) {
+		const mock = makeMockTool( initiallyEnabled );
+		mocks.set( name, mock );
+		tools.set( name, mock as unknown as RegisteredTool );
+	}
+	return { tools, mocks };
+}
+
+const baseWiki: WikiConfig = {
+	sitename: 'Test',
+	server: 'https://test.wiki',
+	articlepath: '/wiki',
+	scriptpath: '/w'
+};
+
+describe( 'reconcileToolsForActiveWiki', () => {
+	it( 'disables every write tool when the active wiki is readOnly', () => {
+		const { tools, mocks } = makeToolMap( true );
+		reconcileToolsForActiveWiki( tools, { ...baseWiki, readOnly: true } );
+		for ( const name of WRITE_TOOL_NAMES ) {
+			expect( mocks.get( name )!.disable ).toHaveBeenCalledTimes( 1 );
+			expect( mocks.get( name )!.enable ).not.toHaveBeenCalled();
+		}
+	} );
+
+	it( 'does not touch non-write tools', () => {
+		const { tools, mocks } = makeToolMap( true );
+		reconcileToolsForActiveWiki( tools, { ...baseWiki, readOnly: true } );
+		for ( const name of NON_WRITE_TOOL_NAMES ) {
+			expect( mocks.get( name )!.disable ).not.toHaveBeenCalled();
+			expect( mocks.get( name )!.enable ).not.toHaveBeenCalled();
+		}
+	} );
+
+	it( 'enables every write tool when the active wiki is not readOnly', () => {
+		const { tools, mocks } = makeToolMap( false );
+		reconcileToolsForActiveWiki( tools, { ...baseWiki, readOnly: false } );
+		for ( const name of WRITE_TOOL_NAMES ) {
+			expect( mocks.get( name )!.enable ).toHaveBeenCalledTimes( 1 );
+			expect( mocks.get( name )!.disable ).not.toHaveBeenCalled();
+		}
+	} );
+
+	it( 'treats missing readOnly as non-readOnly', () => {
+		const { tools, mocks } = makeToolMap( false );
+		reconcileToolsForActiveWiki( tools, baseWiki );
+		for ( const name of WRITE_TOOL_NAMES ) {
+			expect( mocks.get( name )!.enable ).toHaveBeenCalledTimes( 1 );
+		}
+	} );
+
+	it( 'is idempotent: a second call with identical state performs zero toggles', () => {
+		const { tools, mocks } = makeToolMap( true );
+		const wiki = { ...baseWiki, readOnly: true };
+		reconcileToolsForActiveWiki( tools, wiki );
+		for ( const m of mocks.values() ) {
+			m.enable.mockClear();
+			m.disable.mockClear();
+		}
+		reconcileToolsForActiveWiki( tools, wiki );
+		for ( const m of mocks.values() ) {
+			expect( m.enable ).not.toHaveBeenCalled();
+			expect( m.disable ).not.toHaveBeenCalled();
+		}
+	} );
+
+	it( 'skips tools missing from the map', () => {
+		const { tools, mocks } = makeToolMap( true );
+		tools.delete( 'upload-file' );
+		expect( () => reconcileToolsForActiveWiki( tools, { ...baseWiki, readOnly: true } ) ).not.toThrow();
+		for ( const name of WRITE_TOOL_NAMES ) {
+			if ( name === 'upload-file' ) {
+				continue;
+			}
+			expect( mocks.get( name )!.disable ).toHaveBeenCalledTimes( 1 );
+		}
+	} );
+} );


### PR DESCRIPTION
Closes #273.

## Summary

Adds a per-wiki `readOnly` config flag that hides the six write tools (`create-page`, `update-page`, `delete-page`, `undelete-page`, `upload-file`, `upload-file-from-url`) from `tools/list` whenever the active wiki has `readOnly: true`. Dynamic via the MCP SDK's `.enable()` / `.disable()` so the tool list reflects state after `set-wiki` switches.

Also ships a new `docs/deployment.md` documenting the `MCP_TRANSPORT=http` + `allowWikiManagement:false` + `readOnly:true` recipe for running this as a public read-only endpoint — the use case #273 asked for.

**Rebased on top of the docs reorganization (#280, now merged).** The hosted deployment content — originally added here as a `## Hosted deployment` section in README — lives in `docs/deployment.md` instead, to match the new per-topic docs layout. README gets a short `## Deployment` pointer section.

## What changed

- `WikiConfig.readOnly?: boolean` with fail-fast type validation at config load.
- New `src/tools/reconcile.ts` module with `reconcileToolsForActiveWiki` and a de-dup guard so redundant SDK calls don't fire when the effective state is unchanged. Shaped to accept additional rules later (e.g. extension-aware tool gating for Semantic MediaWiki).
- `registerAllTools` now returns `Map<string, RegisteredTool>` keyed by tool name. `set-wiki` is registered separately so its signature can take a reconcile callback without a type cast.
- `setWikiTool` accepts an `OnActiveWikiChanged` callback, invoked only on the success path.
- `createServer` declares the `tools.listChanged` capability, threads a shared tools map, and reconciles at startup and on every `set-wiki`.
- `docs/deployment.md` — new file covering the hosted HTTP endpoint recipe, credential-sharing warning, reverse-proxy / TLS / rate-limiting advice, and Docker snippet.
- README: new `readOnly` row in the wiki-config table with an inline pointer to `docs/deployment.md`; one sentence added to `## Authentication` about the `readOnly` + `tools/list` interaction; new top-level `## Deployment` section (two lines) pointing at `docs/deployment.md`.

## Worth flagging

- **New MCP capability advertised:** `tools.listChanged: true`. Downstream clients that inspect the `initialize` handshake will see the new capability; the existing `resources.listChanged` is unaffected.
- **Endorsed hosted shape:** `allowWikiManagement: false` + per-wiki `readOnly: true` is the documented "public read-only endpoint" recipe. Operators should not configure `token`/`username`/`password` in this mode; `docs/deployment.md` spells this out.
- **Single-tenant constraint documented.** `wikiService` state is module-scoped (pre-existing), so the HTTP transport doesn't isolate session state between concurrent clients. The hosted recipe sidesteps this; the "experimental — single-wiki, read-only only" framing at the top of `docs/deployment.md` calls out the constraint explicitly. Session-scoped isolation is tracked as follow-up work, independent of #60.
- **Startup reconcile ordering matters.** The initial `reconcile()` call in `createServer` runs before the transport connects, so readOnly defaults take effect before any client sees the tool list. Future refactors shouldn't reorder that.

## Test plan

- [x] `npm test` — 181/181 pass (166 from post-reorg master + 15 from this branch: 6 reconciler unit cases, 5 per-wiki readOnly integration cases via `InMemoryTransport`, and 4 supporting cases).
- [x] `npm run lint` — clean (2 pre-existing warnings in `src/common/config.ts` unrelated to this branch).
- [x] `npm run build` — compiles.
- [x] Manual smoke test via MCP Inspector:
  - `readOnly:true` + `allowWikiManagement:false` → `tools/list` returns 11 tools (10 reads + `set-wiki`); all six 🔐 write tools and `add-wiki`/`remove-wiki` correctly omitted.
  - `readOnly:false` + `allowWikiManagement:true` → `tools/list` returns all 19 tools.
  - Calling `create-page` against a `readOnly:true` endpoint returns `MCP error -32602: Tool create-page disabled` — SDK-level rejection confirmed.
- [x] Review of doc wording across README (readOnly row, Authentication note, Deployment pointer) and `docs/deployment.md` (experimental framing + single-tenant caveat).