### PR TITLE
Add tool description style guide and apply it to all 19 tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## Contributing new tools
+
+New tools — and changes to existing tool descriptions, parameter documentation, or annotation hints — must follow the [tool description style guide](docs/tool-descriptions.md). The guide covers voice, depth, sibling disambiguation, canonical MediaWiki terminology, and annotation semantics.
+
+Every tool MUST set all four `ToolAnnotations` hints explicitly: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. This is not strictly required by the MCP spec but is required by OpenAI's ChatGPT developer mode, which rejects submissions missing any of the first three.
+
 ## Unit Tests
 
 Tool handler functions (`handleXxxTool`) must be exported for testability.

--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ The `release` GitHub workflow will trigger automatically:
 
 Contributions are welcome! Please feel free to submit a pull request or open an issue for bugs, feature requests, or suggestions.
 
+When adding or modifying a tool, please read the [tool description style guide](docs/tool-descriptions.md). It covers voice, depth, canonical MediaWiki terminology, and the annotation hints every tool must set.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/docs/tool-descriptions.md
+++ b/docs/tool-descriptions.md
@@ -1,0 +1,166 @@
+# Tool Description Style Guide
+
+This guide is for anyone adding or modifying a tool in this MCP server. It codifies how to write tool descriptions, parameter documentation, and annotation hints so that LLMs consuming the server can select and use tools correctly.
+
+The guide has two parts:
+
+1. **Generic principles** — applicable to any MCP server. Grounded in published tool-use guidance from Anthropic, OpenAI, and Google.
+2. **MediaWiki conventions** — terminology, sibling-overlap notes, and common error patterns specific to this server.
+
+Read both before adding a new tool or rewriting an existing one.
+
+## Part 1 — Generic principles
+
+### Voice and opening
+
+Write tool descriptions in **third-person descriptive voice**. Start with a verb phrase describing what the tool does.
+
+- Do: `"Returns a wiki page."` / `"Renders wikitext through the live wiki without saving."`
+- Don't: `"This tool returns a wiki page."` (tautological preamble)
+- Don't: `"You should use this tool when..."` (instructs the model in second person)
+- Don't: `"Gets a page"` when the tool name already says `get-page` (tautology — add nothing)
+
+Third-person descriptive voice avoids point-of-view inconsistencies that degrade tool discovery. The description is injected into the system prompt; it should read as a capability statement, not a prompt fragment.
+
+### Coverage: what, when, parameters, caveats
+
+Every description answers at least:
+
+1. **What** the tool does.
+2. **What it returns.**
+
+Depth scales from there based on how much there is to disambiguate. Longer descriptions are warranted when any of the following apply:
+
+- **Sibling overlap.** Another tool in the set does something similar. State when to use this vs. the other.
+- **Non-obvious constraints.** Input combinations that are rejected, behaviour at boundaries, capped or truncated output.
+- **Usage hints.** Soft recommendations that help the model pick this tool for the right workflow.
+
+Apply proportional depth: don't pad simple tools with filler, don't keep tautological tools short. A one-sentence description is fine when there's nothing more to say; a paragraph is fine when there is.
+
+### Don't duplicate the schema
+
+The JSON Schema generated from zod already tells the model:
+
+- Parameter names, types, and required-vs-optional.
+- Enum values (use `z.enum(...)` or `z.nativeEnum(...)` — the model sees them).
+- Defaults (use `.default(...)` — the model sees them).
+
+Do not restate this in prose. Prose is for context the schema cannot express.
+
+### Avoid tautology
+
+A description that restates the tool name adds zero information. `"Deletes a wiki page"` for `delete-page` is a bad description. A better description says what "delete" means in MediaWiki (deleted pages are recoverable via `undelete-page` until purge), what the tool returns, and what errors the caller might see.
+
+### Sibling disambiguation with inline routing hints
+
+When two tools in the set overlap, each description should explicitly say when to pick it vs. the other. Use the pattern "Use this instead of X when Y" or "For Z, use X instead."
+
+Examples applicable to this server:
+
+- `get-page` vs `get-pages`: single vs. batch.
+- `search-page` vs `search-page-by-prefix`: full-text vs. title-prefix.
+- `get-revision` vs `get-page` with `metadata=true`: specific historical revision vs. latest with metadata.
+- `compare-pages` vs. fetching two sources and diffing client-side.
+
+### Don't instruct the model imperatively
+
+Describe the condition under which the tool is useful; let the model decide whether to call it.
+
+- Do: `"Required before interacting with a new wiki."`
+- Don't: `"You MUST call this tool before interacting with a new wiki."`
+
+The rule targets general imperatives aimed at the model ("You MUST...", "You should..."). Sibling routing hints that describe a choice — "For X, use Y" — are allowed because they describe tradeoffs about when each tool is appropriate, not commands. Prefer the "For X, use Y" pattern over "Prefer this over Y" or "Use this instead of Y," which read as instructions to the model.
+
+Imperative instructions to the model ("You should...", "You MUST...") in tool descriptions reduce robustness across different LLM implementations.
+
+### Tool consolidation stance (this codebase)
+
+Anthropic's engineering guidance recommends consolidating multiple actions into a single tool with an `action` parameter. OpenAI's Apps SDK recommends the opposite — one job per tool.
+
+This codebase follows **one job per tool** (separate `create-page`, `update-page`, `delete-page`, etc.). Do not consolidate when adding new tools; match the existing pattern. This is an explicit choice, not an oversight.
+
+### Parameter descriptions
+
+Every parameter has a `.describe()` call. Parameter docs complement the schema; they do not duplicate it.
+
+Parameter descriptions must:
+
+- **State format when non-obvious.** `"Revision ID"` is fine for an integer parameter; `"MCP resource URI of the wiki (e.g. mcp://wikis/en.wikipedia.org)"` is better than `"Wiki URI"`.
+- **Call out cross-parameter constraints.** E.g. `"If olderThan is set, newerThan must not be."` when such a constraint exists.
+- **Reuse canonical phrases** from Part 2 for recurring concepts (page title, revision ID, wikitext, namespace, etc.).
+- **Not restate the zod type.** `"Optional integer"` is redundant when the schema is `z.number().int().optional()`.
+- **Be concise.** A sentence or two per parameter. Complex behaviour belongs in the tool description, not in every parameter.
+
+### Annotation hints
+
+MCP's `ToolAnnotations` exposes four boolean hints that shape how clients route and display tools. Spec defaults exist, but **every tool in this repository sets all four explicitly** because OpenAI's ChatGPT developer mode rejects MCP submissions missing `readOnlyHint`, `destructiveHint`, or `openWorldHint`.
+
+Semantics (from the MCP 2025-11-25 spec):
+
+- **`readOnlyHint`** — if `true`, the tool does not modify its environment. Master switch; when `true`, the other behavioural hints are semantically irrelevant (but still set explicitly for clarity and cross-client compatibility).
+- **`destructiveHint`** — if `true`, the tool may perform destructive updates (delete, overwrite, remove). If `false`, the tool performs only additive updates (create new without replacing). Only meaningful when `readOnlyHint: false`. Spec default is `true`.
+- **`idempotentHint`** — if `true`, calling the tool repeatedly with the same arguments has no additional effect on the environment beyond the first call. A call that errors but leaves state unchanged still counts as idempotent. Only meaningful when `readOnlyHint: false`. Spec default is `false`.
+- **`openWorldHint`** — if `true`, the tool interacts with external entities (e.g. a remote API). If `false`, the tool's world is self-contained (server-local state only). Spec default is `true`.
+
+**Decision guide:**
+
+- Pure read-only tools: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: true` (for tools that read from the wiki).
+- Write tools that delete, overwrite, or remove: `readOnlyHint: false`, `destructiveHint: true`.
+- Write tools that only add (create, append, upload-new): `readOnlyHint: false`, `destructiveHint: false`.
+- If the tool does not make network calls and only mutates server-local state (e.g. selecting the active wiki), `openWorldHint: false`.
+
+### Tool titles
+
+The `title` field on `ToolAnnotations` is a human-readable UI label. Use **sentence case**, **imperative verb phrasing**:
+
+- Do: `"Get page"`, `"Compare pages"`, `"Preview wikitext"`.
+- Don't: `"Get Page"` (title case), `"Page retrieval"` (nominal phrasing).
+
+Primarily a UI label. Don't rely on `title` for model routing — put disambiguation in the description.
+
+## Part 2 — MediaWiki conventions
+
+### Canonical terminology
+
+Use these exact terms in descriptions and parameter docs. Do not introduce synonyms.
+
+| Concept | Canonical term | Notes |
+|---|---|---|
+| Addressable content unit | **wiki page** | Not "article" (which is a specific namespace). |
+| Human-readable title | **page title** | Includes namespace prefix for non-main namespaces (e.g. `Talk:Foo`, `File:Bar.png`). |
+| Numeric revision identifier | **revision ID** | Not "revision number" or "revid". |
+| MediaWiki markup source | **wikitext** | Never "wiki source" or "wiki markup" in user-facing prose. |
+| Namespace identifier (integer) | **namespace ID** | Parameter descriptions state "Namespace ID"; prose may mention the namespace name parenthetically. |
+| Content format (wikitext, javascript, css, etc.) | **content model** | Matches MediaWiki's `contentmodel` API field. |
+
+### Page title vs file title
+
+File titles are page titles in the File namespace. The distinction surfaces at the parameter level:
+
+- For tools operating on any page (including file pages): use `"Wiki page title"` in the parameter description.
+- For tools operating specifically on file pages (`get-file`, `upload-file`, `upload-file-from-url`): use `"File title"` in the parameter description for clarity.
+
+Do not interchange these.
+
+### Common MediaWiki error patterns
+
+When an LLM invokes a tool that fails with one of these errors, the caller needs to understand what happened. Descriptions for tools that expose these errors should mention the condition (not the error code).
+
+- **`badtags`** — a change tag is configured that is not registered or not applicable to this action. Surfaces from write tools when the wiki's `tags` config is misset.
+- **`missingtitle`** — the target page does not exist. Surfaces from `get-page`, `update-page`, `compare-pages`, `get-page-history`.
+- **`nosuchrevid`** — the requested revision ID does not exist. Surfaces from `get-revision`, `compare-pages`.
+
+Example phrasing: `"Returns a wiki page. If the title does not exist, an error is returned."` — not `"...a missingtitle error is returned."`
+
+### Sibling overlap pairs in this codebase
+
+When writing or updating a tool in these pairs, each side's description should explicitly say when to use it vs. the other:
+
+- **`get-page` vs `get-pages`** — single page (supports full content formats including HTML) vs. batch (up to 50 pages, source or none).
+- **`search-page` vs `search-page-by-prefix`** — full-text content search vs. title-prefix search.
+- **`get-revision` vs `get-page` with `metadata=true`** — fetch a specific historical revision vs. fetch the latest revision with metadata attached.
+- **`compare-pages` vs. client-side diff** — `compare-pages` computes the diff server-side and returns a compact text diff; prefer it over fetching both sources and diffing locally.
+
+### Tool-consolidation stance
+
+This codebase keeps separate tools for distinct actions on the same object (create-page, update-page, delete-page, undelete-page). When adding a new tool, do not bundle multiple actions into a single tool with an `action` parameter; match the existing one-tool-per-action pattern.

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -9,13 +9,16 @@ import { discoverWiki } from '../common/wikiDiscovery.js';
 export function addWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'add-wiki',
-		'Adds a new wiki to the MCP resources from a URL.',
+		'Registers a new wiki as an MCP resource by fetching its sitename and API configuration from any URL on the wiki (e.g. a page URL). The wiki becomes selectable via set-wiki at mcp://wikis/<servername>. Fails if the URL is not a MediaWiki wiki or if a wiki with the same key is already registered.',
 		{
 			wikiUrl: z.string().url().describe( 'Any URL from the target wiki (e.g. https://en.wikipedia.org/wiki/Main_Page)' )
 		},
 		{
 			title: 'Add wiki',
-			destructiveHint: true
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		( { wikiUrl } ) => handleAddWikiTool( server, wikiUrl )
 	);

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -34,20 +34,22 @@ type Side = 'from' | 'to';
 export function comparePagesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'compare-pages',
-		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Use this instead of fetching both sources and diffing locally — only the changes are returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta.',
+		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Cheaper than fetching both sources and diffing locally, because only the changes are returned. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta.',
 		{
 			fromRevision: z.number().int().positive().optional().describe( 'Revision ID for the "from" side' ),
-			fromTitle: z.string().optional().describe( 'Page title for the "from" side (latest revision is used)' ),
+			fromTitle: z.string().optional().describe( 'Wiki page title for the "from" side (latest revision is used)' ),
 			fromText: z.string().optional().describe( 'Supplied wikitext for the "from" side' ),
 			toRevision: z.number().int().positive().optional().describe( 'Revision ID for the "to" side' ),
-			toTitle: z.string().optional().describe( 'Page title for the "to" side (latest revision is used)' ),
+			toTitle: z.string().optional().describe( 'Wiki page title for the "to" side (latest revision is used)' ),
 			toText: z.string().optional().describe( 'Supplied wikitext for the "to" side' ),
 			includeDiff: z.boolean().optional().describe( 'Include the diff body (default true). Set false for a cheap change-detection response.' )
 		},
 		{
 			title: 'Compare pages',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( args ) => handleComparePagesTool( args as ComparePagesArgs )
 	);

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -11,17 +11,19 @@ import { getPageUrl, formatEditComment } from '../common/utils.js';
 export function createPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'create-page',
-		'Creates a wiki page with the provided content.',
+		'Creates a new wiki page with the provided content and returns the new page\'s title, page ID, and first revision ID. Fails if a page with the given title already exists; for existing pages, use update-page. The optional contentModel parameter selects a non-default content format (e.g. javascript, css); when omitted, MediaWiki picks the default for the title\'s namespace.',
 		{
 			source: z.string().describe( 'Page content in the format specified by the contentModel parameter' ),
 			title: z.string().describe( 'Wiki page title' ),
 			comment: z.string().optional().describe( 'Reason for creating the page' ),
-			contentModel: z.string().optional().describe( 'Type of content on the page. If omitted, MediaWiki picks the default for the title\'s namespace.' )
+			contentModel: z.string().optional().describe( 'Content model of the new page. If omitted, MediaWiki picks the default for the title\'s namespace.' )
 		},
 		{
 			title: 'Create page',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ source, title, comment, contentModel }

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -12,7 +12,7 @@ import { formatEditComment } from '../common/utils.js';
 export function deletePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'delete-page',
-		'Deletes a wiki page.',
+		'Removes a wiki page from public view and returns the deleted title. This is a soft delete: the page and its revision history remain in the database and can be restored with undelete-page until an administrator purges them. Fails if the page does not exist or the authenticated user lacks the delete permission.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			comment: z.string().optional().describe( 'Reason for deleting the page' )
@@ -20,7 +20,9 @@ export function deletePageTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Delete page',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ title, comment }

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -16,16 +16,18 @@ enum CategoryMemberType {
 export function getCategoryMembersTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-category-members',
-		'Gets all members in the category. Returns only page IDs, namespaces, and titles.',
+		'Returns each member\'s page ID, namespace ID, and wiki page title. Optionally filter by member type (page, file, subcat) or by namespace ID.',
 		{
-			category: z.string().describe( 'Category name' ),
+			category: z.string().describe( 'Category name (with or without the "Category:" prefix)' ),
 			types: z.array( z.nativeEnum( CategoryMemberType ) ).optional().describe( 'Types of members to include' ),
 			namespaces: z.array( z.number().int().nonnegative() ).optional().describe( 'Namespace IDs to filter by' )
 		},
 		{
 			title: 'Get category members',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ category, types, namespaces }

--- a/src/tools/get-file.ts
+++ b/src/tools/get-file.ts
@@ -9,14 +9,16 @@ import type { ApiPage, ImageInfo } from 'mwn';
 export function getFileTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-file',
-		'Returns information about a file, including links to download the file in thumbnail, preview, and original formats.',
+		'Returns metadata for a file (uploader, timestamp, size, MIME type) along with download URLs for the thumbnail, preview, and original. The File: prefix is added automatically if omitted.',
 		{
-			title: z.string().describe( 'File title' )
+			title: z.string().describe( 'File title (with or without the "File:" prefix)' )
 		},
 		{
 			title: 'Get file',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( { title } ) => handleGetFileTool( title )
 	);

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -11,17 +11,19 @@ const PAGE_HISTORY_LIMIT = 20;
 export function getPageHistoryTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-page-history',
-		`Returns information about the latest revisions to a wiki page, in segments of ${ PAGE_HISTORY_LIMIT } revisions, starting with the latest revision.`,
+		`Returns revision metadata (revision ID, timestamp, user, comment, size, minor flag) for a wiki page, in segments of ${ PAGE_HISTORY_LIMIT } revisions, newest first. Paginate with olderThan or newerThan (mutually exclusive). If the title does not exist, an error is returned.`,
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			olderThan: z.number().int().positive().optional().describe( 'Revision ID — return revisions older than this' ),
-			newerThan: z.number().int().positive().optional().describe( 'Revision ID — return revisions newer than this' ),
-			filter: z.string().optional().describe( 'Filter that returns only revisions with certain tags' )
+			olderThan: z.number().int().positive().optional().describe( 'Revision ID — return revisions older than this (exclusive). Mutually exclusive with newerThan.' ),
+			newerThan: z.number().int().positive().optional().describe( 'Revision ID — return revisions newer than this (exclusive). Mutually exclusive with olderThan.' ),
+			filter: z.string().optional().describe( 'Change tag — return only revisions carrying this tag' )
 		},
 		{
 			title: 'Get page history',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ title, olderThan, newerThan, filter }

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -10,7 +10,7 @@ import { ContentFormat } from '../common/contentFormat.js';
 export function getPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-page',
-		'Returns a wiki page. Use metadata=true to retrieve the revision ID, which can optionally be passed to update-page for edit-conflict detection. Set content="none" to fetch only metadata without content.',
+		'Returns a single wiki page (wikitext source, rendered HTML, or metadata only). If the title does not exist, an error is returned. Use metadata=true to retrieve the revision ID, which can optionally be passed to update-page for edit-conflict detection. Set content="none" to fetch only metadata. For more than one page at a time, use get-pages. For a specific historical revision, use get-revision.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			content: z.nativeEnum( ContentFormat ).optional().default( ContentFormat.source ).describe( 'Type of content to return' ),
@@ -19,7 +19,9 @@ export function getPageTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Get page',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( { title, content, metadata } ) => handleGetPageTool( title, content, metadata )
 	);

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -16,7 +16,7 @@ export enum BatchContentFormat {
 export function getPagesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-pages',
-		`Fetches multiple wiki pages in one call. Use this instead of calling get-page repeatedly when you need a group of pages — e.g., reading a cluster of related articles, diffing a page family, or syncing pages to local storage. Accepts up to ${ MAX_TITLES } titles; missing pages are reported inline (not as errors). Use get-page for a single page or HTML output.`,
+		`Returns multiple wiki pages in one call (wikitext source or metadata only). Suited to reading a cluster of related pages, diffing a page family, or syncing pages to local storage. Accepts up to ${ MAX_TITLES } titles; missing pages are reported inline (not as errors). For a single page or HTML output, use get-page.`,
 		{
 			titles: z.array( z.string() ).describe( `Array of wiki page titles (1..${ MAX_TITLES })` ),
 			content: z.nativeEnum( BatchContentFormat ).optional().default( BatchContentFormat.source ).describe( 'Type of content to return; "none" returns metadata only' ),
@@ -26,7 +26,9 @@ export function getPagesTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Get pages',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( { titles, content, metadata, followRedirects } ) => handleGetPagesTool(
 			titles, content, metadata, followRedirects

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -11,7 +11,7 @@ import { ContentFormat } from '../common/contentFormat.js';
 export function getRevisionTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-revision',
-		'Returns a revision of a wiki page.',
+		'Returns a specific historical revision of a wiki page by revision ID (wikitext source, rendered HTML, or metadata only). If the revision ID does not exist, an error is returned. For the latest revision plus metadata, use get-page with metadata=true.',
 		{
 			revisionId: z.number().int().positive().describe( 'Revision ID' ),
 			content: z.nativeEnum( ContentFormat ).describe( 'Type of content to return' ).optional().default( ContentFormat.source ),
@@ -20,7 +20,9 @@ export function getRevisionTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Get revision',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ revisionId, content, metadata }

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -33,11 +33,11 @@ function bulletSection( header: string, lines: string[] ): TextContent | null {
 export function parseWikitextTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'parse-wikitext',
-		'Render or preview wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Use this before create-page or update-page to dry-run a planned edit, or on standalone wikitext (template combinations, sanitizer checks) with no target page.',
+		'Renders wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Suited to dry-running a planned edit before create-page or update-page, or previewing standalone wikitext (template combinations, sanitizer checks) with no target page.',
 		{
-			wikitext: z.string().min( 1 ).describe( 'Wikitext source to render' ),
+			wikitext: z.string().min( 1 ).describe( 'Wikitext to render' ),
 			title: z.string().optional().describe(
-				'Page title context for magic words like {{PAGENAME}}. Defaults to "API".'
+				'Wiki page title providing context for magic words like {{PAGENAME}}. Defaults to "API".'
 			),
 			applyPreSaveTransform: z.boolean().optional().default( true ).describe(
 				'Apply pre-save transform (expand ~~~~ signatures, {{subst:}}, normalize whitespace). Matches editor "Show preview" behavior.'
@@ -46,7 +46,9 @@ export function parseWikitextTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Preview wikitext',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( { wikitext, title, applyPreSaveTransform } ) => (
 			handleParseWikitextTool( wikitext, title, applyPreSaveTransform )

--- a/src/tools/remove-wiki.ts
+++ b/src/tools/remove-wiki.ts
@@ -11,13 +11,16 @@ import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wik
 export function removeWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'remove-wiki',
-		'Removes a wiki from the MCP resources.',
+		'Removes a wiki from the MCP resources. Clears any cached credentials and license metadata for the wiki. Fails if the specified wiki is currently active; call set-wiki to switch to a different wiki first.',
 		{
 			uri: z.string().describe( 'MCP resource URI of the wiki to remove (e.g. mcp://wikis/en.wikipedia.org)' )
 		},
 		{
 			title: 'Remove wiki',
-			destructiveHint: true
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: false
 		} as ToolAnnotations,
 		( { uri } ) => handleRemoveWikiTool( server, uri )
 	);

--- a/src/tools/search-page-by-prefix.ts
+++ b/src/tools/search-page-by-prefix.ts
@@ -9,16 +9,18 @@ import { getMwn } from '../common/mwn.js';
 export function searchPageByPrefixTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'search-page-by-prefix',
-		'Performs a prefix search for page titles.',
+		'Returns wiki page titles beginning with a given prefix (suited to autocomplete and title lookup). Only titles are returned — no snippets, sizes, or IDs. For full-text content search, use search-page.',
 		{
-			prefix: z.string().describe( 'Search prefix' ),
+			prefix: z.string().describe( 'Wiki page title prefix' ),
 			limit: z.number().int().min( 1 ).max( 500 ).optional().describe( 'Maximum number of results to return' ),
-			namespace: z.number().int().nonnegative().optional().describe( 'Namespace to search' )
+			namespace: z.number().int().nonnegative().optional().describe( 'Namespace ID to restrict the search to' )
 		},
 		{
 			title: 'Search page by prefix',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ prefix, limit, namespace }

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -10,7 +10,7 @@ import { getPageUrl } from '../common/utils.js';
 export function searchPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'search-page',
-		'Search wiki page titles and contents for the provided search terms, and returns matching pages.',
+		'Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, and timestamp. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.',
 		{
 			query: z.string().describe( 'Search terms' ),
 			limit: z.number().int().min( 1 ).max( 100 ).optional().describe( 'Maximum number of search results to return' )
@@ -18,7 +18,9 @@ export function searchPageTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Search page',
 			readOnlyHint: true,
-			destructiveHint: false
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async ( { query, limit } ) => handleSearchPageTool( query, limit )
 	);

--- a/src/tools/set-wiki.ts
+++ b/src/tools/set-wiki.ts
@@ -9,13 +9,16 @@ import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wik
 export function setWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'set-wiki',
-		'Sets the wiki to use for the current session. You MUST call this tool when interacting with a new wiki.',
+		'Selects the wiki to use for subsequent tool calls in this session. Required before interacting with a wiki that is not the configured default; the active wiki is consulted by every page, file, search, and history tool. Returns the new active wiki\'s sitename and server URL.',
 		{
 			uri: z.string().describe( 'MCP resource URI of the wiki to use (e.g. mcp://wikis/en.wikipedia.org)' )
 		},
 		{
 			title: 'Set wiki',
-			destructiveHint: true
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false
 		} as ToolAnnotations,
 		( { uri } ) => handleSetWikiTool( uri )
 	);

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -12,7 +12,7 @@ import { formatEditComment } from '../common/utils.js';
 export function undeletePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'undelete-page',
-		'Undeletes a wiki page.',
+		'Restores a previously deleted wiki page, including its full revision history, and returns the restored title. The page must currently be in a deleted state (from delete-page); fails if no deleted revisions exist for the title or the authenticated user lacks the undelete permission.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			comment: z.string().optional().describe( 'Reason for undeleting the page' )
@@ -20,7 +20,9 @@ export function undeletePageTool( server: McpServer ): RegisteredTool {
 		{
 			title: 'Undelete page',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ title, comment }

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -11,17 +11,19 @@ import { getPageUrl, formatEditComment } from '../common/utils.js';
 export function updatePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'update-page',
-		'Updates a wiki page. Replaces the existing content of a page with the provided content. Optionally pass latestId (from get-page with metadata=true) to enable edit-conflict detection.',
+		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			source: z.string().describe( 'Page content in the same content model of the existing page' ),
-			latestId: z.number().int().positive().optional().describe( 'Optional base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
+			source: z.string().describe( 'Replacement page content in the existing page\'s content model' ),
+			latestId: z.number().int().positive().optional().describe( 'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
 			comment: z.string().optional().describe( 'Summary of the edit' )
 		},
 		{
 			title: 'Update page',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ title, source, latestId, comment }

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -12,17 +12,19 @@ import { formatEditComment } from '../common/utils.js';
 export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'upload-file-from-url',
-		'Uploads a file to the wiki from a web URL.',
+		'Fetches a file from a remote web URL and uploads it into the wiki\'s File namespace, returning the resulting file title and URL. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists.',
 		{
 			url: z.string().url().describe( 'URL of the file to upload' ),
-			title: z.string().describe( 'File title' ),
+			title: z.string().describe( 'File title (with or without the "File:" prefix)' ),
 			text: z.string().describe( 'Wikitext on the file page' ),
 			comment: z.string().optional().describe( 'Reason for uploading the file' )
 		},
 		{
 			title: 'Upload file from URL',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ url, title, text, comment }

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -12,17 +12,19 @@ import { formatEditComment } from '../common/utils.js';
 export function uploadFileTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'upload-file',
-		'Uploads a file to the wiki from the local disk.',
+		'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url.',
 		{
 			filepath: z.string().describe( 'File path on the local disk' ),
-			title: z.string().describe( 'File title' ),
+			title: z.string().describe( 'File title (with or without the "File:" prefix)' ),
 			text: z.string().describe( 'Wikitext on the file page' ),
 			comment: z.string().optional().describe( 'Reason for uploading the file' )
 		},
 		{
 			title: 'Upload file',
 			readOnlyHint: false,
-			destructiveHint: true
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
 		} as ToolAnnotations,
 		async (
 			{ filepath, title, text, comment }


### PR DESCRIPTION
## Summary

Ships a durable, repo-tracked style guide for writing MCP tool descriptions, then applies it uniformly to every existing tool. Grounded in published LLM tool-use guidance from Anthropic, OpenAI, and Google — not in ad-hoc conventions from this codebase.

## What changed

**`docs/tool-descriptions.md` — new file, two parts:**

1. **Generic principles** — third-person descriptive voice, verb-phrase openers, proportional depth, don't-duplicate-the-schema, avoid-tautology, sibling disambiguation with inline routing hints, don't-instruct-the-model-imperatively, tool-consolidation stance (we follow one-job-per-tool, explicitly), parameter-description rules, annotation-hint semantics + decision guide, tool-title conventions.
2. **MediaWiki conventions** — canonical terminology (wiki page, page title, revision ID, wikitext, namespace ID, content model), page vs file title distinction, common MW error patterns (`badtags`, `missingtitle`, `nosuchrevid`), sibling overlap pairs specific to this server.

**`AGENTS.md` and `README.md`** point contributors at the guide. Adding or modifying a tool starts with reading the guide.

**All 19 tool files** updated to comply with the guide:
- Descriptions rewritten where they violated the guide (tautology, imperative voice, missing sibling disambiguation, non-canonical terminology).
- Parameter `.describe()` calls normalized to canonical terminology.
- All four `ToolAnnotations` hints set explicitly on every tool.

## Worth flagging

- **New MCP capability signal: annotation hints are now explicit on every tool.** Previously 3 tools were missing `readOnlyHint`, all 19 were missing `idempotentHint` and `openWorldHint`. This is required by OpenAI ChatGPT developer mode, which rejects MCP submissions where any of `readOnlyHint`, `destructiveHint`, or `openWorldHint` is unset. Some annotation values also shifted: `set-wiki` and `add-wiki` flipped from `destructiveHint: true` to `false` (both are additive, not destructive); `set-wiki` and `remove-wiki` get `openWorldHint: false` because they mutate server-local state without calling the wiki. Downstream clients that route on these annotations may see behaviour changes.
- **`idempotentHint: true` is subtle for write tools.** `create-page`, `upload-file`, `upload-file-from-url`, `add-wiki`, and `undelete-page` all have `idempotentHint: true` because a duplicate call errors but leaves state unchanged — which matches the MCP 2025-06-18 spec's semantics ("calling the tool repeatedly with the same arguments has no additional effect on the environment"). Defensible but worth knowing; the style guide documents this explicitly.
- **No handler behaviour changes.** This is a pure metadata/docs change. The full test suite (142 tests) passes unchanged.
- **Style guide is local for now.** Part 1 is written to be generic and upstream-portable if it ever proves itself; Part 2 is MediaWiki-specific. No plans to upstream yet.

## Test plan

- [x] `npm run test` — 142/142 tests pass (no behaviour changes; no test updates needed).
- [x] `npm run lint` — clean (2 pre-existing warnings in `src/common/config.ts` unrelated to this branch).
- [x] `npm run build` — compiles.
- [x] Every tool file in `src/tools/*.ts` has all four annotation hints explicitly set (verified via `grep -L "openWorldHint" src/tools/*.ts` returning only `index.ts`, the barrel file).
- [x] Smoke test via MCP Inspector — `tools/list` returns all 19 tools; spot-checked `set-wiki`, `create-page`, `update-page`, `delete-page`, `undelete-page`, `compare-pages`, `search-page-by-prefix`, `get-revision`, `add-wiki`, `remove-wiki`, `upload-file`. All have updated descriptions (no "You MUST..."), canonical terminology, sibling routing hints, and all four annotation hints with the corrected values.
- [x] Review of the style guide itself — the durable artifact most likely to drift if the rules don't feel right.

## Commits

1. **Add tool description style guide** — `docs/tool-descriptions.md` + `AGENTS.md` + `README.md` pointers.
2. **Apply tool description style guide to all 19 tools** — descriptions, parameter docs, annotation hints across every `src/tools/*.ts`.