### PR TITLE
Add result size guards and truncation signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `compare-pages` | Diff two versions of a wiki page by revision, title, or supplied wikitext. | - |
 | `create-page` 🔐 | Create a new wiki page. | `Create, edit, and move pages` |
 | `delete-page` 🔐 | Delete a wiki page. | `Delete pages, revisions, and log entries` |
-| `get-category-members` | Gets all members in the category | - |
+| `get-category-members` | Returns members of a category (up to 500 per call, paginated via `continueFrom`). | - |
 | `get-file` | Returns the standard file object for a file page. | - |
 | `get-page` | Returns the standard page object for a wiki page. | - |
 | `get-page-history` | Returns information about the latest revisions to a wiki page. | - |

--- a/docs/tool-descriptions.md
+++ b/docs/tool-descriptions.md
@@ -91,6 +91,19 @@ Parameter descriptions must:
 - **Not restate the zod type.** `"Optional integer"` is redundant when the schema is `z.number().int().optional()`.
 - **Be concise.** A sentence or two per parameter. Complex behaviour belongs in the tool description, not in every parameter.
 
+### Result caps and truncation signaling
+
+Tools that return variable-size result sets have a per-call cap. When the cap is hit, the tool appends a trailing text block to `content` describing the truncation. Two shapes:
+
+- **With continuation** (the caller can fetch more): `"More results available. Returned N <items>. To fetch the next segment, call <tool-name> again with <param>=<value>."`
+- **Without continuation** (the only remedy is a narrower query): `"Result capped at N <items>. Additional <items> may exist — <narrow-hint>."`
+
+Descriptions for these tools state the cap explicitly. If continuation is supported, descriptions reference the continuation parameter by name so the LLM can pick the right parameter without inspecting the schema.
+
+This convention doesn't apply to tools that reject oversize input (e.g. `get-pages`' 50-title cap): those return an error, not a truncation marker.
+
+There is no MCP-spec-level budget for tool output. Cap sizes are chosen to stay well under Anthropic's 25,000-token Claude Code default ([Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)) and revisited when [MCP discussion #2211](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2211) ratifies a standard.
+
 ### Annotation hints
 
 MCP's `ToolAnnotations` exposes four boolean hints that shape how clients route and display tools. Spec defaults exist, but **every tool in this repository sets all four explicitly** because OpenAI's ChatGPT developer mode rejects MCP submissions missing `readOnlyHint`, `destructiveHint`, or `openWorldHint`.

