### PR TITLE
Reorganize docs by audience and extract topic files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,71 +1,35 @@
 # AGENTS.md
 
-## Contributing new tools
+Project context for AI coding agents working on this repo. For human users, start from [README.md](README.md).
 
-New tools — and changes to existing tool descriptions, parameter documentation, or annotation hints — must follow the [tool conventions](docs/tool-conventions.md). The guide covers voice, depth, sibling disambiguation, canonical MediaWiki terminology, and annotation semantics.
+## Repo layout
 
-Every tool MUST set all four `ToolAnnotations` hints explicitly: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. This is not strictly required by the MCP spec but is required by OpenAI's ChatGPT developer mode, which rejects submissions missing any of the first three.
+- `src/tools/` — one file per MCP tool (`handleXxxTool` handler + schema + registration).
+- `src/common/` — `mwn` wrapper, `wikiService`, config loading and substitution.
+- `src/resources/` — MCP resources exposing `mcp://wikis/{wikiKey}`.
+- `src/server.ts`, `src/stdio.ts`, `src/streamableHttp.ts`, `src/index.ts` — entry points and transports.
+- `tests/` — vitest suites; shared helpers in `tests/helpers/`.
 
-## Unit Tests
+## Commands
 
-Tool handler functions (`handleXxxTool`) must be exported for testability.
+- `npm run build` — compile TypeScript to `dist/`.
+- `npm test` — run the vitest suite once.
+- `npm run lint` — ESLint.
+- `npm run preflight` — full gate (install, lint, validate `server.json`, test, build, bundle). Run before a release.
+- `npm run inspector` — watch-mode build + MCP Inspector UI for interactive debugging.
 
-Tests use Vitest with mocked mwn. Each test file mocks `getMwn` and `wikiService` before any imports that depend on them:
+## Tool conventions
 
-```typescript
-vi.mock( '../../src/common/mwn.js', () => ( { getMwn: vi.fn() } ) );
-vi.mock( '../../src/common/wikiService.js', () => ( {
-	wikiService: {
-		getCurrent: vi.fn().mockReturnValue( {
-			key: 'test-wiki',
-			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
-		} )
-	}
-} ) );
-```
+See [docs/tool-conventions.md](docs/tool-conventions.md) for tool design stance, description voice, parameter docs, annotation hints, sibling disambiguation, canonical MediaWiki terminology, and result-cap behavior. Consult before adding or modifying a tool.
 
-Use `createMockMwn()` from `tests/helpers/mock-mwn.ts` to create mock instances with method overrides.
+## Tool handlers
 
-## Integration Testing with MCP Inspector
+`handleXxxTool` functions must be exported from `src/tools/<name>.ts` so unit tests can import them.
 
