### PR TITLE
Per-request OAuth2 bearer token passthrough for HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ Tools marked 🔐 require authentication. They are also hidden from `tools/list`
 
 > OAuth2 requires the [OAuth extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth) on the wiki.
 
+### Per-request bearer token (HTTP transport)
+
+When using the HTTP transport, clients can pass their own OAuth2 token via the `Authorization` header instead of storing it in `config.json`. The token is forwarded transparently to MediaWiki on each request:
+
+```bash
+claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
+  --header "Authorization: Bearer <your-access-token>"
+```
+
+When no header is present, the server falls back to `config.json` credentials or anonymous access. See [docs/configuration.md](docs/configuration.md#per-request-bearer-token-http-transport) for details and reverse-proxy requirements.
+
 ### Bot password (fallback)
 
 If the OAuth extension isn't available, create a bot password at `Special:BotPasswords` and set `username` and `password` in `config.json` instead of `token`.

--- a/README.md
+++ b/README.md
@@ -141,14 +141,16 @@ Tools marked 🔐 require authentication. They are also hidden from `tools/list`
 
 ### Per-request bearer token (HTTP transport)
 
-When using the HTTP transport, clients can pass their own OAuth2 token via the `Authorization` header instead of storing it in `config.json`. The token is forwarded transparently to MediaWiki on each request:
+When using the HTTP transport, the server accepts a standard OAuth 2.1 `Authorization: Bearer <token>` header on each request (per the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)). Any MCP client that supports HTTP transport authentication can be configured to send it, allowing each client to act as its own wiki user rather than sharing the `config.json` identity.
+
+Example with Claude Code:
 
 ```bash
 claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
   --header "Authorization: Bearer <your-access-token>"
 ```
 
-When no header is present, the server falls back to `config.json` credentials or anonymous access. See [docs/configuration.md](docs/configuration.md#per-request-bearer-token-http-transport) for details and reverse-proxy requirements.
+When no header is present, the server falls back to `config.json` credentials or anonymous access. See [docs/configuration.md](docs/configuration.md#per-request-bearer-token-http-transport) for details, precedence, trust-boundary guidance, and reverse-proxy requirements.
 
 ### Bot password (fallback)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,3 +87,28 @@ Accepts a string or an array of strings:
   }
 }
 ```
+
+## Per-request bearer token (HTTP transport)
+
+When using the Streamable HTTP transport (`MCP_TRANSPORT=http`), clients can authenticate to MediaWiki by sending an `Authorization` header on every request:
+
+```
+Authorization: Bearer <oauth2-access-token>
+```
+
+The token must be a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed.
+
+**Precedence**: request header → `config.json` `token` → `config.json` `username`/`password` → anonymous. When no `Authorization` header is present, the server falls back to the static credentials in `config.json`, preserving existing behaviour.
+
+Each request builds an independent MediaWiki session using the supplied token. Token rotation and revocation take effect immediately on the next request.
+
+Example with Claude Code:
+
+```
+claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
+  --header "Authorization: Bearer eyJhbGciOi..."
+```
+
+### Reverse proxy requirements
+
+If the MCP server runs behind a reverse proxy (Caddy, nginx, Traefik), the proxy must forward the `Authorization` header to the MCP server intact. Configurations that strip or consume the header (e.g. `header_up -Authorization`, `proxy_set_header Authorization ""`, or a proxy-level basic auth handler on the MCP route) will cause the server to see no token and fall back to config/anonymous.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,25 +90,29 @@ Accepts a string or an array of strings:
 
 ## Per-request bearer token (HTTP transport)
 
-When using the Streamable HTTP transport (`MCP_TRANSPORT=http`), clients can authenticate to MediaWiki by sending an `Authorization` header on every request:
+When using the Streamable HTTP transport (`MCP_TRANSPORT=http`), the server accepts a standard OAuth 2.1 `Authorization: Bearer` header on each request, as described in the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization):
 
 ```
 Authorization: Bearer <oauth2-access-token>
 ```
 
-The token must be a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed.
+Any MCP client that supports HTTP transport authentication can be configured to send this header. The token must be a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed.
 
 **Precedence**: request header → `config.json` `token` → `config.json` `username`/`password` → anonymous. When no `Authorization` header is present, the server falls back to the static credentials in `config.json`, preserving existing behaviour.
 
 Each request builds an independent MediaWiki session using the supplied token. Token rotation and revocation take effect immediately on the next request.
 
-Example with Claude Code:
+Example configuration with Claude Code:
 
 ```
 claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
   --header "Authorization: Bearer eyJhbGciOi..."
 ```
 
+> **Note on the MCP authorization model.** The spec envisions the MCP server as a distinct OAuth resource server with its own audience, advertising `/.well-known/oauth-protected-resource` and obtaining a separate upstream token when calling MediaWiki. This server pragmatically uses MediaWiki's OAuth realm directly — the bearer token is a MediaWiki access token, and the MCP server forwards it without re-issuing. This is simpler to deploy against existing wikis but means clients must obtain a MediaWiki-audience token rather than going through an MCP-spec-compliant discovery flow.
+
 ### Reverse proxy requirements
+
+**Trust boundary.** The server trusts any `Authorization: Bearer` header it receives without performing origin checks. Run it behind a reverse proxy that terminates client connections and forwards only intended traffic, or bind it to a trusted interface (e.g. `127.0.0.1`) — never expose the HTTP port directly on an untrusted network.
 
 If the MCP server runs behind a reverse proxy (Caddy, nginx, Traefik), the proxy must forward the `Authorization` header to the MCP server intact. Configurations that strip or consume the header (e.g. `header_up -Authorization`, `proxy_set_header Authorization ""`, or a proxy-level basic auth handler on the MCP route) will cause the server to see no token and fall back to config/anonymous.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,15 +1,20 @@
 # Deployment
 
-> **Experimental — work in progress.** The only supported hosted shape today is **single-wiki, read-only** — one wiki entry, `readOnly: true`, anonymous access. Writable and multi-wiki hosted deployments are on the roadmap but not yet safe to run. Do not expose a single MCP server to mutually untrusted users.
+> **Experimental — work in progress.** Hosted deployments support two shapes:
+>
+> 1. **Single-wiki, read-only, anonymous.** Simplest to deploy — no auth, no writes.
+> 2. **Single-wiki, per-user OAuth2 bearer passthrough.** Each caller sends their own MediaWiki OAuth2 access token in the `Authorization` header; requests act as that caller. For writable / authenticated hosted use.
+>
+> Multi-wiki hosted deployments are on the roadmap but aren't ready. Don't expose a server to mutually untrusted users with a shared `config.json` token or bot password — that collapses every caller into one wiki identity, with no audit trail and no per-user rate limits.
 
 The server can run as a remote HTTP endpoint for clients that only accept URLs (e.g. hosted LLM chat products).
 
 ## Environment
 
 - `MCP_TRANSPORT=http` — switch to the StreamableHTTP transport (the Dockerfile sets this by default).
-- `PORT` — the port to listen on (defaults to `3000` locally and `8080` in the Docker image).
+- `PORT` — listen port (default `3000` locally, `8080` in Docker).
 
-## Required configuration
+## Shape 1 — Single-wiki, read-only, anonymous
 
 ```json
 {
@@ -27,11 +32,39 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 }
 ```
 
-Exactly one wiki entry, `readOnly: true`, `allowWikiManagement: false`. Together these disable `add-wiki` and `remove-wiki`, and hide the six write tools (`create-page`, `update-page`, `delete-page`, `undelete-page`, `upload-file`, `upload-file-from-url`) from `tools/list`. The result is an anonymous, read-only MCP interface.
+One wiki entry, `readOnly: true`, `allowWikiManagement: false`. This disables `add-wiki` and `remove-wiki`, and hides the six write tools (`create-page`, `update-page`, `delete-page`, `undelete-page`, `upload-file`, `upload-file-from-url`) from `tools/list`. Result: an anonymous, read-only MCP interface.
 
-Do not configure `token`, `username`, or `password`. The server has no per-caller authentication; credentials in the config become shared across every caller that reaches the endpoint — almost always the wrong behaviour for a public deployment.
+Don't set `token`, `username`, or `password` — there's no per-caller authentication in this shape, so static credentials would become shared across every caller.
 
-Place the server behind a reverse proxy that terminates TLS and applies rate limiting. Cloudflare, nginx, and Caddy all work well.
+Place the server behind a reverse proxy that terminates TLS and applies rate limiting. Cloudflare, nginx, and Caddy all work.
+
+## Shape 2 — Single-wiki, per-user OAuth2 bearer passthrough
+
+```json
+{
+  "allowWikiManagement": false,
+  "defaultWiki": "example.org",
+  "wikis": {
+    "example.org": {
+      "sitename": "Example Wiki",
+      "server": "https://example.org",
+      "articlepath": "/wiki",
+      "scriptpath": "/w"
+    }
+  }
+}
+```
+
+One wiki entry, `allowWikiManagement: false`, no static credentials. Each HTTP request carries `Authorization: Bearer <token>`, which the server forwards to MediaWiki as that caller's OAuth2 access token. Writes are attributable to the caller, MediaWiki's per-user rate limits apply, and `tools/list` exposes the full write surface.
+
+See [configuration.md — per-request bearer token](configuration.md#per-request-bearer-token-http-transport) for the header contract, precedence, token acquisition, and trust-boundary details.
+
+Hosted-use notes:
+
+- **No static credentials in `config.json`.** Any `token`, `username`, or `password` here silently serves as a fallback identity when a caller omits the header — usually defeating the point of bearer passthrough.
+- **The server process sees every caller's token in flight.** Treat it as a secret-handling component: avoid verbose error logging, and don't pipe raw error objects into error-tracking services that capture arbitrary fields.
+- **Single wiki only for now.** A bearer is scoped to one MediaWiki OAuth2 realm, and `set-wiki` hasn't been audited for concurrent-caller safety. Multi-wiki bearer deployment is on the roadmap.
+- **Reverse proxy must forward `Authorization` intact** and strip it on untrusted inbound paths. The MCP server trusts any `Authorization: Bearer` header it sees — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements).
 
 ## Docker
 
@@ -42,4 +75,4 @@ docker build -t mediawiki-mcp-server .
 docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" mediawiki-mcp-server
 ```
 