--- a/src/common/truncation.ts
+++ b/src/common/truncation.ts
@@ -1,0 +1,47 @@
+/* eslint-disable n/no-missing-import */
+import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+
+export type TruncationInfo =
+	| {
+		reason: 'more-available';
+		returnedCount: number;
+		itemNoun: string;
+		toolName: string;
+		continueWith: { param: string; value: string | number };
+	}
+	| {
+		reason: 'capped-no-continuation';
+		returnedCount: number;
+		limit: number;
+		itemNoun: string;
+		narrowHint: string;
+	};
+
+function formatCursorValue( value: string | number ): string {
+	return typeof value === 'number' ? String( value ) : `"${ value }"`;
+}
+
+export function truncationMarker( info: TruncationInfo ): TextContent {
+	if ( info.reason === 'more-available' ) {
+		const { param, value } = info.continueWith;
+		return {
+			type: 'text',
+			text: `More results available. Returned ${ info.returnedCount } ${ info.itemNoun }. To fetch the next segment, call ${ info.toolName } again with ${ param }=${ formatCursorValue( value ) }.`
+		};
+	}
+	return {
+		type: 'text',
+		text: `Result capped at ${ info.limit } ${ info.itemNoun }. Additional ${ info.itemNoun } may exist — ${ info.narrowHint }.`
+	};
+}
+
+export function appendTruncationMarker(
+	content: TextContent[],
+	info: TruncationInfo | null
+): TextContent[] {
+	if ( info === null ) {
+		return content;
+	}
+	return [ ...content, truncationMarker( info ) ];
+}

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -25,7 +25,7 @@ function normalizeCategoryTitle( input: string ): string {
 export function getCategoryMembersTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-category-members',
-		'Returns each member\'s page ID, namespace ID, and wiki page title. Optionally filter by member type (page, file, subcat) or by namespace ID. Returns up to 500 members per call; paginate with continueFrom (opaque cursor echoed from the previous response).',
+		'Returns each member\'s page ID, namespace ID, and wiki page title. Optionally filter by member type (page, file, subcat) or by namespace ID — filters apply server-side before the cap. Returns up to 500 members per call; paginate with continueFrom (opaque cursor echoed from the previous response).',
 		{
 			category: z.string().describe( 'Category name (with or without the "Category:" prefix)' ),
 			types: z.array( z.nativeEnum( CategoryMemberType ) ).optional().describe( 'Types of members to include' ),

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -2,10 +2,9 @@ import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { ApiQueryCategoryMembersParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
-import type { ApiPageInfo } from '../types/mwn.ts';
 import { getMwn } from '../common/mwn.js';
+import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
 
 enum CategoryMemberType {
 	file = 'file',
@@ -13,14 +12,26 @@ enum CategoryMemberType {
 	subcat = 'subcat'
 }
 
+interface CategoryMember {
+	pageid: number;
+	ns: number;
+	title: string;
+}
+
+function normalizeCategoryTitle( input: string ): string {
+	return /^category:/i.test( input ) ? input : `Category:${ input }`;
+}
+
 export function getCategoryMembersTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-category-members',
-		'Returns each member\'s page ID, namespace ID, and wiki page title. Optionally filter by member type (page, file, subcat) or by namespace ID.',
+		'Returns each member\'s page ID, namespace ID, and wiki page title. Optionally filter by member type (page, file, subcat) or by namespace ID. Returns up to 500 members per call; paginate with continueFrom (opaque cursor echoed from the previous response).',
 		{
 			category: z.string().describe( 'Category name (with or without the "Category:" prefix)' ),
 			types: z.array( z.nativeEnum( CategoryMemberType ) ).optional().describe( 'Types of members to include' ),
-			namespaces: z.array( z.number().int().nonnegative() ).optional().describe( 'Namespace IDs to filter by' )
+			namespaces: z.array( z.number().int().nonnegative() ).optional().describe( 'Namespace IDs to filter by' ),
+			limit: z.number().int().min( 1 ).max( 500 ).optional().describe( 'Maximum members to return (1..500)' ),
+			continueFrom: z.string().optional().describe( 'Opaque continuation token from the previous response; omit on first call' )
 		},
 		{
 			title: 'Get category members',
@@ -30,54 +41,68 @@ export function getCategoryMembersTool( server: McpServer ): RegisteredTool {
 			openWorldHint: true
 		} as ToolAnnotations,
 		async (
-			{ category, types, namespaces }
-		) => handleGetCategoryMembersTool( category, types, namespaces )
+			{ category, types, namespaces, limit, continueFrom }
+		) => handleGetCategoryMembersTool( category, types, namespaces, limit, continueFrom )
 	);
 }
 
-async function handleGetCategoryMembersTool(
-	category: string, types?: CategoryMemberType[], namespaces?: number[]
-): Promise< CallToolResult > {
-	let data: ApiPageInfo[];
+export async function handleGetCategoryMembersTool(
+	category: string,
+	types?: CategoryMemberType[],
+	namespaces?: number[],
+	limit?: number,
+	continueFrom?: string
+): Promise<CallToolResult> {
 	try {
 		const mwn = await getMwn();
-		const mwnCategory = new mwn.Category( category );
 
-		const options: ApiQueryCategoryMembersParams = {};
-
-		if ( types ) {
-			options.cmtype = types;
+		const params: Record<string, string | number | boolean> = {
+			action: 'query',
+			list: 'categorymembers',
+			cmtitle: normalizeCategoryTitle( category ),
+			cmprop: 'ids|title',
+			formatversion: '2'
+		};
+		if ( types && types.length > 0 ) {
+			params.cmtype = types.join( '|' );
+		}
+		if ( namespaces && namespaces.length > 0 ) {
+			params.cmnamespace = namespaces.join( '|' );
+		}
+		params.cmlimit = limit ?? 500;
+		if ( continueFrom ) {
+			params.cmcontinue = continueFrom;
 		}
 
-		if ( namespaces ) {
-			options.cmnamespace = namespaces;
-		}
+		const response = await mwn.request( params );
+		const members: CategoryMember[] = response.query?.categorymembers ?? [];
 
-		data = await mwnCategory.members( options );
+		const content: TextContent[] = members.map( ( m ): TextContent => ( {
+			type: 'text',
+			text: [
+				`Page ID: ${ m.pageid }`,
+				`Namespace: ${ m.ns }`,
+				`Title: ${ m.title }`
+			].join( '\n' )
+		} ) );
+
+		const nextCursor: string | undefined = response.continue?.cmcontinue;
+		const truncation: TruncationInfo | null = nextCursor ? {
+			reason: 'more-available',
+			returnedCount: members.length,
+			itemNoun: 'members',
+			toolName: 'get-category-members',
+			continueWith: { param: 'continueFrom', value: nextCursor }
+		} : null;
+
+		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
 		return {
-			content: [
-				{
-					type: 'text',
-					text: `Get category members failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
+			content: [ {
+				type: 'text',
+				text: `Get category members failed: ${ ( error as Error ).message }`
+			} as TextContent ],
 			isError: true
 		};
 	}
-
-	return {
-		content: data.map( getCategoryMembersToolResult )
-	};
-}
-
-function getCategoryMembersToolResult( result: ApiPageInfo ): TextContent {
-	return {
-		type: 'text',
-		text: [
-			`Page ID: ${ result.pageid }`,
-			`Namespace: ${ result.ns }`,
-			`Title: ${ result.title }`
-		].join( '\n' )
-	};
 }

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import type { ApiPage, ApiRevision } from 'mwn';
+import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
 
 const PAGE_HISTORY_LIMIT = 20;
 
@@ -106,19 +107,40 @@ export async function handleGetPageHistoryTool(
 			};
 		}
 
-		return {
-			content: filteredRevisions.map( ( rev ): TextContent => ( {
-				type: 'text',
-				text: [
-					`Revision ID: ${ rev.revid }`,
-					`Timestamp: ${ rev.timestamp }`,
-					`User: ${ rev.user } (ID: ${ rev.userid })`,
-					`Comment: ${ rev.comment }`,
-					`Size: ${ rev.size }`,
-					`Minor: ${ rev.minor ?? false }`
-				].join( '\n' )
-			} ) )
-		};
+		const content: TextContent[] = filteredRevisions.map( ( rev ): TextContent => ( {
+			type: 'text',
+			text: [
+				`Revision ID: ${ rev.revid }`,
+				`Timestamp: ${ rev.timestamp }`,
+				`User: ${ rev.user } (ID: ${ rev.userid })`,
+				`Comment: ${ rev.comment }`,
+				`Size: ${ rev.size }`,
+				`Minor: ${ rev.minor ?? false }`
+			].join( '\n' )
+		} ) );
+
+		let truncation: TruncationInfo | null = null;
+		if ( response.continue?.rvcontinue && filteredRevisions.length > 0 ) {
+			// The response is always ordered from the boundary side to the
+			// advance side: default rvdir=older walks newest→oldest (last item
+			// is the oldest), rvdir=newer walks oldest→newest (last item is
+			// the newest). The last item is always what the caller should
+			// advance past; only the param name differs.
+			const walkingForward = newerThan !== undefined;
+			const anchorRev = filteredRevisions[ filteredRevisions.length - 1 ].revid!;
+			truncation = {
+				reason: 'more-available',
+				returnedCount: filteredRevisions.length,
+				itemNoun: 'revisions',
+				toolName: 'get-page-history',
+				continueWith: {
+					param: walkingForward ? 'newerThan' : 'olderThan',
+					value: anchorRev
+				}
+			};
+		}
+
+		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
 		return {
 			content: [

--- a/src/tools/search-page-by-prefix.ts
+++ b/src/tools/search-page-by-prefix.ts
@@ -2,14 +2,20 @@ import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { ApiQueryAllPagesParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+
+interface AllPagesEntry {
+	pageid: number;
+	ns: number;
+	title: string;
+}
 
 export function searchPageByPrefixTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'search-page-by-prefix',
-		'Returns wiki page titles beginning with a given prefix (suited to autocomplete and title lookup). Only titles are returned — no snippets, sizes, or IDs. For full-text content search, use search-page.',
+		'Returns wiki page titles beginning with a given prefix (suited to autocomplete and title lookup). Only titles are returned — no snippets, sizes, or IDs. Accepts up to 500 titles per call (default 10); additional matches beyond the cap are flagged in the response. For full-text content search, use search-page.',
 		{
 			prefix: z.string().describe( 'Wiki page title prefix' ),
 			limit: z.number().int().min( 1 ).max( 500 ).optional().describe( 'Maximum number of results to return' ),
@@ -28,22 +34,50 @@ export function searchPageByPrefixTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleSearchPageByPrefixTool(
+export async function handleSearchPageByPrefixTool(
 	prefix: string, limit?: number, namespace?: number
-): Promise< CallToolResult > {
-	let data: string[];
+): Promise<CallToolResult> {
 	try {
 		const mwn = await getMwn();
-		const options: ApiQueryAllPagesParams = {};
 
-		if ( limit ) {
-			options.aplimit = limit;
+		const params: Record<string, string | number | boolean> = {
+			action: 'query',
+			list: 'allpages',
+			apprefix: prefix,
+			formatversion: '2'
+		};
+		if ( limit !== undefined ) {
+			params.aplimit = limit;
 		}
-		if ( namespace ) {
-			options.apnamespace = namespace;
+		if ( namespace !== undefined ) {
+			params.apnamespace = namespace;
 		}
 
-		data = await mwn.getPagesByPrefix( prefix, options );
+		const response = await mwn.request( params );
+		const pages: AllPagesEntry[] = response.query?.allpages ?? [];
+
+		if ( pages.length === 0 ) {
+			return {
+				content: [
+					{ type: 'text', text: `No pages found with the prefix "${ prefix }"` } as TextContent
+				]
+			};
+		}
+
+		const content: TextContent[] = pages.map( ( page ): TextContent => ( {
+			type: 'text',
+			text: page.title
+		} ) );
+
+		const truncation: TruncationInfo | null = response.continue ? {
+			reason: 'capped-no-continuation',
+			returnedCount: pages.length,
+			limit: limit ?? 10,
+			itemNoun: 'titles',
+			narrowHint: 'narrow the prefix or raise limit (max 500)'
+		} : null;
+
+		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
 		return {
 			content: [
@@ -52,23 +86,4 @@ async function handleSearchPageByPrefixTool(
 			isError: true
 		};
 	}
-
-	if ( data.length === 0 ) {
-		return {
-			content: [
-				{ type: 'text', text: `No pages found with the prefix "${ prefix }"` } as TextContent
-			]
-		};
-	}
-
-	return {
-		content: data.map( getSearchPageByPrefixToolResult )
-	};
-}
-
-function getSearchPageByPrefixToolResult( title: string ): TextContent {
-	return {
-		type: 'text',
-		text: title
-	};
 }

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -6,11 +6,12 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 import { getMwn } from '../common/mwn.js';
 import type { ApiSearchResult } from 'mwn';
 import { getPageUrl } from '../common/utils.js';
+import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
 
 export function searchPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'search-page',
-		'Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, and timestamp. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.',
+		'Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, and timestamp. Accepts up to 100 matches per call (default 10); additional matches beyond the cap are flagged in the response — narrow the query to surface more. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.',
 		{
 			query: z.string().describe( 'Search terms' ),
 			limit: z.number().int().min( 1 ).max( 100 ).optional().describe( 'Maximum number of search results to return' )
@@ -56,19 +57,27 @@ export async function handleSearchPageTool(
 			};
 		}
 
-		return {
-			content: searchResults.map( ( result ): TextContent => ( {
-				type: 'text',
-				text: [
-					`Title: ${ result.title }`,
-					`Page ID: ${ result.pageid }`,
-					`Page URL: ${ getPageUrl( result.title ) }`,
-					`Snippet: ${ result.snippet }`,
-					`Size: ${ result.size }`,
-					`Timestamp: ${ result.timestamp }`
-				].join( '\n' )
-			} ) )
-		};
+		const content: TextContent[] = searchResults.map( ( result ): TextContent => ( {
+			type: 'text',
+			text: [
+				`Title: ${ result.title }`,
+				`Page ID: ${ result.pageid }`,
+				`Page URL: ${ getPageUrl( result.title ) }`,
+				`Snippet: ${ result.snippet }`,
+				`Size: ${ result.size }`,
+				`Timestamp: ${ result.timestamp }`
+			].join( '\n' )
+		} ) );
+
+		const truncation: TruncationInfo | null = response.continue ? {
+			reason: 'capped-no-continuation',
+			returnedCount: searchResults.length,
+			limit: limit ?? 10,
+			itemNoun: 'matches',
+			narrowHint: 'narrow the query or raise limit (max 100)'
+		} : null;
+
+		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
 		return {
 			content: [

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -42,7 +42,7 @@ export async function handleSearchPageTool(
 			formatversion: '2'
 		};
 
-		if ( limit ) {
+		if ( limit !== undefined ) {
 			params.srlimit = limit;
 		}
 

--- a/tests/common/truncation.test.ts
+++ b/tests/common/truncation.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+/* eslint-disable n/no-missing-import */
+import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+import {
+	truncationMarker,
+	appendTruncationMarker,
+	type TruncationInfo
+} from '../../src/common/truncation.js';
+
+describe( 'truncationMarker', () => {
+	it( 'renders more-available with a numeric cursor value unquoted', () => {
+		const info: TruncationInfo = {
+			reason: 'more-available',
+			returnedCount: 20,
+			itemNoun: 'revisions',
+			toolName: 'get-page-history',
+			continueWith: { param: 'olderThan', value: 42 }
+		};
+		expect( truncationMarker( info ) ).toEqual( {
+			type: 'text',
+			text: 'More results available. Returned 20 revisions. To fetch the next segment, call get-page-history again with olderThan=42.'
+		} );
+	} );
+
+	it( 'renders more-available with a string cursor value double-quoted', () => {
+		const info: TruncationInfo = {
+			reason: 'more-available',
+			returnedCount: 500,
+			itemNoun: 'members',
+			toolName: 'get-category-members',
+			continueWith: { param: 'continueFrom', value: 'page|DOE|123' }
+		};
+		expect( truncationMarker( info ).text ).toBe(
+			'More results available. Returned 500 members. To fetch the next segment, call get-category-members again with continueFrom="page|DOE|123".'
+		);
+	} );
+
+	it( 'renders capped-no-continuation with em dash before narrow hint', () => {
+		const info: TruncationInfo = {
+			reason: 'capped-no-continuation',
+			returnedCount: 100,
+			limit: 100,
+			itemNoun: 'matches',
+			narrowHint: 'narrow the query or raise limit (max 100)'
+		};
+		expect( truncationMarker( info ).text ).toBe(
+			'Result capped at 100 matches. Additional matches may exist — narrow the query or raise limit (max 100).'
+		);
+	} );
+} );
+
+describe( 'appendTruncationMarker', () => {
+	it( 'returns input content unchanged when info is null', () => {
+		const content: TextContent[] = [
+			{ type: 'text', text: 'one' },
+			{ type: 'text', text: 'two' }
+		];
+		expect( appendTruncationMarker( content, null ) ).toEqual( content );
+	} );
+
+	it( 'appends exactly one marker block when info is non-null', () => {
+		const content: TextContent[] = [ { type: 'text', text: 'one' } ];
+		const info: TruncationInfo = {
+			reason: 'capped-no-continuation',
+			returnedCount: 10,
+			limit: 10,
+			itemNoun: 'titles',
+			narrowHint: 'narrow the prefix'
+		};
+		const result = appendTruncationMarker( content, info );
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ] ).toEqual( { type: 'text', text: 'one' } );
+		expect( result[ 1 ].text ).toContain( 'Result capped at 10 titles' );
+	} );
+} );

--- a/tests/tools/get-category-members.test.ts
+++ b/tests/tools/get-category-members.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( { getMwn: vi.fn() } ) );
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+describe( 'get-category-members', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'prefixes a bare category name with "Category:" for cmtitle', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [ { pageid: 1, ns: 0, title: 'Foo' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		await handleGetCategoryMembersTool( 'Living people' );
+
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( {
+			action: 'query',
+			list: 'categorymembers',
+			cmtitle: 'Category:Living people'
+		} );
+	} );
+
+	it( 'preserves an already-prefixed category name', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		await handleGetCategoryMembersTool( 'Category:Foo' );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].cmtitle ).toBe( 'Category:Foo' );
+	} );
+
+	it( 'forwards types, namespaces, limit, continueFrom to the API', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		await handleGetCategoryMembersTool( 'Foo', [ 'page', 'file' ] as any, [ 0, 6 ], 100, 'page|DOE|123' );
+
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( {
+			cmtype: 'page|file',
+			cmnamespace: '0|6',
+			cmlimit: 100,
+			cmcontinue: 'page|DOE|123'
+		} );
+	} );
+
+	it( 'returns each member as a text block', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [
+					{ pageid: 1, ns: 0, title: 'Alpha' },
+					{ pageid: 2, ns: 6, title: 'File:Bar.png' }
+				] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		const result = await handleGetCategoryMembersTool( 'Foo' );
+
+		expect( result.content ).toHaveLength( 2 );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain( 'Page ID: 1' );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain( 'Title: Alpha' );
+		expect( ( result.content[ 1 ] as { text: string } ).text ).toContain( 'Namespace: 6' );
+	} );
+
+	it( 'appends a more-available marker with a double-quoted continueFrom cursor', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [ { pageid: 1, ns: 0, title: 'A' } ] },
+				continue: { cmcontinue: 'page|DOE|456', continue: '-||' }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		const result = await handleGetCategoryMembersTool( 'Foo' );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'More results available. Returned 1 members. To fetch the next segment, call get-category-members again with continueFrom="page|DOE|456".'
+		);
+	} );
+
+	it( 'does not append a marker when response.continue is absent', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { categorymembers: [ { pageid: 1, ns: 0, title: 'A' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		const result = await handleGetCategoryMembersTool( 'Foo' );
+
+		for ( const block of result.content ) {
+			expect( ( block as { text: string } ).text ).not.toContain( 'More results available' );
+		}
+	} );
+
+	it( 'surfaces errors as isError results', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockRejectedValue( new Error( 'API error' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetCategoryMembersTool } = await import( '../../src/tools/get-category-members.js' );
+		const result = await handleGetCategoryMembersTool( 'Foo' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain( 'API error' );
+	} );
+} );

--- a/tests/tools/get-page-history.test.ts
+++ b/tests/tools/get-page-history.test.ts
@@ -214,4 +214,67 @@ describe( 'get-page-history', () => {
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toContain( 'API error' );
 	} );
+
+	it( 'appends a more-available marker with olderThan when more revisions exist', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { revisions: [
+					{ revid: 100, timestamp: '2026-01-02T00:00:00Z', user: 'A', userid: 1, comment: '', size: 1, minor: false },
+					{ revid: 99, timestamp: '2026-01-01T00:00:00Z', user: 'A', userid: 1, comment: '', size: 1, minor: false }
+				] } ] },
+				continue: { rvcontinue: '20260101000000|98', continue: '||' }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageHistoryTool } = await import( '../../src/tools/get-page-history.js' );
+		const result = await handleGetPageHistoryTool( 'Test Page' );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'More results available. Returned 2 revisions. To fetch the next segment, call get-page-history again with olderThan=99.'
+		);
+	} );
+
+	it( 'appends a more-available marker with newerThan when walking forward', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { revisions: [
+					{ revid: 50, timestamp: '2026-01-01T00:00:00Z', user: 'A', userid: 1, comment: '', size: 1, minor: false },
+					{ revid: 60, timestamp: '2026-01-02T00:00:00Z', user: 'A', userid: 1, comment: '', size: 1, minor: false }
+				] } ] },
+				continue: { rvcontinue: '20260103000000|70', continue: '||' }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageHistoryTool } = await import( '../../src/tools/get-page-history.js' );
+		const result = await handleGetPageHistoryTool( 'Test Page', undefined, 49 );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'More results available. Returned 2 revisions. To fetch the next segment, call get-page-history again with newerThan=60.'
+		);
+
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call.rvdir ).toBe( 'newer' );
+	} );
+
+	it( 'does not append a marker when response.continue is absent', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { revisions: [
+					{ revid: 100, timestamp: '2026-01-01T00:00:00Z', user: 'A', userid: 1, comment: '', size: 1, minor: false }
+				] } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageHistoryTool } = await import( '../../src/tools/get-page-history.js' );
+		const result = await handleGetPageHistoryTool( 'Test Page' );
+
+		for ( const block of result.content ) {
+			expect( ( block as { text: string } ).text ).not.toContain( 'More results available' );
+		}
+	} );
 } );

--- a/tests/tools/search-page-by-prefix.test.ts
+++ b/tests/tools/search-page-by-prefix.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( { getMwn: vi.fn() } ) );
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+describe( 'search-page-by-prefix', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'calls action=query&list=allpages with apprefix and aplimit', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { allpages: [ { pageid: 1, ns: 0, title: 'Foo' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		await handleSearchPageByPrefixTool( 'F', 50, 0 );
+
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( {
+			action: 'query',
+			list: 'allpages',
+			apprefix: 'F',
+			aplimit: 50,
+			apnamespace: 0
+		} );
+	} );
+
+	it( 'returns matching titles as text blocks', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { allpages: [
+					{ pageid: 1, ns: 0, title: 'Alpha' },
+					{ pageid: 2, ns: 0, title: 'Alphabet' }
+				] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		const result = await handleSearchPageByPrefixTool( 'Alph', undefined, undefined );
+
+		expect( result.content ).toHaveLength( 2 );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Alpha' );
+		expect( ( result.content[ 1 ] as { text: string } ).text ).toBe( 'Alphabet' );
+	} );
+
+	it( 'returns empty-state message when no matches', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { allpages: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		const result = await handleSearchPageByPrefixTool( 'Zzz', undefined, undefined );
+
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain( 'No pages found with the prefix' );
+	} );
+
+	it( 'appends a capped marker when response.continue is present', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { allpages: [ { pageid: 1, ns: 0, title: 'A' } ] },
+				continue: { apcontinue: 'B', continue: '-||' }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		const result = await handleSearchPageByPrefixTool( 'A', 10, undefined );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'Result capped at 10 titles. Additional titles may exist — narrow the prefix or raise limit (max 500).'
+		);
+	} );
+
+	it( 'does not append a marker when response.continue is absent', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { allpages: [ { pageid: 1, ns: 0, title: 'A' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		const result = await handleSearchPageByPrefixTool( 'A', undefined, undefined );
+
+		for ( const block of result.content ) {
+			expect( ( block as { text: string } ).text ).not.toContain( 'Result capped' );
+		}
+	} );
+
+	it( 'surfaces errors as isError results', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockRejectedValue( new Error( 'API error' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageByPrefixTool } = await import( '../../src/tools/search-page-by-prefix.js' );
+		const result = await handleSearchPageByPrefixTool( 'A', undefined, undefined );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain( 'API error' );
+	} );
+} );

--- a/tests/tools/search-page.test.ts
+++ b/tests/tools/search-page.test.ts
@@ -69,4 +69,71 @@ describe( 'search-page', () => {
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toContain( 'API error' );
 	} );
+
+	it( 'appends a capped marker when response.continue is present', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: {
+					search: [ {
+						ns: 0, title: 'Test Page', pageid: 1, size: 1,
+						snippet: 's', timestamp: '2026-01-01T00:00:00Z'
+					} ]
+				},
+				continue: { sroffset: 10, continue: '-||' }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageTool } = await import( '../../src/tools/search-page.js' );
+		const result = await handleSearchPageTool( 'test', 10 );
+
+		expect( result.isError ).toBeUndefined();
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'Result capped at 10 matches. Additional matches may exist — narrow the query or raise limit (max 100).'
+		);
+	} );
+
+	it( 'does not append a marker when response.continue is absent', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: {
+					search: [ {
+						ns: 0, title: 'A', pageid: 1, size: 1,
+						snippet: 's', timestamp: '2026-01-01T00:00:00Z'
+					} ]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageTool } = await import( '../../src/tools/search-page.js' );
+		const result = await handleSearchPageTool( 'test', 10 );
+
+		for ( const block of result.content ) {
+			expect( ( block as { text: string } ).text ).not.toContain( 'Result capped' );
+			expect( ( block as { text: string } ).text ).not.toContain( 'More results available' );
+		}
+	} );
+
+	it( 'uses the effective limit in the marker when no limit was provided', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: {
+					search: [ {
+						ns: 0, title: 'A', pageid: 1, size: 1,
+						snippet: 's', timestamp: '2026-01-01T00:00:00Z'
+					} ]
+				},
+				continue: { sroffset: 10 }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleSearchPageTool } = await import( '../../src/tools/search-page.js' );
+		const result = await handleSearchPageTool( 'test', undefined );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toContain( 'Result capped at 10 matches' );
+	} );
 } );


### PR DESCRIPTION
## Summary

- Introduces a shared `src/common/truncation.ts` helper that renders a canonical trailing `TextContent` marker from a structured `TruncationInfo` input. Shaped to be reused by #278's structured-output work without rework.
- Applies truncation signaling to four read-many tools: `search-page`, `search-page-by-prefix`, `get-page-history` (direction-aware cursor), and `get-category-members`.
- Caps `get-category-members` at 500 members per call (MediaWiki's `cmlimit` non-bot maximum) and adds opaque-cursor pagination via new `limit` and `continueFrom` parameters. Previously this tool was uncapped — a popular category could return tens of thousands of entries.
- Swaps `search-page-by-prefix` and `get-category-members` from auto-paginating `mwn` convenience methods to raw `mwn.request()` so MediaWiki's `continue` signal is observable.
- Documents the convention in `docs/tool-descriptions.md` Part 1, including the reasoning behind cap sizes (no MCP-spec-level budget; Anthropic's 25,000-token Claude Code default is the only concrete external anchor; MCP discussion #2211 is unratified).

## Test plan

- [x] `npm test` — 166/166 tests pass locally, 18 suites
- [x] `npm run lint` — clean (two pre-existing warnings in `config.ts` unrelated)
- [x] `npm run build` — clean
- [x] MCP Inspector smoke tests against a real wiki:
  - [x] `search-page` with a broad query — verify the capped marker appears as the last content block
  - [x] `search-page-by-prefix` with a common prefix — verify capped marker appears
  - [x] `get-page-history` paginates backward via the `olderThan` cursor echoed from the marker
  - [x] `get-page-history` paginates forward via `newerThan` (and does not re-return previously-seen revisions)
  - [x] `get-category-members` on a large category — verify the `continueFrom` round-trip advances correctly

Closes #276