-The [MCP Inspector CLI](https://github.com/modelcontextprotocol/inspector) tests tools against a real wiki. Build first with `npm run build`, then:
+## Testing
 
-```bash
-# List all tools
-npx @modelcontextprotocol/inspector --cli node dist/index.js \
-  --method tools/list
+Unit tests mock `getMwn` and `wikiService` **before** importing the handler under test. Use `createMockMwn()` from `tests/helpers/mock-mwn.ts`. See [docs/testing.md](docs/testing.md) for the full pattern, MCP Inspector CLI examples, and the bot-password setup required to exercise authenticated tools against a local wiki.
 
-# Call a tool
-npx @modelcontextprotocol/inspector --cli node dist/index.js \
-  --method tools/call \
-  --tool-name get-page \
-  --tool-arg 'title=Main Page' \
-  --tool-arg 'metadata=true'
+## Releasing
 
-# Read a resource
-npx @modelcontextprotocol/inspector --cli node dist/index.js \
-  --method resources/read \
-  --uri 'mcp://wikis/en.wikipedia.org'
-```
-
-Each invocation starts a fresh MCP session, so `set-wiki` does not persist between calls. Set `defaultWiki` in `config.json` to target a specific wiki.
-
-## Local Wiki with Bot Passwords
-
-Authenticated tools (create, update, delete, undelete, upload) require bot passwords. To set one up on a local MediaWiki:
-
-```bash
-docker exec <container> php /var/www/html/w/maintenance/run.php createBotPassword \
-  --appid mcp-server \
-  --grants 'basic,editpage,editprotected,createeditmovepage,uploadfile,highvolume,delete' \
-  <username>
-```
-
-Then add the credentials to `config.json` (copy from `config.example.json` if it doesn't exist):
-
-```json
-{
-  "username": "<username>@mcp-server",
-  "password": "<generated-password>"
-}
-```
+See [docs/releasing.md](docs/releasing.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Contributing new tools
 
-New tools — and changes to existing tool descriptions, parameter documentation, or annotation hints — must follow the [tool description style guide](docs/tool-descriptions.md). The guide covers voice, depth, sibling disambiguation, canonical MediaWiki terminology, and annotation semantics.
+New tools — and changes to existing tool descriptions, parameter documentation, or annotation hints — must follow the [tool conventions](docs/tool-conventions.md). The guide covers voice, depth, sibling disambiguation, canonical MediaWiki terminology, and annotation semantics.
 
 Every tool MUST set all four `ToolAnnotations` hints explicitly: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. This is not strictly required by the MCP spec but is required by OpenAI's ChatGPT developer mode, which rejects submissions missing any of the first three.
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The `release` GitHub workflow will trigger automatically:
 
 Contributions are welcome! Please feel free to submit a pull request or open an issue for bugs, feature requests, or suggestions.
 
-When adding or modifying a tool, please read the [tool description style guide](docs/tool-descriptions.md). It covers voice, depth, canonical MediaWiki terminology, and the annotation hints every tool must set.
+When adding or modifying a tool, please read the [tool conventions](docs/tool-conventions.md). It covers voice, depth, canonical MediaWiki terminology, and the annotation hints every tool must set.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An MCP (Model Context Protocol) server that enables Large Language Model (LLM) clients to interact with any MediaWiki wiki.
 
-## Feature
+## Features
 
 ### Tools
 
@@ -122,67 +122,9 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
 | `tags` | No | Change tag(s) applied to every write. The tag must be created and activated on the wiki at `Special:Tags` before use; MediaWiki returns a `badtags` error otherwise. Accepts a string or array of strings |
 
-### Environment variable substitution
+> For `${VAR}` environment variable substitution, `exec` secret sources (to read credentials from a password manager or keyring), the plaintext-warning behavior, and further `tags` notes, see [docs/configuration.md](docs/configuration.md).
 
-Config values support `${VAR_NAME}` syntax for referencing environment variables. This allows you to keep secrets out of your `config.json` file.
-
-```json
-{
-  "defaultWiki": "my.wiki.org",
-  "wikis": {
-    "my.wiki.org": {
-      "sitename": "My Wiki",
-      "server": "https://my.wiki.org",
-      "articlepath": "/wiki",
-      "scriptpath": "/w",
-      "token": "${WIKI_OAUTH_TOKEN}",
-      "username": "${WIKI_USERNAME}",
-      "password": "${WIKI_PASSWORD}"
-    }
-  }
-}
-```
-
-If a referenced variable is not set:
-
-- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front instead of as confusing failures later.
-- **Non-secret fields**: the `${VAR_NAME}` text is kept as-is.
-
-### Secret sources
-
-As an alternative to `${VAR_NAME}`, secret fields can run an external command at startup and use its output as the secret. This lets you fetch credentials from a password manager, keyring, or secret store without writing them to disk:
-
-```json
-{
-  "defaultWiki": "my.wiki.org",
-  "wikis": {
-    "my.wiki.org": {
-      "sitename": "My Wiki",
-      "server": "https://my.wiki.org",
-      "articlepath": "/wiki",
-      "scriptpath": "/w",
-      "token": {
-        "exec": {
-          "command": "op",
-          "args": ["read", "op://Private/my-wiki/oauth-token"]
-        }
-      }
-    }
-  }
-}
-```
-
-The command runs directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies.
-
-If the command fails, times out, or prints nothing, the server exits at startup. Error messages identify the failing wiki and field — the secret value itself is never logged.
-
-Any CLI that prints a credential to stdout works: 1Password's `op`, `pass`, `secret-tool`, Bitwarden's `bw`, HashiCorp Vault, or a custom script.
-
-### Plaintext secrets
-
-Plaintext credentials in `config.json` still work but print a one-line warning to stderr on startup. Prefer `${VAR}` or an `exec` source when possible.
-
-### Authentication setup
+## Authentication
 
 For tools marked with 🔐, authentication is required.
 
@@ -319,90 +261,13 @@ You should end up with something like the below in your `.claude.json` config:
 ```
 </details>
 
-## Development
-
-> 🐋 **Develop with Docker:** Replace the `npm run` part of the command with `make` (e.g. `make inspector`).
-
-
-### [MCP Inspector](https://github.com/modelcontextprotocol/inspector)
-
-Test and debug the MCP server without a MCP client and LLM.
-
-To start the development server and the MCP Inspector together:
-```sh
-npm run inspector
-```
-
-The command will build and start the MCP Proxy server locally at `6277` and the MCP Inspector client UI at `http://localhost:6274`.
-
-
-### [MCPJam Inspector](https://github.com/MCPJam/inspector)
-
-Test and debug the MCP server, with a built-in MCP client and support for different LLMs.
-
-To start the development server and the MCP Inspector together:
-```sh
-npm run mcpjam
-```
-
-### Test with MCP clients
-
-To enable your MCP client to use this MediaWiki MCP Server for local development: 
-
-1. [Install](#installation) the MCP server on your MCP client.
-2. Change the `command` and `args` values as shown in the [`mcp.json`](mcp.json) file (or [`mcp.docker.json`](mcp.docker.json) if you prefer to run the MCP server in Docker).
-3. Run the `dev` command so that the source will be compiled whenever there is a change:
-
-	```sh
-	npm run dev
-	```
-
-### Release process
-
-To release a new version:
-
-<details>
-<summary><b>1. Use npm version to create a release</b></summary>
-
-```sh
-# For patch release (0.1.1 → 0.1.2)
-npm version patch
-
-# For minor release (0.1.1 → 0.2.0)
-npm version minor
-
-# For major release (0.1.1 → 1.0.0)
-npm version major
-
-# Or specify exact version
-npm version 0.2.0
-```
-
-This command automatically:
-- Updates `package.json` and `package-lock.json`
-- Syncs the version in `server.json`, `mcpb/manifest.json`, `Dockerfile` (via the version script)
-- Creates a git commit
-- Creates a git tag (e.g., `v0.2.0`)
-</details>
-
-<details>
-<summary><b>2. Push to GitHub</b></summary>
-
-```sh
-git push origin master --follow-tags
-```
-
-The `release` GitHub workflow will trigger automatically:
-- Build a MCP bundle `.mcpb` and publish to [GitHub](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases)
-- Build and publish to [NPM](https://www.npmjs.com/package/@professional-wiki/mediawiki-mcp-server) 
-- Publish to the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.professionalwiki/mediawiki-mcp-server)
-</details>
-
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a pull request or open an issue for bugs, feature requests, or suggestions.
+Contributions are welcome — pull requests and issues (bugs, feature requests, suggestions) both work.
 
-When adding or modifying a tool, please read the [tool conventions](docs/tool-conventions.md). It covers voice, depth, canonical MediaWiki terminology, and the annotation hints every tool must set.
+- **Working on tool code?** Start from [AGENTS.md](AGENTS.md) for repo layout, commands, and testing patterns.
+- **Adding or modifying a tool?** Read [docs/tool-conventions.md](docs/tool-conventions.md) — it covers description voice, parameter docs, annotation hints, and MediaWiki terminology conventions.
+- **Running a release?** See [docs/releasing.md](docs/releasing.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,31 +9,32 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 
 | Name | Description | Permissions |
 |---|---|---|
-| `add-wiki` | Adds a new wiki as an MCP resource from a URL. Disabled when `allowWikiManagement` is `false`. | - |
+| `add-wiki` | Add a wiki as an MCP resource from its URL. Disabled when `allowWikiManagement` is `false`. | - |
 | `compare-pages` | Diff two versions of a wiki page by revision, title, or supplied wikitext. | - |
 | `create-page` 🔐 | Create a new wiki page. | `Create, edit, and move pages` |
 | `delete-page` 🔐 | Delete a wiki page. | `Delete pages, revisions, and log entries` |
-| `get-category-members` | Returns members of a category (up to 500 per call, paginated via `continueFrom`). | - |
-| `get-file` | Returns the standard file object for a file page. | - |
-| `get-page` | Returns the standard page object for a wiki page. | - |
-| `get-page-history` | Returns information about the latest revisions to a wiki page. | - |
-| `get-pages` | Returns multiple wiki pages in one call (up to 50). | - |
-| `get-revision` | Returns the standard revision object for a page. | - |
-| `parse-wikitext` | Renders wikitext and returns the HTML, parse warnings, wikilinks, templates, and external URLs without saving a page. | - |
-| `remove-wiki` | Removes a wiki resource. Disabled when `allowWikiManagement` is `false`. | - |
-| `search-page` | Search wiki page titles and contents for the provided search terms. | - |
-| `search-page-by-prefix` | Perform a prefix search for page titles. | - |
-| `set-wiki` | Sets the wiki resource to use for the current session. | - |
+| `get-category-members` | List members of a category (up to 500 per call, paginated via `continueFrom`). | - |
+| `get-file` | Fetch a file page. | - |
+| `get-page` | Fetch a wiki page. | - |
+| `get-page-history` | List recent revisions of a wiki page. | - |
+| `get-pages` | Fetch multiple wiki pages in one call (up to 50). | - |
+| `get-revision` | Fetch a specific revision of a page. | - |
+| `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. | - |
+| `remove-wiki` | Remove a wiki resource. Disabled when `allowWikiManagement` is `false`. | - |
+| `search-page` | Search wiki page titles and contents. | - |
+| `search-page-by-prefix` | Search page titles by prefix. | - |
+| `set-wiki` | Set the active wiki for the current session. | - |
 | `undelete-page` 🔐 | Undelete a wiki page. | `Delete pages, revisions, and log entries` |
 | `update-page` 🔐 | Update an existing wiki page. | `Edit existing pages` |
-| `upload-file` 🔐 | Uploads a file to the wiki from the local disk. | `Upload new files` |
-| `upload-file-from-url` 🔐 | Uploads a file to the wiki from a web URL. | `Upload, replace, and move files` |
+| `upload-file` 🔐 | Upload a file to the wiki from local disk. | `Upload new files` |
+| `upload-file-from-url` 🔐 | Upload a file to the wiki from a URL. | `Upload, replace, and move files` |
 
 ### Resources
 
-`mcp://wikis/{wikiKey}`
-- Credentials (e.g., `token`, `username`, `password`) are never exposed in resource content.
-- After `add-wiki`/`remove-wiki`, the server sends `notifications/resources/list_changed` so clients refresh.
+**`mcp://wikis/{wikiKey}`** — per-wiki resource exposing `sitename`, `server`, `articlepath`, `scriptpath`, and a `private` flag.
+
+- Credentials (`token`, `username`, `password`) are never exposed in resource content.
+- After `add-wiki` or `remove-wiki`, the server sends `notifications/resources/list_changed` so clients refresh.
 
 <details><summary>Example list result</summary>
 
@@ -120,30 +121,26 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 | `username` | No | Bot username (fallback when OAuth2 is not available) |
 | `password` | No | Bot password (fallback when OAuth2 is not available) |
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
-| `tags` | No | Change tag(s) applied to every write. The tag must be created and activated on the wiki at `Special:Tags` before use; MediaWiki returns a `badtags` error otherwise. Accepts a string or array of strings |
+| `tags` | No | Change tag(s) to apply to every write (string or array). The tag must exist and be active at `Special:Tags` — see [docs/configuration.md](docs/configuration.md#change-tags-tags) for details. |
 
-> For `${VAR}` environment variable substitution, `exec` secret sources (to read credentials from a password manager or keyring), the plaintext-warning behavior, and further `tags` notes, see [docs/configuration.md](docs/configuration.md).
+> Environment variable substitution (`${VAR}`), secret sources that read from a password manager, and the plaintext-warning behavior are covered in [docs/configuration.md](docs/configuration.md).
 
 ## Authentication
 
-For tools marked with 🔐, authentication is required.
+Tools marked 🔐 require authentication.
 
-**Preferred method: OAuth2 Token**
+### OAuth2 (preferred)
 
-1. Navigate to `Special:OAuthConsumerRegistration/propose/oauth2` on your wiki
-2. Select "This consumer is for use only by [YourUsername]"
-3. Grant the necessary permissions
-4. After approval, you'll receive:
-   - Client ID
-   - Client Secret
-   - Access Token
-5. Add the `token` to your wiki configuration in `config.json`
+1. Navigate to `Special:OAuthConsumerRegistration/propose/oauth2` on your wiki.
+2. Select "This consumer is for use only by [YourUsername]".
+3. Grant the permissions your tools need — see the Permissions column in the [Tools](#tools) table.
+4. After approval, copy the **Access Token** into the `token` field for that wiki in `config.json`.
 
-> **Note:** OAuth2 requires the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) to be installed on the wiki.
+> OAuth2 requires the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) on the wiki.
 
-**Fallback method: Username & Password**
+### Bot password (fallback)
 
-If OAuth2 is not available on your wiki, you can use bot credentials (from `Special:BotPasswords` ) instead of the OAuth2 token.
+If the OAuth extension isn't available, create a bot password at `Special:BotPasswords` and set `username` and `password` in `config.json` instead of `token`.
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Config values support `${VAR_NAME}` syntax for referencing environment variables
 
 If a referenced variable is not set:
 
-- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front instead of as confusing failures later.
+- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front, not as confusing failures later.
 - **Non-secret fields**: the `${VAR_NAME}` text is kept as-is.
 
 ## Secret sources
@@ -64,9 +64,9 @@ Plaintext credentials in `config.json` still work but print a one-line warning t
 
 ## Change tags (`tags`)
 
-The `tags` field applies one or more [change tags](https://www.mediawiki.org/wiki/Manual:Tags) to every write operation (create, update, delete, upload). The tag must be created and activated on the wiki at `Special:Tags` before use; otherwise MediaWiki returns a `badtags` error and the write fails.
+The `tags` field applies one or more [change tags](https://www.mediawiki.org/wiki/Manual:Tags) to every write (create, update, delete, upload). Register and activate the tag at `Special:Tags` first — otherwise MediaWiki returns a `badtags` error and the write fails.
 
-Accepts a string or array of strings:
+Accepts a string or an array of strings:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,89 @@
+# Advanced configuration
+
+Covers configuration topics beyond the basic `config.json` shape documented in [README.md](../README.md#configuration): environment variable substitution, secret sources, plaintext fallback, and the `tags` field.
+
+## Environment variable substitution
+
+Config values support `${VAR_NAME}` syntax for referencing environment variables. This allows you to keep secrets out of your `config.json` file.
+
+```json
+{
+  "defaultWiki": "my.wiki.org",
+  "wikis": {
+    "my.wiki.org": {
+      "sitename": "My Wiki",
+      "server": "https://my.wiki.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "token": "${WIKI_OAUTH_TOKEN}",
+      "username": "${WIKI_USERNAME}",
+      "password": "${WIKI_PASSWORD}"
+    }
+  }
+}
+```
+
+If a referenced variable is not set:
+
+- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front instead of as confusing failures later.
+- **Non-secret fields**: the `${VAR_NAME}` text is kept as-is.
+
+## Secret sources
+
+As an alternative to `${VAR_NAME}`, secret fields can run an external command at startup and use its output as the secret. This lets you fetch credentials from a password manager, keyring, or secret store without writing them to disk:
+
+```json
+{
+  "defaultWiki": "my.wiki.org",
+  "wikis": {
+    "my.wiki.org": {
+      "sitename": "My Wiki",
+      "server": "https://my.wiki.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "token": {
+        "exec": {
+          "command": "op",
+          "args": ["read", "op://Private/my-wiki/oauth-token"]
+        }
+      }
+    }
+  }
+}
+```
+
+The command runs directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies.
+
+If the command fails, times out, or prints nothing, the server exits at startup. Error messages identify the failing wiki and field — the secret value itself is never logged.
+
+Any CLI that prints a credential to stdout works: 1Password's `op`, `pass`, `secret-tool`, Bitwarden's `bw`, HashiCorp Vault, or a custom script.
+
+## Plaintext secrets
+
+Plaintext credentials in `config.json` still work but print a one-line warning to stderr on startup. Prefer `${VAR}` or an `exec` source when possible.
+
+## Change tags (`tags`)
+
+The `tags` field applies one or more [change tags](https://www.mediawiki.org/wiki/Manual:Tags) to every write operation (create, update, delete, upload). The tag must be created and activated on the wiki at `Special:Tags` before use; otherwise MediaWiki returns a `badtags` error and the write fails.
+
+Accepts a string or array of strings:
+
+```json
+{
+  "wikis": {
+    "my.wiki.org": {
+      "tags": "mcp-server"
+    }
+  }
+}
+```
+
+```json
+{
+  "wikis": {
+    "my.wiki.org": {
+      "tags": ["mcp-server", "automated"]
+    }
+  }
+}
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,40 @@
+# Releasing
+
+Maintainer-only. Instructions for cutting a new release of the MediaWiki MCP Server.
+
+## 1. Create a release with `npm version`
+
+```sh
+# For patch release (0.1.1 → 0.1.2)
+npm version patch
+
+# For minor release (0.1.1 → 0.2.0)
+npm version minor
+
+# For major release (0.1.1 → 1.0.0)
+npm version major
+
+# Or specify exact version
+npm version 0.2.0
+```
+
+This command automatically:
+
+- Updates `package.json` and `package-lock.json`
+- Syncs the version in `server.json`, `mcpb/manifest.json`, and `Dockerfile` (via the `version` script)
+- Creates a git commit
+- Creates a git tag (e.g. `v0.2.0`)
+
+The `preversion` hook runs `npm run preflight` first (install, lint, server.json validation, test, build, bundle) and aborts the release if any step fails.
+
+## 2. Push to GitHub
+
+```sh
+git push origin master --follow-tags
+```
+
+The `release` GitHub workflow triggers automatically on the tag and:
+
+- Builds the `.mcpb` bundle and attaches it to a new [GitHub Release](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases).
+- Publishes the package to [NPM](https://www.npmjs.com/package/@professional-wiki/mediawiki-mcp-server).
+- Publishes to the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.professionalwiki/mediawiki-mcp-server).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Maintainer-only. Instructions for cutting a new release of the MediaWiki MCP Server.
+How to cut a new release of the MediaWiki MCP Server. Maintainers only.
 
 ## 1. Create a release with `npm version`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,108 @@
+# Testing
+
+Reference for unit tests, integration testing against a real wiki, and the local wiki setup needed to exercise authenticated tools.
+
+> 🐋 **Docker alternative:** Replace `npm run` with `make` (e.g. `make inspector`).
+
+## Unit tests
+
+Tests use [Vitest](https://vitest.dev/) with mocked `mwn`. Tool handler functions (`handleXxxTool`) must be exported from their `src/tools/<name>.ts` file so tests can import them.
+
+Each test file mocks `getMwn` and `wikiService` **before** any imports that depend on them:
+
+```typescript
+vi.mock( '../../src/common/mwn.js', () => ( { getMwn: vi.fn() } ) );
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+```
+
+Use `createMockMwn()` from `tests/helpers/mock-mwn.ts` to create mock `mwn` instances with method overrides. See existing test files under `tests/` for the full pattern.
+
+Run:
+
+```sh
+npm test           # one-shot
+npm run test:watch # watch mode
+```
+
+## MCP Inspector (UI)
+
+Test and debug the MCP server interactively without an MCP client or LLM.
+
+```sh
+npm run inspector
+```
+
+Builds in watch mode and starts the MCP Proxy server at `localhost:6277` and the Inspector UI at `http://localhost:6274`.
+
+## MCPJam Inspector
+
+Test and debug with a built-in MCP client and support for different LLMs.
+
+```sh
+npm run mcpjam
+```
+
+## MCP Inspector CLI (integration tests)
+
+The [MCP Inspector CLI](https://github.com/modelcontextprotocol/inspector) exercises tools against a real wiki. Build first with `npm run build`, then:
+
+```bash
+# List all tools
+npx @modelcontextprotocol/inspector --cli node dist/index.js \
+  --method tools/list
+
+# Call a tool
+npx @modelcontextprotocol/inspector --cli node dist/index.js \
+  --method tools/call \
+  --tool-name get-page \
+  --tool-arg 'title=Main Page' \
+  --tool-arg 'metadata=true'
+
+# Read a resource
+npx @modelcontextprotocol/inspector --cli node dist/index.js \
+  --method resources/read \
+  --uri 'mcp://wikis/en.wikipedia.org'
+```
+
+Each invocation starts a fresh MCP session, so `set-wiki` does not persist between calls. Set `defaultWiki` in `config.json` to target a specific wiki.
+
+## Testing against MCP clients during development
+
+To wire your MCP client (Claude Desktop, VS Code, Cursor, etc.) into a locally-built copy:
+
+1. [Install](../README.md#installation) the MCP server on your MCP client.
+2. Change the `command` and `args` values as shown in the [`mcp.json`](../mcp.json) file (or [`mcp.docker.json`](../mcp.docker.json) if you prefer Docker).
+3. Run the `dev` command so sources recompile on change:
+
+   ```sh
+   npm run dev
+   ```
+
+## Local wiki setup (for authenticated tools)
+
+Authenticated tools (create, update, delete, undelete, upload) require credentials. To set up bot passwords on a local MediaWiki running in Docker:
+
+```bash
+docker exec <container> php /var/www/html/w/maintenance/run.php createBotPassword \
+  --appid mcp-server \
+  --grants 'basic,editpage,editprotected,createeditmovepage,uploadfile,highvolume,delete' \
+  <username>
+```
+
+Then add the credentials to `config.json` (copy from `config.example.json` if it doesn't exist):
+
+```json
+{
+  "username": "<username>@mcp-server",
+  "password": "<generated-password>"
+}
+```
+
+For production auth, OAuth2 is preferred — see the [Authentication](../README.md#authentication) section in README.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 Reference for unit tests, integration testing against a real wiki, and the local wiki setup needed to exercise authenticated tools.
 
-> 🐋 **Docker alternative:** Replace `npm run` with `make` (e.g. `make inspector`).
+> 🐋 **Docker alternative:** commands that use `npm run <script>` have a Makefile equivalent — run `make <script>` instead (e.g. `make test`, `make inspector`). The MCP Inspector CLI examples below use `npx` directly and have no Makefile target.
 
 ## Unit tests
 
@@ -39,11 +39,11 @@ Test and debug the MCP server interactively without an MCP client or LLM.
 npm run inspector
 ```
 
-Builds in watch mode and starts the MCP Proxy server at `localhost:6277` and the Inspector UI at `http://localhost:6274`.
+Starts a watch-mode TypeScript build plus the MCP Proxy server on port `6277` and the Inspector UI at http://localhost:6274.
 
 ## MCPJam Inspector
 
-Test and debug with a built-in MCP client and support for different LLMs.
+Like the MCP Inspector, but with a built-in MCP client that can drive the server against different LLMs — useful for checking how a given LLM actually calls the tools.
 
 ```sh
 npm run mcpjam
@@ -73,13 +73,13 @@ npx @modelcontextprotocol/inspector --cli node dist/index.js \
 
 Each invocation starts a fresh MCP session, so `set-wiki` does not persist between calls. Set `defaultWiki` in `config.json` to target a specific wiki.
 
-## Testing against MCP clients during development
+## Using a local build from your MCP client
 
-To wire your MCP client (Claude Desktop, VS Code, Cursor, etc.) into a locally-built copy:
+To point an MCP client (Claude Desktop, VS Code, Cursor, etc.) at a locally-built copy of the server:
 
-1. [Install](../README.md#installation) the MCP server on your MCP client.
-2. Change the `command` and `args` values as shown in the [`mcp.json`](../mcp.json) file (or [`mcp.docker.json`](../mcp.docker.json) if you prefer Docker).
-3. Run the `dev` command so sources recompile on change:
+1. [Install](../README.md#installation) the server on the client.
+2. Replace the `command` and `args` values with the ones from [`mcp.json`](../mcp.json) (or [`mcp.docker.json`](../mcp.docker.json) for Docker).
+3. Run the `dev` command so sources recompile on save:
 
    ```sh
    npm run dev
@@ -87,7 +87,7 @@ To wire your MCP client (Claude Desktop, VS Code, Cursor, etc.) into a locally-b
 
 ## Local wiki setup (for authenticated tools)
 
-Authenticated tools (create, update, delete, undelete, upload) require credentials. To set up bot passwords on a local MediaWiki running in Docker:
+Authenticated tools (create, update, delete, undelete, upload) need credentials. To create bot passwords on a local MediaWiki running in Docker:
 
 ```bash
 docker exec <container> php /var/www/html/w/maintenance/run.php createBotPassword \
@@ -105,4 +105,4 @@ Then add the credentials to `config.json` (copy from `config.example.json` if it
 }
 ```
 
-For production auth, OAuth2 is preferred — see the [Authentication](../README.md#authentication) section in README.
+For production authentication, use OAuth2 — see [Authentication](../README.md#authentication) in the README.

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -1,6 +1,6 @@
-# Tool Description Style Guide
+# Tool Conventions
 
-This guide is for anyone adding or modifying a tool in this MCP server. It codifies how to write tool descriptions, parameter documentation, and annotation hints so that LLMs consuming the server can select and use tools correctly.
+This guide is for anyone adding or modifying a tool in this MCP server. It covers tool design decisions, how to write descriptions and parameter docs, the runtime conventions for returned content, and the metadata every tool must set.
 
 The guide has two parts:
 
@@ -11,7 +11,17 @@ Read both before adding a new tool or rewriting an existing one.
 
 ## Part 1 — Generic principles
 
-### Voice and opening
+### Tool design
+
+#### One job per tool
+
+Anthropic's engineering guidance recommends consolidating multiple actions into a single tool with an `action` parameter. OpenAI's Apps SDK recommends the opposite — one job per tool.
+
+This codebase follows **one job per tool** (separate `create-page`, `update-page`, `delete-page`, `undelete-page`, etc.). Do not consolidate when adding new tools; match the existing pattern. This is an explicit choice, not an oversight.
+
+### Descriptions
+
+#### Voice and opening
 
 Write tool descriptions in **third-person descriptive voice**. Start with a verb phrase describing what the tool does.
 
@@ -22,7 +32,7 @@ Write tool descriptions in **third-person descriptive voice**. Start with a verb
 
 Third-person descriptive voice avoids point-of-view inconsistencies that degrade tool discovery. The description is injected into the system prompt; it should read as a capability statement, not a prompt fragment.
 
-### Coverage: what, when, parameters, caveats
+#### Coverage: what, when, parameters, caveats
 
 Every description answers at least:
 
@@ -37,7 +47,7 @@ Depth scales from there based on how much there is to disambiguate. Longer descr
 
 Apply proportional depth: don't pad simple tools with filler, don't keep tautological tools short. A one-sentence description is fine when there's nothing more to say; a paragraph is fine when there is.
 
-### Don't duplicate the schema
+#### Don't duplicate the schema
 
 The JSON Schema generated from zod already tells the model:
 
@@ -47,11 +57,11 @@ The JSON Schema generated from zod already tells the model:
 
 Do not restate this in prose. Prose is for context the schema cannot express.
 
-### Avoid tautology
+#### Avoid tautology
 
 A description that restates the tool name adds zero information. `"Deletes a wiki page"` for `delete-page` is a bad description. A better description says what "delete" means in MediaWiki (deleted pages are recoverable via `undelete-page` until purge), what the tool returns, and what errors the caller might see.
 
-### Sibling disambiguation with inline routing hints
+#### Sibling disambiguation with inline routing hints
 
 When two tools in the set overlap, each description should explicitly say when to pick it vs. the other. Use the pattern "Use this instead of X when Y" or "For Z, use X instead."
 
@@ -62,7 +72,7 @@ Examples applicable to this server:
 - `get-revision` vs `get-page` with `metadata=true`: specific historical revision vs. latest with metadata.
 - `compare-pages` vs. fetching two sources and diffing client-side.
 
-### Don't instruct the model imperatively
+#### Don't instruct the model imperatively
 
 Describe the condition under which the tool is useful; let the model decide whether to call it.
 
@@ -73,13 +83,9 @@ The rule targets general imperatives aimed at the model ("You MUST...", "You sho
 
 Imperative instructions to the model ("You should...", "You MUST...") in tool descriptions reduce robustness across different LLM implementations.
 
-### Tool consolidation stance (this codebase)
+### Parameter docs
 
-Anthropic's engineering guidance recommends consolidating multiple actions into a single tool with an `action` parameter. OpenAI's Apps SDK recommends the opposite — one job per tool.
-
-This codebase follows **one job per tool** (separate `create-page`, `update-page`, `delete-page`, etc.). Do not consolidate when adding new tools; match the existing pattern. This is an explicit choice, not an oversight.
-
-### Parameter descriptions
+#### Parameter descriptions
 
 Every parameter has a `.describe()` call. Parameter docs complement the schema; they do not duplicate it.
 
@@ -91,7 +97,9 @@ Parameter descriptions must:
 - **Not restate the zod type.** `"Optional integer"` is redundant when the schema is `z.number().int().optional()`.
 - **Be concise.** A sentence or two per parameter. Complex behaviour belongs in the tool description, not in every parameter.
 
-### Result caps and truncation signaling
+### Runtime behavior
+
+#### Result caps and truncation signaling
 
 Tools that return variable-size result sets have a per-call cap. When the cap is hit, the tool appends a trailing text block to `content` describing the truncation. Two shapes:
 
@@ -104,7 +112,9 @@ This convention doesn't apply to tools that reject oversize input (e.g. `get-pag
 
 There is no MCP-spec-level budget for tool output. Cap sizes are chosen to stay well under Anthropic's 25,000-token Claude Code default ([Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)) and revisited when [MCP discussion #2211](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2211) ratifies a standard.
 
-### Annotation hints
+### Metadata
+
+#### Annotation hints
 
 MCP's `ToolAnnotations` exposes four boolean hints that shape how clients route and display tools. Spec defaults exist, but **every tool in this repository sets all four explicitly** because OpenAI's ChatGPT developer mode rejects MCP submissions missing `readOnlyHint`, `destructiveHint`, or `openWorldHint`.
 
@@ -122,7 +132,7 @@ Semantics (from the MCP 2025-11-25 spec):
 - Write tools that only add (create, append, upload-new): `readOnlyHint: false`, `destructiveHint: false`.
 - If the tool does not make network calls and only mutates server-local state (e.g. selecting the active wiki), `openWorldHint: false`.
 
-### Tool titles
+#### Tool titles
 
 The `title` field on `ToolAnnotations` is a human-readable UI label. Use **sentence case**, **imperative verb phrasing**:
 
@@ -133,7 +143,9 @@ Primarily a UI label. Don't rely on `title` for model routing — put disambigua
 
 ## Part 2 — MediaWiki conventions
 
-### Canonical terminology
+### Terminology
+
+#### Canonical terminology
 
 Use these exact terms in descriptions and parameter docs. Do not introduce synonyms.
 
@@ -146,7 +158,7 @@ Use these exact terms in descriptions and parameter docs. Do not introduce synon
 | Namespace identifier (integer) | **namespace ID** | Parameter descriptions state "Namespace ID"; prose may mention the namespace name parenthetically. |
 | Content format (wikitext, javascript, css, etc.) | **content model** | Matches MediaWiki's `contentmodel` API field. |
 
-### Page title vs file title
+#### Page title vs file title
 
 File titles are page titles in the File namespace. The distinction surfaces at the parameter level:
 
@@ -155,7 +167,7 @@ File titles are page titles in the File namespace. The distinction surfaces at t
 
 Do not interchange these.
 
-### Common MediaWiki error patterns
+#### Common MediaWiki error patterns
 
 When an LLM invokes a tool that fails with one of these errors, the caller needs to understand what happened. Descriptions for tools that expose these errors should mention the condition (not the error code).
 
@@ -165,7 +177,9 @@ When an LLM invokes a tool that fails with one of these errors, the caller needs
 
 Example phrasing: `"Returns a wiki page. If the title does not exist, an error is returned."` — not `"...a missingtitle error is returned."`
 
-### Sibling overlap pairs in this codebase
+### This codebase
+
+#### Sibling overlap pairs
 
 When writing or updating a tool in these pairs, each side's description should explicitly say when to use it vs. the other:
 
@@ -173,7 +187,3 @@ When writing or updating a tool in these pairs, each side's description should e
 - **`search-page` vs `search-page-by-prefix`** — full-text content search vs. title-prefix search.
 - **`get-revision` vs `get-page` with `metadata=true`** — fetch a specific historical revision vs. fetch the latest revision with metadata attached.
 - **`compare-pages` vs. client-side diff** — `compare-pages` computes the diff server-side and returns a compact text diff; prefer it over fetching both sources and diffing locally.
-
-### Tool-consolidation stance
-
-This codebase keeps separate tools for distinct actions on the same object (create-page, update-page, delete-page, undelete-page). When adding a new tool, do not bundle multiple actions into a single tool with an `action` parameter; match the existing one-tool-per-action pattern.


### PR DESCRIPTION
## Summary

- Split `README.md` (human users) from `AGENTS.md` (AI coding agents, loaded every session via `CLAUDE.md`'s `@AGENTS.md`). Previously both files mixed contributor/maintainer/user content.
- Rename `docs/tool-descriptions.md` → `docs/tool-conventions.md` and regroup Part 1 by topic. ~40% of the file was never about descriptions (tool design stance, parameter docs, runtime response behavior, annotation metadata), so the name was misleading.
- Extract advanced configuration, maintainer release steps, and contributor testing workflows into three new topic files under `docs/`.
- Trim `AGENTS.md` from 72 → 35 lines by replacing inlined on-demand details (Inspector CLI commands, `createBotPassword`, the `vi.mock` code block) with pointers to the new topic docs. Reduces per-session token cost in Claude Code.
- Trim `README.md` from 410 → 271 lines by moving contributor-only and advanced-config content out, and fix the `## Feature` → `## Features` typo that slipped in at some point.

## What changed

**New files:**

- `docs/configuration.md` — `${VAR}` substitution, `exec` secret sources, plaintext fallback, `tags` field.
- `docs/releasing.md` — `npm version` flow, what the `version` script auto-syncs, release workflow outputs.
- `docs/testing.md` — vitest patterns (with `createMockMwn`), MCP Inspector UI, MCPJam, MCP Inspector CLI, local-build-in-MCP-client loop, local wiki bot-password setup.

**Renamed + restructured:**

- `docs/tool-descriptions.md` → `docs/tool-conventions.md`. Part 1 now groups: Tool design / Descriptions / Parameter docs / Runtime behavior / Metadata. The tool-consolidation stance appeared twice in the old file (Part 1 and Part 2); deduped into one entry under Tool design.

**Trimmed:**

- `README.md` — removed `### Environment variable substitution`, `### Secret sources`, `### Plaintext secrets`, `## Development` (Inspector + MCPJam + test-with-clients + release process). Elevated `### Authentication setup` to a top-level `## Authentication` section with `### OAuth2 (preferred)` / `### Bot password (fallback)` subsections and dropped the Client ID/Client Secret steps the server never uses. Normalized the tool table to imperative voice.
- `AGENTS.md` — rewritten to cover repo layout, commands, and pointers to `tool-conventions.md` / `testing.md` / `releasing.md`. No more duplicated annotation-hints rule. No more hardcoded `wikiService` mock code block that would rot on interface changes.

## Worth flagging

- **`AGENTS.md` is loaded into every Claude Code session in this repo** via `CLAUDE.md`'s `@AGENTS.md` import. Keeping it at ~35 lines and pointing to topic docs is a deliberate tradeoff: on-demand details (bot-password setup, Inspector CLI examples) don't pay per-session token cost anymore; agents fetch them when relevant. If future work shows an agent repeatedly re-reading one of the topic docs, we can inline that bit.
- **Anchor link behavior.** The README `tags` row points at `docs/configuration.md#change-tags-tags`. GitHub's slugifier strips backticks and parens from the heading `## Change tags (` + "`" + `tags` + "`" + `)` to produce that anchor. Verified it resolves on GitHub's render.
- **Commit ordering is deliberate.** The rename + internal reference update happens in commit 1 so no commit leaves the tree with broken cross-file links.

## Test plan

- [x] `npm run lint` — clean (2 pre-existing `security/detect-non-literal-fs-filename` warnings in `config.ts`, unchanged)
- [x] `npm run test` — 166/166 pass (no code changes; smoke only)
- [x] `npm run build` — compiles
- [x] Every markdown link resolves:
  - README → `AGENTS.md`, `docs/configuration.md` (+ `#change-tags-tags` anchor), `docs/tool-conventions.md`, `docs/releasing.md`, `#tools`, `#authentication`
  - AGENTS.md → `README.md`, `docs/tool-conventions.md`, `docs/testing.md`, `docs/releasing.md`, `tests/helpers/mock-mwn.ts`
  - `docs/*.md` → `../README.md#configuration`, `../README.md#authentication`, `../README.md#installation`, `../mcp.json`, `../mcp.docker.json`
- [x] `grep -rn tool-descriptions --include='*.md' .` returns only files under `docs/superpowers/` (untracked spec/plan references — intentional)
- [x] Section order in `README.md`: `Features → Configuration → Authentication → Installation → Contributing → License`

## Commits

1. `6ff0fed` Rename and restructure tool-descriptions guide
2. `a977ae8` Add docs/configuration.md for advanced config topics
3. `fb75f92` Add docs/releasing.md for maintainer release steps
4. `a350bea` Add docs/testing.md consolidating dev and test workflows
5. `f5a861a` Rewrite AGENTS.md as lean agent-facing reference
6. `5d15267` Trim README and split audience-specific content into docs/
7. `e0eac18` Polish docs and normalize prose after reorganization