-The image sets `MCP_TRANSPORT=http` and `PORT=8080`, runs as a non-root user, and exposes `/health` for orchestration probes. No image is published to a registry; build from source.
+The image sets `MCP_TRANSPORT=http` and `PORT=8080`, runs as a non-root user, and exposes `/health` for orchestration probes. No image is published; build from source.

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -20,6 +20,8 @@ export interface WikiConfig {
 	scriptpath: string;
 	/**
 	 * OAuth consumer token requested from Extension:OAuth.
+	 * Used as a fallback when no Authorization header is supplied
+	 * by the MCP client on the HTTP request.
 	 */
 	token?: string | null;
 	/**

--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -2,6 +2,7 @@ import { USER_AGENT } from '../server.js';
 import { wikiService } from './wikiService.js';
 import type { WikiConfig } from './config.js';
 import { Mwn, MwnOptions } from 'mwn';
+import { getRuntimeToken } from './requestContext.js';
 
 // Cache the Promise, not the resolved instance, so concurrent first-calls
 // for the same wiki share a single login / getSiteInfo round-trip.
@@ -21,6 +22,11 @@ export async function getMwn( wikiKey?: string ): Promise<Mwn> {
 		( { key, config } = wikiService.getCurrent() );
 	}
 
+	const runtimeToken = getRuntimeToken();
+	if ( runtimeToken ) {
+		return createMwnInstance( config, runtimeToken );
+	}
+
 	let pending = mwnInstances.get( key );
 	if ( !pending ) {
 		pending = createMwnInstance( config );
@@ -34,28 +40,46 @@ export async function getMwn( wikiKey?: string ): Promise<Mwn> {
 	return pending;
 }
 
-async function createMwnInstance( config: Readonly<WikiConfig> ): Promise<Mwn> {
+async function createMwnInstance(
+	config: Readonly<WikiConfig>,
+	runtimeToken?: string
+): Promise<Mwn> {
 	const { server, scriptpath, token, username, password } = config;
+	const effectiveToken = runtimeToken ?? token;
 
 	const options: MwnOptions = {
 		apiUrl: `${ server }${ scriptpath }/api.php`,
 		userAgent: USER_AGENT
 	};
 
-	if ( token ) {
-		options.OAuth2AccessToken = token;
-		return Mwn.init( options );
-	}
+	try {
+		if ( effectiveToken ) {
+			options.OAuth2AccessToken = effectiveToken;
+			return await Mwn.init( options );
+		}
 
-	if ( username && password ) {
-		options.username = username;
-		options.password = password;
-		return Mwn.init( options );
-	}
+		if ( username && password ) {
+			options.username = username;
+			options.password = password;
+			return await Mwn.init( options );
+		}
 
-	const instance = new Mwn( options );
-	await instance.getSiteInfo();
-	return instance;
+		const instance = new Mwn( options );
+		await instance.getSiteInfo();
+		return instance;
+	} catch ( error: unknown ) {
+		if ( error instanceof Error ) {
+			// mwn/axios attach full request config (incl. Authorization header)
+			// to error objects — strip to prevent token leaks in logs/responses
+			delete ( error as unknown as Record<string, unknown> ).request;
+			delete ( error as unknown as Record<string, unknown> ).config;
+			delete ( error as unknown as Record<string, unknown> ).response;
+			if ( effectiveToken && error.message.includes( effectiveToken ) ) {
+				error.message = error.message.replaceAll( effectiveToken, '[REDACTED]' );
+			}
+		}
+		throw error;
+	}
 }
 
 export function removeMwnInstance( wikiKey: string ): void {

--- a/src/common/mwn.ts
+++ b/src/common/mwn.ts
@@ -3,6 +3,7 @@ import { wikiService } from './wikiService.js';
 import type { WikiConfig } from './config.js';
 import { Mwn, MwnOptions } from 'mwn';
 import { getRuntimeToken } from './requestContext.js';
+import { redactAuthorizationHeader, wrapMwnErrors } from './mwnErrorSanitizer.js';
 
 // Cache the Promise, not the resolved instance, so concurrent first-calls
 // for the same wiki share a single login / getSiteInfo round-trip.
@@ -45,41 +46,32 @@ async function createMwnInstance(
 	runtimeToken?: string
 ): Promise<Mwn> {
 	const { server, scriptpath, token, username, password } = config;
-	const effectiveToken = runtimeToken ?? token;
+	const effectiveToken: string | undefined = runtimeToken ?? token ?? undefined;
 
 	const options: MwnOptions = {
 		apiUrl: `${ server }${ scriptpath }/api.php`,
 		userAgent: USER_AGENT
 	};
 
+	let instance: Mwn;
 	try {
 		if ( effectiveToken ) {
 			options.OAuth2AccessToken = effectiveToken;
-			return await Mwn.init( options );
-		}
-
-		if ( username && password ) {
+			instance = await Mwn.init( options );
+		} else if ( username && password ) {
 			options.username = username;
 			options.password = password;
-			return await Mwn.init( options );
+			instance = await Mwn.init( options );
+		} else {
+			instance = new Mwn( options );
+			await instance.getSiteInfo();
 		}
-
-		const instance = new Mwn( options );
-		await instance.getSiteInfo();
-		return instance;
 	} catch ( error: unknown ) {
-		if ( error instanceof Error ) {
-			// mwn/axios attach full request config (incl. Authorization header)
-			// to error objects — strip to prevent token leaks in logs/responses
-			delete ( error as unknown as Record<string, unknown> ).request;
-			delete ( error as unknown as Record<string, unknown> ).config;
-			delete ( error as unknown as Record<string, unknown> ).response;
-			if ( effectiveToken && error.message.includes( effectiveToken ) ) {
-				error.message = error.message.replaceAll( effectiveToken, '[REDACTED]' );
-			}
-		}
+		redactAuthorizationHeader( error, effectiveToken );
 		throw error;
 	}
+
+	return wrapMwnErrors( instance, effectiveToken );
 }
 
 export function removeMwnInstance( wikiKey: string ): void {

--- a/src/common/mwnErrorSanitizer.ts
+++ b/src/common/mwnErrorSanitizer.ts
@@ -1,0 +1,54 @@
+const REDACTED = '[REDACTED]';
+
+function redactHeadersObject( obj: unknown ): void {
+	if ( obj && typeof obj === 'object' ) {
+		const headers = ( obj as Record<string, unknown> ).headers;
+		if ( headers && typeof headers === 'object' && 'Authorization' in headers ) {
+			( headers as Record<string, unknown> ).Authorization = REDACTED;
+		}
+	}
+}
+
+export function redactAuthorizationHeader( err: unknown, token?: string ): void {
+	if ( !( err instanceof Error ) ) {
+		return;
+	}
+	const e = err as unknown as Record<string, unknown>;
+	redactHeadersObject( e.request );
+	redactHeadersObject( e.config );
+	if ( e.response && typeof e.response === 'object' ) {
+		redactHeadersObject( ( e.response as Record<string, unknown> ).config );
+	}
+	if ( token && typeof err.message === 'string' && err.message.includes( token ) ) {
+		err.message = err.message.replaceAll( token, REDACTED );
+	}
+}
+
+export function wrapMwnErrors<T extends object>( target: T, token?: string ): T {
+	return new Proxy( target, {
+		get( obj, prop, receiver ): unknown {
+			const value = Reflect.get( obj, prop, receiver );
+			if ( typeof value !== 'function' ) {
+				return value;
+			}
+			return function ( this: unknown, ...args: unknown[] ): unknown {
+				try {
+					const result = ( value as ( ...a: unknown[] ) => unknown ).apply(
+						this === receiver ? obj : this,
+						args
+					);
+					if ( result && typeof ( result as Promise<unknown> ).then === 'function' ) {
+						return ( result as Promise<unknown> ).catch( ( err: unknown ) => {
+							redactAuthorizationHeader( err, token );
+							throw err;
+						} );
+					}
+					return result;
+				} catch ( err ) {
+					redactAuthorizationHeader( err, token );
+					throw err;
+				}
+			};
+		}
+	} );
+}

--- a/src/common/mwnErrorSanitizer.ts
+++ b/src/common/mwnErrorSanitizer.ts
@@ -1,10 +1,18 @@
 const REDACTED = '[REDACTED]';
 
+const SENSITIVE_HEADER_PATTERN = /^(?:proxy-)?authorization$/i;
+
 function redactHeadersObject( obj: unknown ): void {
-	if ( obj && typeof obj === 'object' ) {
-		const headers = ( obj as Record<string, unknown> ).headers;
-		if ( headers && typeof headers === 'object' && 'Authorization' in headers ) {
-			( headers as Record<string, unknown> ).Authorization = REDACTED;
+	if ( !obj || typeof obj !== 'object' ) {
+		return;
+	}
+	const headers = ( obj as Record<string, unknown> ).headers;
+	if ( !headers || typeof headers !== 'object' ) {
+		return;
+	}
+	for ( const key of Object.keys( headers ) ) {
+		if ( SENSITIVE_HEADER_PATTERN.test( key ) ) {
+			( headers as Record<string, unknown> )[ key ] = REDACTED;
 		}
 	}
 }
@@ -19,8 +27,13 @@ export function redactAuthorizationHeader( err: unknown, token?: string ): void 
 	if ( e.response && typeof e.response === 'object' ) {
 		redactHeadersObject( ( e.response as Record<string, unknown> ).config );
 	}
+	// replaceAll with a string pattern does literal (non-regex) replacement —
+	// do not "refactor" this to a RegExp, which would misbehave on special chars in the token.
 	if ( token && typeof err.message === 'string' && err.message.includes( token ) ) {
 		err.message = err.message.replaceAll( token, REDACTED );
+	}
+	if ( token && typeof err.stack === 'string' && err.stack.includes( token ) ) {
+		err.stack = err.stack.replaceAll( token, REDACTED );
 	}
 }
 

--- a/src/common/mwnErrorSanitizer.ts
+++ b/src/common/mwnErrorSanitizer.ts
@@ -37,6 +37,42 @@ export function redactAuthorizationHeader( err: unknown, token?: string ): void 
 	}
 }
 
+function isAsyncIterable( value: unknown ): value is AsyncIterable<unknown> {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		typeof ( value as AsyncIterable<unknown> )[ Symbol.asyncIterator ] === 'function'
+	);
+}
+
+// Wrap an async iterable (e.g. mwn's *Gen methods, which return AsyncGenerators
+// — both iterable and iterator) so rejections from .next() / .return() / .throw()
+// during iteration go through the same redaction path as rejections from
+// Promise-returning methods.
+function wrapAsyncIterable<T>(
+	iter: AsyncIterable<T>,
+	token: string | undefined
+): AsyncIterableIterator<T> {
+	const inner = iter[ Symbol.asyncIterator ]();
+	const sanitise = <R>( p: Promise<R> ): Promise<R> => p.catch( ( err: unknown ) => {
+		redactAuthorizationHeader( err, token );
+		throw err;
+	} );
+	const wrapped: AsyncIterableIterator<T> = {
+		[ Symbol.asyncIterator ](): AsyncIterableIterator<T> {
+			return wrapped;
+		},
+		next: ( ...args ) => sanitise( inner.next( ...args ) ),
+		return: inner.return ?
+			( value ) => sanitise( inner.return!( value ) ) :
+			undefined,
+		throw: inner.throw ?
+			( e ) => sanitise( inner.throw!( e ) ) :
+			undefined
+	};
+	return wrapped;
+}
+
 export function wrapMwnErrors<T extends object>( target: T, token?: string ): T {
 	return new Proxy( target, {
 		get( obj, prop, receiver ): unknown {
@@ -55,6 +91,9 @@ export function wrapMwnErrors<T extends object>( target: T, token?: string ): T 
 							redactAuthorizationHeader( err, token );
 							throw err;
 						} );
+					}
+					if ( isAsyncIterable( result ) ) {
+						return wrapAsyncIterable( result, token );
 					}
 					return result;
 				} catch ( err ) {

--- a/src/common/requestContext.ts
+++ b/src/common/requestContext.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestContext {
+	runtimeToken?: string;
+}
+
+export const runtimeTokenStore = new AsyncLocalStorage<RequestContext>();
+
+export function getRuntimeToken(): string | undefined {
+	return runtimeTokenStore.getStore()?.runtimeToken;
+}

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -9,12 +9,17 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { createServer } from './server.js';
 import { runtimeTokenStore } from './common/requestContext.js';
 
-function extractBearerToken( req: Request ): string | undefined {
-	const auth = req.headers.authorization;
-	if ( typeof auth === 'string' && auth.toLowerCase().startsWith( 'bearer ' ) ) {
-		return auth.slice( 7 );
+export function extractBearerToken( req: Request ): string | undefined {
+	const raw = req.headers.authorization;
+	if ( typeof raw !== 'string' ) {
+		return undefined;
 	}
-	return undefined;
+	const first = raw.split( ',' )[ 0 ].trim();
+	if ( !first.toLowerCase().startsWith( 'bearer ' ) ) {
+		return undefined;
+	}
+	const token = first.slice( 7 ).trim();
+	return token || undefined;
 }
 
 const app = express();

--- a/src/streamableHttp.ts
+++ b/src/streamableHttp.ts
@@ -7,6 +7,15 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { createServer } from './server.js';
+import { runtimeTokenStore } from './common/requestContext.js';
+
+function extractBearerToken( req: Request ): string | undefined {
+	const auth = req.headers.authorization;
+	if ( typeof auth === 'string' && auth.toLowerCase().startsWith( 'bearer ' ) ) {
+		return auth.slice( 7 );
+	}
+	return undefined;
+}
 
 const app = express();
 app.use( express.json() );
@@ -47,7 +56,10 @@ app.post( '/mcp', async ( req: Request, res: Response ) => {
 		return;
 	}
 
-	await transport.handleRequest( req, res, req.body );
+	const runtimeToken = extractBearerToken( req );
+	await runtimeTokenStore.run( { runtimeToken }, () =>
+		transport.handleRequest( req, res, req.body )
+	);
 } );
 
 const handleSessionRequest = async ( req: Request, res: Response ): Promise<void> => {
@@ -58,7 +70,10 @@ const handleSessionRequest = async ( req: Request, res: Response ): Promise<void
 	}
 
 	const transport = transports[ sessionId ];
-	await transport.handleRequest( req, res );
+	const runtimeToken = extractBearerToken( req );
+	await runtimeTokenStore.run( { runtimeToken }, () =>
+		transport.handleRequest( req, res )
+	);
 };
 
 app.get( '/mcp', handleSessionRequest );

--- a/tests/common/mwn.test.ts
+++ b/tests/common/mwn.test.ts
@@ -192,7 +192,8 @@ describe( 'mwn instance management', () => {
 
 		const result = await getMwn();
 
-		expect( result ).toBe( oauthInstance );
+		// Instance is wrapped in a token-redacting Proxy; structural equality holds.
+		expect( result ).toEqual( oauthInstance );
 		expect( mockInit ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				OAuth2AccessToken: 'my-oauth-token'
@@ -212,7 +213,7 @@ describe( 'mwn instance management', () => {
 
 		const result = await getMwn();
 
-		expect( result ).toBe( loginInstance );
+		expect( result ).toEqual( loginInstance );
 		expect( mockInit ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				username: 'user',
@@ -267,7 +268,7 @@ describe( 'runtime token', () => {
 
 		const result = await getMwn();
 
-		expect( result ).toBe( oauthInstance );
+		expect( result ).toEqual( oauthInstance );
 		expect( mockInit ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				OAuth2AccessToken: 'runtime-token-X'
@@ -282,7 +283,7 @@ describe( 'runtime token', () => {
 
 		const result = await getMwn();
 
-		expect( result ).toBe( oauthInstance );
+		expect( result ).toEqual( oauthInstance );
 		expect( mockInit ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				OAuth2AccessToken: 'runtime-token-Y'
@@ -301,7 +302,7 @@ describe( 'runtime token', () => {
 
 		const result = await getMwn();
 
-		expect( result ).toBe( oauthInstance );
+		expect( result ).toEqual( oauthInstance );
 		expect( mockInit ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				OAuth2AccessToken: 'config-token'
@@ -350,12 +351,15 @@ describe( 'runtime token', () => {
 		await expect( getMwn() ).rejects.not.toThrow( /secret-token-123/ );
 	} );
 
-	it( 'strips request, config, and response from error objects', async () => {
+	it( 'redacts Authorization headers on request, config, and response of error objects', async () => {
 		const err = new Error( 'connection failed' );
 		( err as Record<string, unknown> ).request = {
 			headers: { Authorization: 'Bearer secret' }
 		};
-		( err as Record<string, unknown> ).config = { url: 'https://...' };
+		( err as Record<string, unknown> ).config = {
+			url: 'https://...',
+			headers: { Authorization: 'Bearer secret' }
+		};
 		( err as Record<string, unknown> ).response = {
 			config: { headers: { Authorization: 'Bearer secret' } }
 		};
@@ -367,9 +371,68 @@ describe( 'runtime token', () => {
 			await getMwn();
 			expect.unreachable( 'should have thrown' );
 		} catch ( caught ) {
-			expect( ( caught as Record<string, unknown> ).request ).toBeUndefined();
-			expect( ( caught as Record<string, unknown> ).config ).toBeUndefined();
-			expect( ( caught as Record<string, unknown> ).response ).toBeUndefined();
+			const c = caught as {
+				request: { headers: Record<string, string> };
+				config: { headers: Record<string, string> };
+				response: { config: { headers: Record<string, string> } };
+			};
+			expect( c.request.headers.Authorization ).toBe( '[REDACTED]' );
+			expect( c.config.headers.Authorization ).toBe( '[REDACTED]' );
+			expect( c.response.config.headers.Authorization ).toBe( '[REDACTED]' );
 		}
+	} );
+} );
+
+describe( 'post-init error redaction', () => {
+	beforeEach( async () => {
+		vi.resetModules();
+		mockInit.mockReset();
+		mockConstructor.mockReset();
+		mockGetSiteInfo.mockReset();
+		currentWikiKey = 'wiki-a';
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w'
+		};
+		const mwnModule = await import( '../../src/common/mwn.js' );
+		getMwn = mwnModule.getMwn;
+		removeMwnInstance = mwnModule.removeMwnInstance;
+		const ctx = await import( '../../src/common/requestContext.js' );
+		setRuntimeToken = ( ctx as unknown as { _setRuntimeToken: typeof setRuntimeToken } )._setRuntimeToken;
+		setRuntimeToken( undefined );
+	} );
+
+	it( 'redacts Authorization on errors thrown by mwn methods after init', async () => {
+		const save = vi.fn().mockRejectedValue(
+			Object.assign( new Error( 'bad token' ), {
+				request: { headers: { Authorization: 'Bearer runtime-secret' } }
+			} )
+		);
+		mockInit.mockResolvedValueOnce( { save, id: 'wiki-a' } );
+		setRuntimeToken( 'runtime-secret' );
+
+		const instance = await getMwn();
+		await expect( ( instance as unknown as { save: () => Promise<unknown> } ).save() )
+			.rejects.toMatchObject( {
+				request: { headers: { Authorization: '[REDACTED]' } }
+			} );
+	} );
+
+	it( 'redacts token substrings and Authorization in init-time error messages', async () => {
+		mockInit.mockRejectedValueOnce(
+			Object.assign( new Error( 'init failed for Bearer init-secret' ), {
+				config: { headers: { Authorization: 'Bearer init-secret' } }
+			} )
+		);
+		setRuntimeToken( 'init-secret' );
+
+		const rejection = getMwn();
+		await expect( rejection ).rejects.toMatchObject( {
+			config: { headers: { Authorization: '[REDACTED]' } }
+		} );
+		await rejection.catch( ( err: Error ) => {
+			expect( err.message ).toContain( '[REDACTED]' );
+			expect( err.message ).not.toContain( 'init-secret' );
+		} );
 	} );
 } );

--- a/tests/common/mwn.test.ts
+++ b/tests/common/mwn.test.ts
@@ -22,6 +22,16 @@ vi.mock( '../../src/server.js', () => ( {
 	USER_AGENT: 'test-agent'
 } ) );
 
+vi.mock( '../../src/common/requestContext.js', () => {
+	let token: string | undefined;
+	return {
+		getRuntimeToken: () => token,
+		_setRuntimeToken: ( t: string | undefined ) => {
+			token = t;
+		}
+	};
+} );
+
 let currentWikiKey = 'wiki-a';
 let currentWikiConfig: Record<string, unknown> = {
 	server: 'https://wiki-a.example.com',
@@ -39,6 +49,7 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 
 let getMwn: typeof import( '../../src/common/mwn.js' ).getMwn;
 let removeMwnInstance: typeof import( '../../src/common/mwn.js' ).removeMwnInstance;
+let setRuntimeToken: ( t: string | undefined ) => void;
 
 describe( 'mwn instance management', () => {
 
@@ -57,6 +68,10 @@ describe( 'mwn instance management', () => {
 		const mwnModule = await import( '../../src/common/mwn.js' );
 		getMwn = mwnModule.getMwn;
 		removeMwnInstance = mwnModule.removeMwnInstance;
+
+		const contextModule = await import( '../../src/common/requestContext.js' );
+		setRuntimeToken = ( contextModule as unknown as { _setRuntimeToken: ( t: string | undefined ) => void } )._setRuntimeToken;
+		setRuntimeToken( undefined );
 	} );
 
 	it( 'returns cached instance for same wiki key', async () => {
@@ -214,5 +229,147 @@ describe( 'mwn instance management', () => {
 		expect( result ).toBeDefined();
 		expect( mockInit ).not.toHaveBeenCalled();
 		expect( mockGetSiteInfo ).toHaveBeenCalledOnce();
+	} );
+} );
+
+describe( 'runtime token', () => {
+
+	beforeEach( async () => {
+		vi.resetModules();
+		mockInit.mockReset();
+		mockConstructor.mockReset();
+		mockGetSiteInfo.mockReset();
+
+		currentWikiKey = 'wiki-a';
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w'
+		};
+
+		const mwnModule = await import( '../../src/common/mwn.js' );
+		getMwn = mwnModule.getMwn;
+		removeMwnInstance = mwnModule.removeMwnInstance;
+
+		const contextModule = await import( '../../src/common/requestContext.js' );
+		setRuntimeToken = ( contextModule as unknown as { _setRuntimeToken: ( t: string | undefined ) => void } )._setRuntimeToken;
+		setRuntimeToken( undefined );
+	} );
+
+	it( 'uses runtime token over config token', async () => {
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w',
+			token: 'config-fallback'
+		};
+		const oauthInstance = { id: 'runtime' };
+		mockInit.mockResolvedValue( oauthInstance );
+		setRuntimeToken( 'runtime-token-X' );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'runtime-token-X'
+			} )
+		);
+	} );
+
+	it( 'uses runtime token when config has no credentials', async () => {
+		const oauthInstance = { id: 'runtime-no-config' };
+		mockInit.mockResolvedValue( oauthInstance );
+		setRuntimeToken( 'runtime-token-Y' );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'runtime-token-Y'
+			} )
+		);
+	} );
+
+	it( 'falls back to config token when no runtime token', async () => {
+		currentWikiConfig = {
+			server: 'https://wiki-a.example.com',
+			scriptpath: '/w',
+			token: 'config-token'
+		};
+		const oauthInstance = { id: 'config' };
+		mockInit.mockResolvedValue( oauthInstance );
+
+		const result = await getMwn();
+
+		expect( result ).toBe( oauthInstance );
+		expect( mockInit ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				OAuth2AccessToken: 'config-token'
+			} )
+		);
+	} );
+
+	it( 'does not cache runtime-token instances', async () => {
+		mockInit.mockResolvedValue( { id: 'first' } );
+		setRuntimeToken( 'same-token' );
+
+		await getMwn();
+
+		mockInit.mockResolvedValue( { id: 'second' } );
+
+		const second = await getMwn();
+
+		expect( second ).toEqual( { id: 'second' } );
+		expect( mockInit ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'runtime-token calls do not pollute the config cache', async () => {
+		mockGetSiteInfo.mockResolvedValue( undefined );
+
+		// First: anonymous (cached)
+		const anon = await getMwn();
+
+		// Second: runtime token (should not affect cache)
+		mockInit.mockResolvedValue( { id: 'runtime' } );
+		setRuntimeToken( 'runtime-token-Z' );
+		await getMwn();
+
+		// Third: back to anonymous (should be cache hit)
+		setRuntimeToken( undefined );
+		const anonAgain = await getMwn();
+
+		expect( anonAgain ).toBe( anon );
+		expect( mockConstructor ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'redacts token from error message', async () => {
+		setRuntimeToken( 'secret-token-123' );
+		mockInit.mockRejectedValue( new Error( 'OAuth failed: secret-token-123 is invalid' ) );
+
+		await expect( getMwn() ).rejects.toThrow( /\[REDACTED\]/ );
+		await expect( getMwn() ).rejects.not.toThrow( /secret-token-123/ );
+	} );
+
+	it( 'strips request, config, and response from error objects', async () => {
+		const err = new Error( 'connection failed' );
+		( err as Record<string, unknown> ).request = {
+			headers: { Authorization: 'Bearer secret' }
+		};
+		( err as Record<string, unknown> ).config = { url: 'https://...' };
+		( err as Record<string, unknown> ).response = {
+			config: { headers: { Authorization: 'Bearer secret' } }
+		};
+
+		setRuntimeToken( 'secret' );
+		mockInit.mockRejectedValue( err );
+
+		try {
+			await getMwn();
+			expect.unreachable( 'should have thrown' );
+		} catch ( caught ) {
+			expect( ( caught as Record<string, unknown> ).request ).toBeUndefined();
+			expect( ( caught as Record<string, unknown> ).config ).toBeUndefined();
+			expect( ( caught as Record<string, unknown> ).response ).toBeUndefined();
+		}
 	} );
 } );

--- a/tests/common/mwn.test.ts
+++ b/tests/common/mwn.test.ts
@@ -22,14 +22,9 @@ vi.mock( '../../src/server.js', () => ( {
 	USER_AGENT: 'test-agent'
 } ) );
 
-vi.mock( '../../src/common/requestContext.js', () => {
-	let token: string | undefined;
-	return {
-		getRuntimeToken: () => token,
-		_setRuntimeToken: ( t: string | undefined ) => {
-			token = t;
-		}
-	};
+vi.mock( '../../src/common/requestContext.js', async () => {
+	const { createRuntimeTokenMock } = await import( '../helpers/runtime-context.js' );
+	return createRuntimeTokenMock();
 } );
 
 let currentWikiKey = 'wiki-a';

--- a/tests/common/mwnErrorSanitizer.test.ts
+++ b/tests/common/mwnErrorSanitizer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import { redactAuthorizationHeader, wrapMwnErrors } from '../../src/common/mwnErrorSanitizer.js';
+
+describe( 'redactAuthorizationHeader', () => {
+	it( 'redacts Authorization on .request.headers but preserves other fields', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			request: {
+				method: 'POST',
+				path: '/w/api.php',
+				headers: { Authorization: 'Bearer secret123', 'User-Agent': 'x' }
+			}
+		} );
+		redactAuthorizationHeader( err );
+		expect( ( err as any ).request.headers.Authorization ).toBe( '[REDACTED]' );
+		expect( ( err as any ).request.headers[ 'User-Agent' ] ).toBe( 'x' );
+		expect( ( err as any ).request.method ).toBe( 'POST' );
+		expect( ( err as any ).request.path ).toBe( '/w/api.php' );
+	} );
+
+	it( 'redacts Authorization on .config.headers', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			config: { headers: { Authorization: 'Bearer secret123' } }
+		} );
+		redactAuthorizationHeader( err );
+		expect( ( err as any ).config.headers.Authorization ).toBe( '[REDACTED]' );
+	} );
+
+	it( 'redacts Authorization on .response.config.headers if present', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			response: {
+				status: 500,
+				config: { headers: { Authorization: 'Bearer secret123' } }
+			}
+		} );
+		redactAuthorizationHeader( err );
+		expect( ( err as any ).response.config.headers.Authorization ).toBe( '[REDACTED]' );
+		expect( ( err as any ).response.status ).toBe( 500 );
+	} );
+
+	it( 'redacts token substring in error message when token is supplied', () => {
+		const err = new Error( 'failed with token Bearer secret123 somewhere' );
+		redactAuthorizationHeader( err, 'secret123' );
+		expect( err.message ).toBe( 'failed with token Bearer [REDACTED] somewhere' );
+	} );
+
+	it( 'does nothing when no Authorization header present', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			request: { method: 'GET', headers: { 'User-Agent': 'x' } }
+		} );
+		redactAuthorizationHeader( err );
+		expect( ( err as any ).request.headers[ 'User-Agent' ] ).toBe( 'x' );
+	} );
+
+	it( 'is a no-op for non-Error inputs', () => {
+		expect( () => redactAuthorizationHeader( null ) ).not.toThrow();
+		expect( () => redactAuthorizationHeader( 'string' ) ).not.toThrow();
+		expect( () => redactAuthorizationHeader( { headers: {} } ) ).not.toThrow();
+	} );
+} );
+
+describe( 'wrapMwnErrors', () => {
+	it( 'redacts Authorization on errors thrown by async methods', async () => {
+		const target = {
+			request: vi.fn().mockRejectedValue(
+				Object.assign( new Error( 'api error' ), {
+					request: { headers: { Authorization: 'Bearer secret123' } }
+				} )
+			)
+		};
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+		await expect( wrapped.request() ).rejects.toMatchObject( {
+			message: 'api error',
+			request: { headers: { Authorization: '[REDACTED]' } }
+		} );
+	} );
+
+	it( 'redacts Authorization on errors thrown by sync methods', () => {
+		const target = {
+			syncFail: vi.fn( () => {
+				throw Object.assign( new Error( 'sync' ), {
+					request: { headers: { Authorization: 'Bearer secret123' } }
+				} );
+			} )
+		};
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+		expect( () => wrapped.syncFail() ).toThrow( 'sync' );
+		try {
+			wrapped.syncFail();
+		} catch ( e ) {
+			expect( ( e as any ).request.headers.Authorization ).toBe( '[REDACTED]' );
+		}
+	} );
+
+	it( 'redacts token substrings in message when token supplied', async () => {
+		const target = {
+			request: vi.fn().mockRejectedValue( new Error( 'fail with Bearer secret123' ) )
+		};
+		const wrapped = wrapMwnErrors( target, 'secret123' ) as typeof target;
+		await expect( wrapped.request() ).rejects.toThrow( 'fail with Bearer [REDACTED]' );
+	} );
+
+	it( 'passes through non-function property access unchanged', () => {
+		const target = {
+			cookieJar: null,
+			Category: { members: vi.fn() }
+		};
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+		expect( wrapped.cookieJar ).toBeNull();
+		expect( wrapped.Category ).toBe( target.Category );
+	} );
+
+	it( 'preserves this binding for methods that call other methods', async () => {
+		const target = {
+			inner: vi.fn().mockResolvedValue( 'ok' ),
+			outer() {
+				return ( this as any ).inner();
+			}
+		};
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+		await expect( wrapped.outer() ).resolves.toBe( 'ok' );
+	} );
+
+	it( 'passes through successful return values', async () => {
+		const target = { request: vi.fn().mockResolvedValue( { ok: true } ) };
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+		await expect( wrapped.request() ).resolves.toEqual( { ok: true } );
+	} );
+} );

--- a/tests/common/mwnErrorSanitizer.test.ts
+++ b/tests/common/mwnErrorSanitizer.test.ts
@@ -56,6 +56,30 @@ describe( 'redactAuthorizationHeader', () => {
 		expect( () => redactAuthorizationHeader( 'string' ) ).not.toThrow();
 		expect( () => redactAuthorizationHeader( { headers: {} } ) ).not.toThrow();
 	} );
+
+	it( 'redacts lowercase authorization header (axios-normalised)', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			config: { headers: { authorization: 'Bearer secret123' } }
+		} );
+		redactAuthorizationHeader( err );
+		expect( ( err as any ).config.headers.authorization ).toBe( '[REDACTED]' );
+	} );
+
+	it( 'keeps the Authorization field present (redacts, does not delete)', () => {
+		const err = Object.assign( new Error( 'boom' ), {
+			request: { headers: { Authorization: 'Bearer secret123' } }
+		} );
+		redactAuthorizationHeader( err );
+		expect( 'Authorization' in ( err as any ).request.headers ).toBe( true );
+		expect( ( err as any ).request.headers.Authorization ).toBe( '[REDACTED]' );
+	} );
+
+	it( 'redacts token substring in err.stack when token supplied', () => {
+		const err = new Error( 'plain' );
+		err.stack = 'Error: something went wrong with Bearer secret123\n    at X';
+		redactAuthorizationHeader( err, 'secret123' );
+		expect( err.stack ).toBe( 'Error: something went wrong with Bearer [REDACTED]\n    at X' );
+	} );
 } );
 
 describe( 'wrapMwnErrors', () => {

--- a/tests/common/mwnErrorSanitizer.test.ts
+++ b/tests/common/mwnErrorSanitizer.test.ts
@@ -149,4 +149,58 @@ describe( 'wrapMwnErrors', () => {
 		const wrapped = wrapMwnErrors( target ) as typeof target;
 		await expect( wrapped.request() ).resolves.toEqual( { ok: true } );
 	} );
+
+	it( 'redacts Authorization on errors thrown during async iteration', async () => {
+		async function* failing(): AsyncGenerator<{ page: string }> {
+			yield { page: 'first' };
+			throw Object.assign( new Error( 'page fetch failed' ), {
+				request: { headers: { Authorization: 'Bearer secret123' } }
+			} );
+		}
+		const target = { readGen: vi.fn( () => failing() ) };
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+
+		const iter = wrapped.readGen();
+		await expect( iter.next() ).resolves.toEqual( { value: { page: 'first' }, done: false } );
+		await expect( iter.next() ).rejects.toMatchObject( {
+			request: { headers: { Authorization: '[REDACTED]' } }
+		} );
+	} );
+
+	it( 'passes through normal async iteration values unchanged', async () => {
+		async function* ok(): AsyncGenerator<number> {
+			yield 1;
+			yield 2;
+			yield 3;
+		}
+		const target = { gen: vi.fn( () => ok() ) };
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+
+		const results: number[] = [];
+		for await ( const v of wrapped.gen() ) {
+			results.push( v );
+		}
+		expect( results ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	it( 'forwards return() to the underlying iterator for early termination cleanup', async () => {
+		let cleanedUp = false;
+		async function* withCleanup(): AsyncGenerator<number> {
+			try {
+				yield 1;
+				yield 2;
+			} finally {
+				cleanedUp = true;
+			}
+		}
+		const target = { gen: vi.fn( () => withCleanup() ) };
+		const wrapped = wrapMwnErrors( target ) as typeof target;
+
+		for await ( const v of wrapped.gen() ) {
+			if ( v === 1 ) {
+				break;
+			}
+		}
+		expect( cleanedUp ).toBe( true );
+	} );
 } );

--- a/tests/common/requestContext.test.ts
+++ b/tests/common/requestContext.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { runtimeTokenStore, getRuntimeToken } from '../../src/common/requestContext.js';
+
+describe( 'requestContext', () => {
+
+	it( 'returns undefined outside a run', () => {
+		expect( getRuntimeToken() ).toBeUndefined();
+	} );
+
+	it( 'returns the token inside a run', () => {
+		runtimeTokenStore.run( { runtimeToken: 'abc' }, () => {
+			expect( getRuntimeToken() ).toBe( 'abc' );
+		} );
+	} );
+
+	it( 'returns undefined when runtimeToken is not set in the context', () => {
+		runtimeTokenStore.run( {}, () => {
+			expect( getRuntimeToken() ).toBeUndefined();
+		} );
+	} );
+
+	it( 'inner run overrides outer token', () => {
+		runtimeTokenStore.run( { runtimeToken: 'outer' }, () => {
+			expect( getRuntimeToken() ).toBe( 'outer' );
+			runtimeTokenStore.run( { runtimeToken: 'inner' }, () => {
+				expect( getRuntimeToken() ).toBe( 'inner' );
+			} );
+			expect( getRuntimeToken() ).toBe( 'outer' );
+		} );
+	} );
+
+	it( 'isolates concurrent runs', async () => {
+		const results: string[] = [];
+
+		await Promise.all( [
+			runtimeTokenStore.run( { runtimeToken: 'token-a' }, async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+				results.push( `a:${ getRuntimeToken() }` );
+			} ),
+			runtimeTokenStore.run( { runtimeToken: 'token-b' }, async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 5 ) );
+				results.push( `b:${ getRuntimeToken() }` );
+			} )
+		] );
+
+		expect( results ).toContain( 'a:token-a' );
+		expect( results ).toContain( 'b:token-b' );
+	} );
+
+} );

--- a/tests/common/streamableHttp.test.ts
+++ b/tests/common/streamableHttp.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import type { Request } from 'express';
+import { extractBearerToken } from '../../src/streamableHttp.js';
+
+function req( authorization: string | undefined ): Request {
+	return { headers: { authorization } } as unknown as Request;
+}
+
+describe( 'extractBearerToken', () => {
+	it( 'returns the token for a standard Bearer header', () => {
+		expect( extractBearerToken( req( 'Bearer abc123' ) ) ).toBe( 'abc123' );
+	} );
+	it( 'is case-insensitive on the scheme', () => {
+		expect( extractBearerToken( req( 'bearer abc123' ) ) ).toBe( 'abc123' );
+		expect( extractBearerToken( req( 'BEARER abc123' ) ) ).toBe( 'abc123' );
+	} );
+	it( 'trims whitespace around the token', () => {
+		expect( extractBearerToken( req( 'Bearer   abc123  ' ) ) ).toBe( 'abc123' );
+	} );
+	it( 'returns undefined for whitespace-only tokens', () => {
+		expect( extractBearerToken( req( 'Bearer   \t' ) ) ).toBeUndefined();
+		expect( extractBearerToken( req( 'Bearer ' ) ) ).toBeUndefined();
+	} );
+	it( 'returns undefined when header is missing', () => {
+		expect( extractBearerToken( req( undefined ) ) ).toBeUndefined();
+	} );
+	it( 'returns undefined for non-Bearer schemes', () => {
+		expect( extractBearerToken( req( 'Basic xyz' ) ) ).toBeUndefined();
+		expect( extractBearerToken( req( 'Digest xyz' ) ) ).toBeUndefined();
+	} );
+	it( 'takes the first well-formed value from comma-joined duplicate headers', () => {
+		expect( extractBearerToken( req( 'Bearer abc, Bearer def' ) ) ).toBe( 'abc' );
+	} );
+	it( 'returns undefined if the first comma-joined value is not Bearer', () => {
+		expect( extractBearerToken( req( ', Bearer abc' ) ) ).toBeUndefined();
+		expect( extractBearerToken( req( 'Basic xyz, Bearer abc' ) ) ).toBeUndefined();
+	} );
+} );

--- a/tests/helpers/runtime-context.ts
+++ b/tests/helpers/runtime-context.ts
@@ -1,0 +1,12 @@
+export function createRuntimeTokenMock(): {
+	getRuntimeToken: () => string | undefined;
+	_setRuntimeToken: ( t: string | undefined ) => void;
+} {
+	let token: string | undefined;
+	return {
+		getRuntimeToken: (): string | undefined => token,
+		_setRuntimeToken: ( t: string | undefined ): void => {
+			token = t;
+		}
+	};
+}


### PR DESCRIPTION
## Summary

Allows HTTP-transport clients to send their own `Authorization: Bearer <token>` header; the server forwards it to MediaWiki via `AsyncLocalStorage` so each request acts as that client's wiki identity. Falls back to `config.json` credentials (or anonymous) when no header is sent. stdio transport unchanged.

Unblocks hosted / multi-user deployment — each user now has their own wiki identity rather than sharing a single `config.json` bot account (#273).

## What's in this PR

The feature landed in two stages on the `oauth2-multi` integration branch:

1. **Core feature** (originally #281): AsyncLocalStorage-based token propagation, per-request Mwn instances that bypass the cache, `Authorization: Bearer` header parsing in the Streamable HTTP transport, and user-facing docs.
2. **Security hardening follow-ups** addressing https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/281#issuecomment-4305085128:
   - Sanitising `Proxy` around every returned `Mwn` instance that redacts `Authorization` / `Proxy-Authorization` on thrown errors (`.request` / `.config` / `.response.config`), redacts token substrings in `.message` and `.stack`, and covers mwn's async-generator methods (`readGen` / `continuedQueryGen` / `massQueryGen`).
   - Hardened `extractBearerToken` — trims whitespace, handles comma-joined duplicate headers by taking the first well-formed value, rejects malformed / non-Bearer input.
   - Docs reframed to lead with the OAuth 2.1 header contract per the MCP authorization spec; Claude Code demoted from the leading frame to one illustrative example; explicit trust-boundary note added; paragraph explaining the architectural choice to use MediaWiki's OAuth realm directly rather than advertising a distinct MCP resource-server metadata endpoint.
   - `docs/deployment.md` split into two supported shapes — **Shape 1: single-wiki, read-only, anonymous** (existing recipe) and **Shape 2: single-wiki, per-user OAuth2 bearer passthrough** (new). Shape 2 reuses the hardening and cross-links to `configuration.md`. Multi-wiki hosted remains on the roadmap.
   - Test helper `createRuntimeTokenMock()` extracted into `tests/helpers/` to match the existing `createMockMwn()` pattern.

## Changes

- 3 new src files (`src/common/mwnErrorSanitizer.ts`, `src/common/requestContext.ts`, runtime handling in `src/common/mwn.ts` / `src/streamableHttp.ts`)
- 3 new test files + expansions to existing tests (+28 new tests, 221 passing in total)
- Docs updated in `README.md`, `docs/configuration.md`, and `docs/deployment.md`
- Fully backward-compatible — existing `config.json` auth paths unchanged when no header is sent

## Test plan

- [x] Unit tests: 221 passing, lint clean, build clean, preflight green
- [x] Live passthrough verified against a real wiki — bearer from HTTP header propagates to MediaWiki, requests act as the header's user
- [x] Live leak tests verified — 6 header shapes tested (plain Bearer, comma-joined with canary in first/second value, whitespace-only, regex-special characters in token, upper-case scheme): zero token leakage in responses or server stderr
- [x] Live 401 from MediaWiki verified — error surfaced to the client does not contain the invalid token

## Known limitations / deferred

- Not strictly MCP-spec-compliant: uses MediaWiki's OAuth realm directly rather than advertising a distinct MCP OAuth resource server (`/.well-known/oauth-protected-resource`). Documented in `docs/configuration.md`. A future compliant-mode PR could layer a distinct MCP audience on top.
- Multi-wiki hosted deployment with bearer passthrough — a bearer is scoped to one MediaWiki OAuth2 realm, and `set-wiki` hasn't been audited for concurrent-caller safety. Documented in `docs/deployment.md`.
- Minor review suggestions deferred for follow-ups: walk `err.cause` chains for ES2022 wrapped errors, reject whitespace-inside-token (`Bearer abc def`), add a one-line comment explaining when the comma-split branch triggers.