### PR TITLE
Allow HTTP clients to authenticate with their own wiki account via OAuth2 bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ Tools marked 🔐 require authentication.
 
 > OAuth2 requires the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) on the wiki.
 
+### Per-request bearer token (HTTP transport)
+
+When using the HTTP transport, clients can pass their own OAuth2 token via the `Authorization` header instead of storing it in `config.json`. The token is forwarded transparently to MediaWiki on each request:
+
+```bash
+claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
+  --header "Authorization: Bearer <your-access-token>"
+```
+
+When no header is present, the server falls back to `config.json` credentials or anonymous access. See [docs/configuration.md](docs/configuration.md#per-request-bearer-token-http-transport) for details and reverse-proxy requirements.
+
 ### Bot password (fallback)
 
 If the OAuth extension isn't available, create a bot password at `Special:BotPasswords` and set `username` and `password` in `config.json` instead of `token`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,3 +87,28 @@ Accepts a string or an array of strings:
   }
 }
 ```
+
+## Per-request bearer token (HTTP transport)
+
+When using the Streamable HTTP transport (`MCP_TRANSPORT=http`), clients can authenticate to MediaWiki by sending an `Authorization` header on every request:
+
+```
+Authorization: Bearer <oauth2-access-token>
+```
+
+The token must be a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed.
+
+**Precedence**: request header → `config.json` `token` → `config.json` `username`/`password` → anonymous. When no `Authorization` header is present, the server falls back to the static credentials in `config.json`, preserving existing behaviour.
+
+Each request builds an independent MediaWiki session using the supplied token. Token rotation and revocation take effect immediately on the next request.
+
+Example with Claude Code:
+
+```
+claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
+  --header "Authorization: Bearer eyJhbGciOi..."
+```
+
+### Reverse proxy requirements
+
+If the MCP server runs behind a reverse proxy (Caddy, nginx, Traefik), the proxy must forward the `Authorization` header to the MCP server intact. Configurations that strip or consume the header (e.g. `header_up -Authorization`, `proxy_set_header Authorization ""`, or a proxy-level basic auth handler on the MCP route) will cause the server to see no token and fall back to config/anonymous.

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -20,6 +20,8 @@ export interface WikiConfig {
 	scriptpath: string;
 	/**
 	 * OAuth consumer token requested from Extension:OAuth.
+	 * Used as a fallback when no Authorization header is supplied
+	 * by the MCP client on the HTTP request.
 	 */
 	token?: string | null;
 	/**

--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -2,6 +2,7 @@ import { USER_AGENT } from '../server.js';
 import { wikiService } from './wikiService.js';
 import type { WikiConfig } from './config.js';
 import { Mwn, MwnOptions } from 'mwn';
+import { getRuntimeToken } from './requestContext.js';
 
 // Cache the Promise, not the resolved instance, so concurrent first-calls
 // for the same wiki share a single login / getSiteInfo round-trip.
@@ -21,6 +22,11 @@ export async function getMwn( wikiKey?: string ): Promise<Mwn> {
 		( { key, config } = wikiService.getCurrent() );
 	}
 
+	const runtimeToken = getRuntimeToken();
+	if ( runtimeToken ) {
+		return createMwnInstance( config, runtimeToken );
+	}
+
 	let pending = mwnInstances.get( key );
 	if ( !pending ) {
 		pending = createMwnInstance( config );
@@ -34,28 +40,46 @@ export async function getMwn( wikiKey?: string ): Promise<Mwn> {
 	return pending;
 }
 
-async function createMwnInstance( config: Readonly<WikiConfig> ): Promise<Mwn> {
+async function createMwnInstance(
+	config: Readonly<WikiConfig>,
+	runtimeToken?: string
+): Promise<Mwn> {
 	const { server, scriptpath, token, username, password } = config;
+	const effectiveToken = runtimeToken ?? token;
 
 	const options: MwnOptions = {
 		apiUrl: `${ server }${ scriptpath }/api.php`,
 		userAgent: USER_AGENT
 	};
 
-	if ( token ) {
-		options.OAuth2AccessToken = token;
-		return Mwn.init( options );
-	}
+	try {
+		if ( effectiveToken ) {
+			options.OAuth2AccessToken = effectiveToken;
+			return await Mwn.init( options );
+		}
 
-	if ( username && password ) {
-		options.username = username;
-		options.password = password;
-		return Mwn.init( options );
-	}
+		if ( username && password ) {
+			options.username = username;
+			options.password = password;
+			return await Mwn.init( options );
+		}
 
-	const instance = new Mwn( options );
-	await instance.getSiteInfo();
-	return instance;
+		const instance = new Mwn( options );
+		await instance.getSiteInfo();
+		return instance;
+	} catch ( error: unknown ) {
+		if ( error instanceof Error ) {
+			// mwn/axios attach full request config (incl. Authorization header)
+			// to error objects — strip to prevent token leaks in logs/responses
+			delete ( error as unknown as Record<string, unknown> ).request;
+			delete ( error as unknown as Record<string, unknown> ).config;
+			delete ( error as unknown as Record<string, unknown> ).response;
+			if ( effectiveToken && error.message.includes( effectiveToken ) ) {
+				error.message = error.message.replaceAll( effectiveToken, '[REDACTED]' );
+			}
+		}
+		throw error;
+	}
 }
 
 export function removeMwnInstance( wikiKey: string ): void {

--- a/src/common/requestContext.ts
+++ b/src/common/requestContext.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestContext {
+	runtimeToken?: string;
+}
+
+export const runtimeTokenStore = new AsyncLocalStorage<RequestContext>();
+
+export function getRuntimeToken(): string | undefined {
+	return runtimeTokenStore.getStore()?.runtimeToken;
+}

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -7,6 +7,15 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { createServer } from './server.js';
+import { runtimeTokenStore } from './common/requestContext.js';
+
+function extractBearerToken( req: Request ): string | undefined {
+	const auth = req.headers.authorization;
+	if ( typeof auth === 'string' && auth.toLowerCase().startsWith( 'bearer ' ) ) {
+		return auth.slice( 7 );
+	}
+	return undefined;
+}
 
 const app = express();
 app.use( express.json() );
@@ -47,7 +56,10 @@ app.post( '/mcp', async ( req: Request, res: Response ) => {
 		return;
 	}
 
-	await transport.handleRequest( req, res, req.body );
+	const runtimeToken = extractBearerToken( req );
+	await runtimeTokenStore.run( { runtimeToken }, () =>
+		transport.handleRequest( req, res, req.body )
+	);
 } );
 
 const handleSessionRequest = async ( req: Request, res: Response ): Promise<void> => {
@@ -58,7 +70,10 @@ const handleSessionRequest = async ( req: Request, res: Response ): Promise<void
 	}
 
 	const transport = transports[ sessionId ];
-	await transport.handleRequest( req, res );
+	const runtimeToken = extractBearerToken( req );
+	await runtimeTokenStore.run( { runtimeToken }, () =>
+		transport.handleRequest( req, res )
+	);
 };
 
 app.get( '/mcp', handleSessionRequest );

--- a/tests/common/mwn.test.ts
+++ b/tests/common/mwn.test.ts
@@ -22,6 +22,16 @@ vi.mock( '../../src/server.js', () => ( {
 	USER_AGENT: 'test-agent'
 } ) );
 
+vi.mock( '../../src/common/requestContext.js', () => {
+	let token: string | undefined;
+	return {
+		getRuntimeToken: () => token,
+		_setRuntimeToken: ( t: string | undefined ) => {
+			token = t;
+		}
+	};
+} );
+
 let currentWikiKey = 'wiki-a';
 let currentWikiConfig: Record<string, unknown> = {
 	server: 'https://wiki-a.example.com',
@@ -39,6 +49,7 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 
 let getMwn: typeof import( '../../src/common/mwn.js' ).getMwn;
 let removeMwnInstance: typeof import( '../../src/common/mwn.js' ).removeMwnInstance;
+let setRuntimeToken: ( t: string | undefined ) => void;
 
 describe( 'mwn instance management', () => {
 
@@ -57,6 +68,10 @@ describe( 'mwn instance management', () => {
 		const mwnModule = await import( '../../src/common/mwn.js' );
 		getMwn = mwnModule.getMwn;
 		removeMwnInstance = mwnModule.removeMwnInstance;
+
+		const contextModule = await import( '../../src/common/requestContext.js' );
+		setRuntimeToken = ( contextModule as unknown as { _setRuntimeToken: ( t: string | undefined ) => void } )._setRuntimeToken;
+		setRuntimeToken( undefined );
 	} );
 
 	it( 'returns cached instance for same wiki key', async () => {
@@ -214,5 +229,147 @@ describe( 'mwn instance management', () => {
 		expect( result ).toBeDefined();
 		expect( mockInit ).not.toHaveBeenCalled();
 		expect( mockGetSiteInfo ).toHaveBeenCalledOnce();
+	} );
+} );
+
+describe( 'runtime token', () => {
+
+	beforeEach( async () => {
+		vi.resetModules();
+		mockInit.mockReset();
+		mockConstructor.mockReset();
+		mockGetSiteInfo.mockReset();
+
+		currentWikiKey = 'wiki-a';
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w'
+		};
+
+		const mwnModule = await import( '../../src/common/mwn.js' );
+		getMwn = mwnModule.getMwn;
+		removeMwnInstance = mwnModule.removeMwnInstance;
+
+		const contextModule = await import( '../../src/common/requestContext.js' );
+		setRuntimeToken = ( contextModule as unknown as { _setRuntimeToken: ( t: string | undefined ) => void } )._setRuntimeToken;
+		setRuntimeToken( undefined );
+	} );
+
+	it( 'uses runtime token over config token', async () => {
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w',
+			token: 'config-fallback'
+		};
+		const oauthInstance = { id: 'runtime' };
+		mockInit.mockResolvedValue( oauthInstance );
+		setRuntimeToken( 'runtime-token-X' );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'runtime-token-X'
+			} )
+		);
+	} );
+
+	it( 'uses runtime token when config has no credentials', async () => {
+		const oauthInstance = { id: 'runtime-no-config' };
+		mockInit.mockResolvedValue( oauthInstance );
+		setRuntimeToken( 'runtime-token-Y' );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'runtime-token-Y'
+			} )
+		);
+	} );
+
+	it( 'falls back to config token when no runtime token', async () => {
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w',
+			token: 'config-token'
+		};
+		const oauthInstance = { id: 'config' };
+		mockInit.mockResolvedValue( oauthInstance );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'config-token'
+			} )
+		);
+	} );
+
+	it( 'does not cache runtime-token instances', async () => {
+		mockInit.mockResolvedValue( { id: 'first' } );
+		setRuntimeToken( 'same-token' );
+
+		await getMwn();
+
+		mockInit.mockResolvedValue( { id: 'second' } );
+
+		const second = await getMwn();
+
+		expect( second ).toEqual( { id: 'second' } );
+		expect( mockInit ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'runtime-token calls do not pollute the config cache', async () => {
+		mockGetSiteInfo.mockResolvedValue( undefined );
+
+		// First: anonymous (cached)
+		const anon = await getMwn();
+
+		// Second: runtime token (should not affect cache)
+		mockInit.mockResolvedValue( { id: 'runtime' } );
+		setRuntimeToken( 'runtime-token-Z' );
+		await getMwn();
+
+		// Third: back to anonymous (should be cache hit)
+		setRuntimeToken( undefined );
+		const anonAgain = await getMwn();
+
+		expect( anonAgain ).toBe( anon );
+		expect( mockConstructor ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'redacts token from error message', async () => {
+		setRuntimeToken( 'secret-token-123' );
+		mockInit.mockRejectedValue( new Error( 'OAuth failed: secret-token-123 is invalid' ) );
+
+		await expect( getMwn() ).rejects.toThrow( /\[REDACTED\]/ );
+		await expect( getMwn() ).rejects.not.toThrow( /secret-token-123/ );
+	} );
+
+	it( 'strips request, config, and response from error objects', async () => {
+		const err = new Error( 'connection failed' );
+		( err as Record<string, unknown> ).request = {
+			headers: { Authorization: 'Bearer secret' }
+		};
+		( err as Record<string, unknown> ).config = { url: 'https://...' };
+		( err as Record<string, unknown> ).response = {
+			config: { headers: { Authorization: 'Bearer secret' } }
+		};
+
+		setRuntimeToken( 'secret' );
+		mockInit.mockRejectedValue( err );
+
+		try {
+			await getMwn();
+			expect.unreachable( 'should have thrown' );
+		} catch ( caught ) {
+			expect( ( caught as Record<string, unknown> ).request ).toBeUndefined();
+			expect( ( caught as Record<string, unknown> ).config ).toBeUndefined();
+			expect( ( caught as Record<string, unknown> ).response ).toBeUndefined();
+		}
 	} );
 } );

--- a/tests/common/requestContext.test.ts
+++ b/tests/common/requestContext.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { runtimeTokenStore, getRuntimeToken } from '../../src/common/requestContext.js';
+
+describe( 'requestContext', () => {
+
+	it( 'returns undefined outside a run', () => {
+		expect( getRuntimeToken() ).toBeUndefined();
+	} );
+
+	it( 'returns the token inside a run', () => {
+		runtimeTokenStore.run( { runtimeToken: 'abc' }, () => {
+			expect( getRuntimeToken() ).toBe( 'abc' );
+		} );
+	} );
+
+	it( 'returns undefined when runtimeToken is not set in the context', () => {
+		runtimeTokenStore.run( {}, () => {
+			expect( getRuntimeToken() ).toBeUndefined();
+		} );
+	} );
+
+	it( 'inner run overrides outer token', () => {
+		runtimeTokenStore.run( { runtimeToken: 'outer' }, () => {
+			expect( getRuntimeToken() ).toBe( 'outer' );
+			runtimeTokenStore.run( { runtimeToken: 'inner' }, () => {
+				expect( getRuntimeToken() ).toBe( 'inner' );
+			} );
+			expect( getRuntimeToken() ).toBe( 'outer' );
+		} );
+	} );
+
+	it( 'isolates concurrent runs', async () => {
+		const results: string[] = [];
+
+		await Promise.all( [
+			runtimeTokenStore.run( { runtimeToken: 'token-a' }, async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+				results.push( `a:${ getRuntimeToken() }` );
+			} ),
+			runtimeTokenStore.run( { runtimeToken: 'token-b' }, async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 5 ) );
+				results.push( `b:${ getRuntimeToken() }` );
+			} )
+		] );
+
+		expect( results ).toContain( 'a:token-a' );
+		expect( results ).toContain( 'b:token-b' );
+	} );
+
+} );


### PR DESCRIPTION
## What this does                                                                
                                               
  When running the MCP server over HTTP, clients can now send their own                                                                                     
  MediaWiki OAuth2 token via the `Authorization: Bearer <token>` header.
  The server forwards it to MediaWiki, so each client acts as their own                                                                                     
  wiki user — not a shared bot account.                                                                                                                     
                                                                                                                                                            
  Without a token, everything works exactly as before (config.json                                                                                          
  credentials or anonymous).                                                                                                                                
                                                                                                                                                            
  Example:                                                                         
                                               
    claude mcp add --transport http my-wiki https://wiki.example.org/mcp \                                                                                  
      --header "Authorization: Bearer eyJhbGciOi..."
                                                                                                                                                            
  ## Why                                                                           
                                               
  Today, all clients share one wiki identity defined in config.json.                                                                                        
  This makes the hosted use case (#273) impractical: you can't tell who
  did what in the wiki history, and you can't give different users                                                                                          
  different permissions.                                                                                                                                    
                                                                                                                                                            
  With this change, each user gets their own OAuth2 token from the wiki                                                                                     
  (Special:OAuthConsumerRegistration), passes it in the header, and their          
  edits show up under their own name.                                                                                                                       
                                                                                                                                                            
  ## How it works                              
                                                                                                                                                            
  - The token is read from the HTTP header on every request (not stored                                                                                     
    between requests). Changing or revoking a token takes effect immediately.
  - Tool handlers are not modified — the token is propagated internally                                                                                     
    via AsyncLocalStorage.                                                                                                                                  
  - Tokens are never logged. If a MediaWiki API call fails, the error is                                                                                    
    sanitised to strip any token content before surfacing it.                                                                                               
  - The existing config.json authentication (token, username/password,                                                                                      
    anonymous) is completely unchanged when no header is sent.                                                                                              
  - stdio transport is unaffected.                                                                                                                          
                                                                                                                                                            
  ## Changes                                                                                                                                                
                                                                                                                                                            
  - 2 new files, 4 modified files, 2 new test files                                                                                                         
  - 350 lines added, 15 removed                
  - 178/178 tests pass, build and lint clean                                                                                                                
  - Fully backward compatible — no changes to tool files, cache format,                                                                                     
    or config schema                                                                                                                                        
                                                                                                                                                            
  ## Documentation                                                                                                                                          
                                                                                   
  - docs/configuration.md: new section covering usage, token precedence,                                                                                    
    and reverse-proxy requirements
  - README.md: new section under Authentication  