### PR TITLE
Add byte-based content truncation for read tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | Name | Description | Default |
 |---|---|---|
 | `CONFIG` | Path to your configuration file | `config.json` |
+| `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -101,12 +101,15 @@ Parameter descriptions must:
 
 #### Result caps and truncation signaling
 
-Tools that return variable-size result sets have a per-call cap. When the cap is hit, the tool appends a trailing text block to `content` describing the truncation. Two shapes:
+Tools that return variable-size result sets or content bodies have a per-call cap. When the cap is hit, the tool appends a trailing text block to `content` describing the truncation. Three shapes:
 
 - **With continuation** (the caller can fetch more): `"More results available. Returned N <items>. To fetch the next segment, call <tool-name> again with <param>=<value>."`
 - **Without continuation** (the only remedy is a narrower query): `"Result capped at N <items>. Additional <items> may exist — <narrow-hint>."`
+- **Content truncated** (the response body exceeded the byte budget): `"Content truncated at N of M bytes. [Available sections: 0 (Lead), 1 (<heading>), ....] <remedy>"` where `<remedy>` is a full sentence of the form `"To <purpose>, <action>."` (e.g. `"To read a specific section, call get-page again with section=N."`), matching the connector-phrase pattern used by the `more-available` shape.
 
 Descriptions for these tools state the cap explicitly. If continuation is supported, descriptions reference the continuation parameter by name so the LLM can pick the right parameter without inspecting the schema.
+
+The byte budget for content bodies is centrally defined as `CONTENT_MAX_BYTES` in `src/common/truncation.ts`; tools do not invent their own limits. Section-aware tools (`get-page`, `get-pages`) include a section list in the marker so the caller can navigate without a follow-up "list sections" call.
 
 This convention doesn't apply to tools that reject oversize input (e.g. `get-pages`' 50-title cap): those return an error, not a truncation marker.
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -109,7 +109,7 @@ Tools that return variable-size result sets or content bodies have a per-call ca
 
 Descriptions for these tools state the cap explicitly. If continuation is supported, descriptions reference the continuation parameter by name so the LLM can pick the right parameter without inspecting the schema.
 
-The byte budget for content bodies is centrally defined as `CONTENT_MAX_BYTES` in `src/common/truncation.ts`; tools do not invent their own limits. Section-aware tools (`get-page`, `get-pages`) include a section list in the marker so the caller can navigate without a follow-up "list sections" call.
+The byte budget for content bodies is centrally resolved via `resolveContentMaxBytes()` in `src/common/truncation.ts` — it reads the `MCP_CONTENT_MAX_BYTES` environment variable and falls back to `DEFAULT_CONTENT_MAX_BYTES` (50000). Tools do not invent their own limits. Section-aware tools (`get-page`, `get-pages`) include a section list in the marker so the caller can navigate without a follow-up "list sections" call.
 
 This convention doesn't apply to tools that reject oversize input (e.g. `get-pages`' 50-title cap): those return an error, not a truncation marker.
 

--- a/src/common/truncation.ts
+++ b/src/common/truncation.ts
@@ -2,7 +2,19 @@
 import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 
-export const CONTENT_MAX_BYTES = 50000;
+export const DEFAULT_CONTENT_MAX_BYTES = 50000;
+
+export function resolveContentMaxBytes(): number {
+	const raw = process.env.MCP_CONTENT_MAX_BYTES;
+	if ( raw === undefined || raw === '' ) {
+		return DEFAULT_CONTENT_MAX_BYTES;
+	}
+	const parsed = Number.parseInt( raw, 10 );
+	if ( !Number.isFinite( parsed ) || parsed <= 0 ) {
+		return DEFAULT_CONTENT_MAX_BYTES;
+	}
+	return parsed;
+}
 
 export type TruncationInfo =
 	| {
@@ -84,7 +96,7 @@ export interface TruncatedContent {
 
 export function truncateByBytes(
 	text: string,
-	maxBytes: number = CONTENT_MAX_BYTES
+	maxBytes: number = resolveContentMaxBytes()
 ): TruncatedContent {
 	const buffer = Buffer.from( text, 'utf8' );
 	const totalBytes = buffer.byteLength;

--- a/src/common/truncation.ts
+++ b/src/common/truncation.ts
@@ -2,6 +2,8 @@
 import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 
+export const CONTENT_MAX_BYTES = 50000;
+
 export type TruncationInfo =
 	| {
 		reason: 'more-available';
@@ -16,10 +18,27 @@ export type TruncationInfo =
 		limit: number;
 		itemNoun: string;
 		narrowHint: string;
+	}
+	| {
+		reason: 'content-truncated';
+		returnedBytes: number;
+		totalBytes: number;
+		itemNoun: string;
+		toolName: string;
+		sections?: string[];
+		remedyHint: string;
 	};
 
 function formatCursorValue( value: string | number ): string {
 	return typeof value === 'number' ? String( value ) : `"${ value }"`;
+}
+
+function formatSectionsClause( sections: string[] ): string {
+	const entries = sections.map( ( heading, index ) => {
+		const label = index === 0 ? 'Lead' : heading;
+		return `${ index } (${ label })`;
+	} );
+	return `Available sections: ${ entries.join( ', ' ) }.`;
 }
 
 export function truncationMarker( info: TruncationInfo ): TextContent {
@@ -29,6 +48,16 @@ export function truncationMarker( info: TruncationInfo ): TextContent {
 			type: 'text',
 			text: `More results available. Returned ${ info.returnedCount } ${ info.itemNoun }. To fetch the next segment, call ${ info.toolName } again with ${ param }=${ formatCursorValue( value ) }.`
 		};
+	}
+	if ( info.reason === 'content-truncated' ) {
+		const parts = [
+			`Content truncated at ${ info.returnedBytes } of ${ info.totalBytes } bytes.`
+		];
+		if ( info.sections && info.sections.length > 0 ) {
+			parts.push( formatSectionsClause( info.sections ) );
+		}
+		parts.push( info.remedyHint );
+		return { type: 'text', text: parts.join( ' ' ) };
 	}
 	return {
 		type: 'text',
@@ -44,4 +73,32 @@ export function appendTruncationMarker(
 		return content;
 	}
 	return [ ...content, truncationMarker( info ) ];
+}
+
+export interface TruncatedContent {
+	text: string;
+	truncated: boolean;
+	returnedBytes: number;
+	totalBytes: number;
+}
+
+export function truncateByBytes(
+	text: string,
+	maxBytes: number = CONTENT_MAX_BYTES
+): TruncatedContent {
+	const buffer = Buffer.from( text, 'utf8' );
+	const totalBytes = buffer.byteLength;
+	if ( totalBytes <= maxBytes ) {
+		return { text, truncated: false, returnedBytes: totalBytes, totalBytes };
+	}
+	// Slice on a byte boundary, then decode. Node's Buffer#toString handles
+	// incomplete trailing UTF-8 sequences by replacing them with U+FFFD,
+	// which is acceptable for a truncated preview.
+	const sliced = buffer.subarray( 0, maxBytes ).toString( 'utf8' );
+	return {
+		text: sliced,
+		truncated: true,
+		returnedBytes: Buffer.byteLength( sliced, 'utf8' ),
+		totalBytes
+	};
 }

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -5,6 +5,10 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { inlineDiffToText } from '../common/diffFormat.js';
+import {
+	truncationMarker,
+	truncateByBytes
+} from '../common/truncation.js';
 
 interface ComparePagesArgs {
 	fromRevision?: number;
@@ -34,7 +38,7 @@ type Side = 'from' | 'to';
 export function comparePagesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'compare-pages',
-		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Cheaper than fetching both sources and diffing locally, because only the changes are returned. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta.',
+		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Cheaper than fetching both sources and diffing locally, because only the changes are returned. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta. Diff output is truncated at 50000 bytes with a trailing marker; a narrower revision range or includeDiff=false avoids truncation.',
 		{
 			fromRevision: z.number().int().positive().optional().describe( 'Revision ID for the "from" side' ),
 			fromTitle: z.string().optional().describe( 'Wiki page title for the "from" side (latest revision is used)' ),
@@ -207,7 +211,18 @@ export async function handleComparePagesTool(
 		];
 
 		if ( includeDiff && changed && diffText ) {
-			results.push( { type: 'text', text: diffText } );
+			const truncated = truncateByBytes( diffText );
+			results.push( { type: 'text', text: truncated.text } );
+			if ( truncated.truncated ) {
+				results.push( truncationMarker( {
+					reason: 'content-truncated',
+					returnedBytes: truncated.returnedBytes,
+					totalBytes: truncated.totalBytes,
+					itemNoun: 'diff',
+					toolName: 'compare-pages',
+					remedyHint: 'To avoid truncation, compare a narrower revision range or set includeDiff=false for a metadata-only response.'
+				} ) );
+			}
 		}
 
 		return { content: results };

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -3,18 +3,27 @@ import { z } from 'zod';
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
+import type { Mwn } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { getPageUrl } from '../common/utils.js';
 import { ContentFormat } from '../common/contentFormat.js';
+import {
+	truncationMarker,
+	truncateByBytes,
+	type TruncationInfo
+} from '../common/truncation.js';
 
 export function getPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-page',
-		'Returns a single wiki page (wikitext source, rendered HTML, or metadata only). If the title does not exist, an error is returned. Use metadata=true to retrieve the revision ID, which can optionally be passed to update-page for edit-conflict detection. Set content="none" to fetch only metadata. For more than one page at a time, use get-pages. For a specific historical revision, use get-revision.',
+		'Returns a single wiki page (wikitext source, rendered HTML, or metadata only). If the title does not exist, an error is returned. Use metadata=true to retrieve the revision ID (for edit-conflict detection), page size, and section outline. Set content="none" to fetch only metadata. Large content is truncated at 50000 bytes with a trailing marker listing available sections; a follow-up call with section=N fetches a specific section. For more than one page at a time, use get-pages. For a specific historical revision, use get-revision.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			content: z.nativeEnum( ContentFormat ).optional().default( ContentFormat.source ).describe( 'Type of content to return' ),
-			metadata: z.boolean().optional().default( false ).describe( 'Whether to include metadata (page ID, revision info) in the response' )
+			metadata: z.boolean().optional().default( false ).describe(
+				'Whether to include metadata (page ID, revision info, size, section outline) in the response'
+			),
+			section: z.number().int().nonnegative().optional().describe( 'Section number (0 = lead; 1..N = heading sections). Narrows content to one section.' )
 		},
 		{
 			title: 'Get page',
@@ -23,35 +32,80 @@ export function getPageTool( server: McpServer ): RegisteredTool {
 			idempotentHint: true,
 			openWorldHint: true
 		} as ToolAnnotations,
-		async ( { title, content, metadata } ) => handleGetPageTool( title, content, metadata )
+		async ( { title, content, metadata, section } ) => (
+			handleGetPageTool( title, content, metadata, section )
+		)
 	);
+}
+
+interface PageSectionsApi {
+	line?: string;
+}
+
+async function fetchSectionsList( mwn: Mwn, title: string ): Promise<string[]> {
+	const response = await mwn.request( {
+		action: 'parse',
+		page: title,
+		prop: 'sections',
+		formatversion: '2'
+	} );
+	const apiSections: PageSectionsApi[] = response?.parse?.sections ?? [];
+	// MediaWiki's prop=sections returns only heading sections; prepend a slot
+	// for the lead so indices align with MediaWiki's rvsection convention
+	// (0 = lead, 1..N = headings).
+	return [ '', ...apiSections.map( ( s ) => s.line ?? '' ) ];
+}
+
+function formatSectionsBlock( sections: string[] ): string {
+	const lines = sections.map( ( heading, index ) => {
+		const label = index === 0 ? 'Lead' : heading;
+		return `- ${ index }: ${ label }`;
+	} );
+	return `Sections:\n${ lines.join( '\n' ) }`;
 }
 
 function buildPageMetadata(
 	page: { pageid: number; title: string },
-	rev?: { revid?: number; timestamp?: string; contentmodel?: string }
+	rev: { revid?: number; timestamp?: string; contentmodel?: string; size?: number } | undefined,
+	sections: string[] | undefined
 ): TextContent {
-	return {
-		type: 'text',
-		text: [
-			`Page ID: ${ page.pageid }`,
-			`Title: ${ page.title }`,
-			`Latest revision ID: ${ rev?.revid }`,
-			`Latest revision timestamp: ${ rev?.timestamp }`,
-			`Content model: ${ rev?.contentmodel }`,
-			`HTML URL: ${ getPageUrl( page.title ) }`
-		].join( '\n' )
-	};
+	const lines = [
+		`Page ID: ${ page.pageid }`,
+		`Title: ${ page.title }`,
+		`Latest revision ID: ${ rev?.revid }`,
+		`Latest revision timestamp: ${ rev?.timestamp }`,
+		`Content model: ${ rev?.contentmodel }`
+	];
+	if ( rev?.size !== undefined ) {
+		lines.push( `Size: ${ rev.size }` );
+	}
+	if ( sections !== undefined ) {
+		lines.push( formatSectionsBlock( sections ) );
+	}
+	lines.push( `HTML URL: ${ getPageUrl( page.title ) }` );
+	return { type: 'text', text: lines.join( '\n' ) };
 }
 
 export async function handleGetPageTool(
-	title: string, content: ContentFormat, metadata: boolean
+	title: string,
+	content: ContentFormat,
+	metadata: boolean,
+	section?: number
 ): Promise<CallToolResult> {
 	if ( content === ContentFormat.none && !metadata ) {
 		return {
 			content: [ {
 				type: 'text',
 				text: 'When content is set to "none", metadata must be true'
+			} ],
+			isError: true
+		};
+	}
+	if ( section !== undefined && content === ContentFormat.none ) {
+		return {
+			content: [ {
+				type: 'text',
+				text: 'section is not compatible with content="none"'
 			} ],
 			isError: true
 		};
@@ -66,11 +120,17 @@ export async function handleGetPageTool(
 			content === ContentFormat.none;
 		const needsSource = content === ContentFormat.source;
 
+		let sections: string[] | undefined;
+
 		if ( needsReadCall ) {
 			const rvprop = needsSource ?
-				'ids|timestamp|contentmodel|content' :
-				'ids|timestamp|contentmodel';
-			const page = await mwn.read( title, { rvprop } );
+				'ids|timestamp|contentmodel|size|content' :
+				'ids|timestamp|contentmodel|size';
+			const readParams: Record<string, string | number> = { rvprop };
+			if ( needsSource && section !== undefined ) {
+				readParams.rvsection = section;
+			}
+			const page = await mwn.read( title, readParams );
 
 			if ( page.missing ) {
 				return {
@@ -84,33 +144,79 @@ export async function handleGetPageTool(
 
 			const rev = page.revisions?.[ 0 ];
 
+			if ( metadata ) {
+				sections = await fetchSectionsList( mwn, title );
+			}
+
 			if ( metadata || content === ContentFormat.none ) {
-				results.push( buildPageMetadata( page, rev ) );
+				results.push( buildPageMetadata( page, rev, sections ) );
 			}
 
 			if ( needsSource && rev?.content !== undefined ) {
+				const truncated = truncateByBytes( rev.content );
 				results.push( {
 					type: 'text',
-					text: metadata ?
-						`Source:\n${ rev.content }` : rev.content
+					text: metadata ? `Source:\n${ truncated.text }` : truncated.text
 				} );
+				if ( truncated.truncated ) {
+					if ( sections === undefined ) {
+						sections = await fetchSectionsList( mwn, title );
+					}
+					const info: TruncationInfo = {
+						reason: 'content-truncated',
+						returnedBytes: truncated.returnedBytes,
+						totalBytes: truncated.totalBytes,
+						itemNoun: 'wikitext',
+						toolName: 'get-page',
+						sections,
+						remedyHint: 'To read a specific section, call get-page again with section=N.'
+					};
+					results.push( truncationMarker( info ) );
+				}
 			}
 		}
 
 		if ( content === ContentFormat.html ) {
-			const parseResult = await mwn.request( {
+			const parseParams: Record<string, string | number> = {
 				action: 'parse',
 				page: title,
 				prop: 'text',
 				formatversion: '2'
-			} );
-			const html = parseResult.parse?.text;
+			};
+			if ( section !== undefined ) {
+				parseParams.section = section;
+			}
+			const parseResult = await mwn.request( parseParams );
+			const html: string | undefined = parseResult.parse?.text;
+			const htmlSource = html ?? '';
+			const truncated = truncateByBytes( htmlSource );
 
-			results.push( {
-				type: 'text',
-				text: metadata ?
-					`HTML:\n${ html }` : ( html ?? 'Not available' )
-			} );
+			if ( html === undefined ) {
+				results.push( {
+					type: 'text',
+					text: metadata ? 'HTML:\nNot available' : 'Not available'
+				} );
+			} else {
+				results.push( {
+					type: 'text',
+					text: metadata ? `HTML:\n${ truncated.text }` : truncated.text
+				} );
+				if ( truncated.truncated ) {
+					if ( sections === undefined ) {
+						sections = await fetchSectionsList( mwn, title );
+					}
+					const info: TruncationInfo = {
+						reason: 'content-truncated',
+						returnedBytes: truncated.returnedBytes,
+						totalBytes: truncated.totalBytes,
+						itemNoun: 'HTML',
+						toolName: 'get-page',
+						sections,
+						remedyHint: 'To read a specific section, call get-page again with section=N.'
+					};
+					results.push( truncationMarker( info ) );
+				}
+			}
 		}
 
 		return { content: results };

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -3,8 +3,13 @@ import { z } from 'zod';
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
+import type { Mwn } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { getPageUrl } from '../common/utils.js';
+import {
+	truncationMarker,
+	truncateByBytes
+} from '../common/truncation.js';
 
 const MAX_TITLES = 50;
 
@@ -16,7 +21,7 @@ export enum BatchContentFormat {
 export function getPagesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-pages',
-		`Returns multiple wiki pages in one call (wikitext source or metadata only). Suited to reading a cluster of related pages, diffing a page family, or syncing pages to local storage. Accepts up to ${ MAX_TITLES } titles; missing pages are reported inline (not as errors). For a single page or HTML output, use get-page.`,
+		`Returns multiple wiki pages in one call (wikitext source or metadata only). Suited to reading a cluster of related pages, diffing a page family, or syncing pages to local storage. Accepts up to ${ MAX_TITLES } titles; missing pages are reported inline (not as errors). Each page's content is truncated at 50000 bytes with a trailing marker listing available sections; get-page with section=N fetches a specific section. For a single page or HTML output, use get-page.`,
 		{
 			titles: z.array( z.string() ).describe( `Array of wiki page titles (1..${ MAX_TITLES })` ),
 			content: z.nativeEnum( BatchContentFormat ).optional().default( BatchContentFormat.source ).describe( 'Type of content to return; "none" returns metadata only' ),
@@ -77,6 +82,21 @@ function buildMetadataLines(
 		`HTML URL: ${ getPageUrl( page.title ) }`
 	);
 	return lines.join( '\n' );
+}
+
+interface PageSectionsApi {
+	line?: string;
+}
+
+async function fetchSectionsList( mwn: Mwn, title: string ): Promise<string[]> {
+	const response = await mwn.request( {
+		action: 'parse',
+		page: title,
+		prop: 'sections',
+		formatversion: '2'
+	} );
+	const apiSections: PageSectionsApi[] = response?.parse?.sections ?? [];
+	return [ '', ...apiSections.map( ( s ) => s.line ?? '' ) ];
 }
 
 function resolveChain(
@@ -194,6 +214,14 @@ export async function handleGetPagesTool(
 		const missing: string[] = [];
 		const missingSeen = new Set<string>();
 
+		interface PendingMarker {
+			position: number;
+			title: string;
+			returnedBytes: number;
+			totalBytes: number;
+		}
+		const pendingMarkers: PendingMarker[] = [];
+
 		for ( const requested of titles ) {
 			let resolvedTitle: string;
 			let viaRedirect: boolean;
@@ -231,11 +259,40 @@ export async function handleGetPagesTool(
 				} );
 			}
 			if ( needsSource && rev?.content !== undefined ) {
+				const truncated = truncateByBytes( rev.content );
 				results.push( {
 					type: 'text',
-					text: metadata ? `Source:\n${ rev.content }` : rev.content
+					text: metadata ? `Source:\n${ truncated.text }` : truncated.text
 				} );
+				if ( truncated.truncated ) {
+					// Reserve a slot; the marker's section list is filled in after
+					// a single parallel pass fetches outlines for every truncated page.
+					results.push( { type: 'text', text: '' } );
+					pendingMarkers.push( {
+						position: results.length - 1,
+						title: page.title,
+						returnedBytes: truncated.returnedBytes,
+						totalBytes: truncated.totalBytes
+					} );
+				}
 			}
+		}
+
+		if ( pendingMarkers.length > 0 ) {
+			const sectionLists = await Promise.all(
+				pendingMarkers.map( ( p ) => fetchSectionsList( mwn, p.title ) )
+			);
+			pendingMarkers.forEach( ( p, i ) => {
+				results[ p.position ] = truncationMarker( {
+					reason: 'content-truncated',
+					returnedBytes: p.returnedBytes,
+					totalBytes: p.totalBytes,
+					itemNoun: 'wikitext',
+					toolName: 'get-pages',
+					sections: sectionLists[ i ],
+					remedyHint: 'To read a specific section, call get-page again with section=N.'
+				} );
+			} );
 		}
 
 		if ( missing.length > 0 ) {

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -4,6 +4,10 @@ import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
+import {
+	truncationMarker,
+	truncateByBytes
+} from '../common/truncation.js';
 
 const DEFAULT_TITLE = 'API';
 
@@ -33,7 +37,7 @@ function bulletSection( header: string, lines: string[] ): TextContent | null {
 export function parseWikitextTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'parse-wikitext',
-		'Renders wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Suited to dry-running a planned edit before create-page or update-page, or previewing standalone wikitext (template combinations, sanitizer checks) with no target page.',
+		'Renders wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Suited to dry-running a planned edit before create-page or update-page, or previewing standalone wikitext (template combinations, sanitizer checks) with no target page. HTML output is truncated at 50000 bytes with a trailing marker; a smaller wikitext fragment in a follow-up call returns the rest.',
 		{
 			wikitext: z.string().min( 1 ).describe( 'Wikitext to render' ),
 			title: z.string().optional().describe(
@@ -84,10 +88,21 @@ export async function handleParseWikitextTool(
 		}
 
 		const html: string = parse.text ?? '';
+		const truncated = truncateByBytes( html );
 		results.push( {
 			type: 'text',
-			text: `HTML:\n${ html }`
+			text: `HTML:\n${ truncated.text }`
 		} );
+		if ( truncated.truncated ) {
+			results.push( truncationMarker( {
+				reason: 'content-truncated',
+				returnedBytes: truncated.returnedBytes,
+				totalBytes: truncated.totalBytes,
+				itemNoun: 'HTML',
+				toolName: 'parse-wikitext',
+				remedyHint: 'To avoid truncation, render a smaller wikitext fragment in a follow-up call.'
+			} ) );
+		}
 
 		const effectiveTitle = title ?? DEFAULT_TITLE;
 		const displayTitle: string | undefined = parse.displaytitle;

--- a/tests/common/truncation.test.ts
+++ b/tests/common/truncation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 /* eslint-disable n/no-missing-import */
 import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
@@ -6,7 +6,7 @@ import {
 	truncationMarker,
 	appendTruncationMarker,
 	truncateByBytes,
-	CONTENT_MAX_BYTES,
+	DEFAULT_CONTENT_MAX_BYTES,
 	type TruncationInfo
 } from '../../src/common/truncation.js';
 
@@ -96,9 +96,41 @@ describe( 'truncationMarker', () => {
 	} );
 } );
 
-describe( 'CONTENT_MAX_BYTES', () => {
+describe( 'DEFAULT_CONTENT_MAX_BYTES', () => {
 	it( 'is exported and equals 50000', () => {
-		expect( CONTENT_MAX_BYTES ).toBe( 50000 );
+		expect( DEFAULT_CONTENT_MAX_BYTES ).toBe( 50000 );
+	} );
+} );
+
+describe( 'MCP_CONTENT_MAX_BYTES env var', () => {
+	afterEach( () => {
+		vi.unstubAllEnvs();
+	} );
+
+	it( 'overrides the default when set to a positive integer', () => {
+		vi.stubEnv( 'MCP_CONTENT_MAX_BYTES', '100' );
+		const result = truncateByBytes( 'x'.repeat( 500 ) );
+		expect( result.truncated ).toBe( true );
+		expect( result.returnedBytes ).toBe( 100 );
+		expect( result.totalBytes ).toBe( 500 );
+	} );
+
+	it( 'falls back to the default when set to a non-numeric value', () => {
+		vi.stubEnv( 'MCP_CONTENT_MAX_BYTES', 'nope' );
+		const result = truncateByBytes( 'x'.repeat( DEFAULT_CONTENT_MAX_BYTES + 1 ) );
+		expect( result.returnedBytes ).toBe( DEFAULT_CONTENT_MAX_BYTES );
+	} );
+
+	it( 'falls back to the default when set to zero or negative', () => {
+		vi.stubEnv( 'MCP_CONTENT_MAX_BYTES', '0' );
+		const result = truncateByBytes( 'x'.repeat( DEFAULT_CONTENT_MAX_BYTES + 1 ) );
+		expect( result.returnedBytes ).toBe( DEFAULT_CONTENT_MAX_BYTES );
+	} );
+
+	it( 'falls back to the default when set to an empty string', () => {
+		vi.stubEnv( 'MCP_CONTENT_MAX_BYTES', '' );
+		const result = truncateByBytes( 'x'.repeat( DEFAULT_CONTENT_MAX_BYTES + 1 ) );
+		expect( result.returnedBytes ).toBe( DEFAULT_CONTENT_MAX_BYTES );
 	} );
 } );
 
@@ -127,12 +159,12 @@ describe( 'truncateByBytes', () => {
 		expect( result.text.length ).toBe( 100 );
 	} );
 
-	it( 'defaults to CONTENT_MAX_BYTES when no limit is passed', () => {
-		const input = 'x'.repeat( CONTENT_MAX_BYTES + 1 );
+	it( 'defaults to DEFAULT_CONTENT_MAX_BYTES when no limit is passed', () => {
+		const input = 'x'.repeat( DEFAULT_CONTENT_MAX_BYTES + 1 );
 		const result = truncateByBytes( input );
 		expect( result.truncated ).toBe( true );
-		expect( result.returnedBytes ).toBe( CONTENT_MAX_BYTES );
-		expect( result.totalBytes ).toBe( CONTENT_MAX_BYTES + 1 );
+		expect( result.returnedBytes ).toBe( DEFAULT_CONTENT_MAX_BYTES );
+		expect( result.totalBytes ).toBe( DEFAULT_CONTENT_MAX_BYTES + 1 );
 	} );
 
 	it( 'handles a multi-byte UTF-8 character straddling the byte boundary', () => {

--- a/tests/common/truncation.test.ts
+++ b/tests/common/truncation.test.ts
@@ -5,6 +5,8 @@ import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
 import {
 	truncationMarker,
 	appendTruncationMarker,
+	truncateByBytes,
+	CONTENT_MAX_BYTES,
 	type TruncationInfo
 } from '../../src/common/truncation.js';
 
@@ -36,6 +38,50 @@ describe( 'truncationMarker', () => {
 		);
 	} );
 
+	it( 'renders content-truncated without a section list', () => {
+		const info: TruncationInfo = {
+			reason: 'content-truncated',
+			returnedBytes: 50000,
+			totalBytes: 120000,
+			itemNoun: 'HTML',
+			toolName: 'parse-wikitext',
+			remedyHint: 'To avoid truncation, render a smaller wikitext fragment in a follow-up call.'
+		};
+		expect( truncationMarker( info ).text ).toBe(
+			'Content truncated at 50000 of 120000 bytes. To avoid truncation, render a smaller wikitext fragment in a follow-up call.'
+		);
+	} );
+
+	it( 'renders content-truncated with a section list (section 0 labeled Lead)', () => {
+		const info: TruncationInfo = {
+			reason: 'content-truncated',
+			returnedBytes: 50000,
+			totalBytes: 200000,
+			itemNoun: 'wikitext',
+			toolName: 'get-page',
+			sections: [ '', 'History', 'Background' ],
+			remedyHint: 'To read a specific section, call get-page again with section=N.'
+		};
+		expect( truncationMarker( info ).text ).toBe(
+			'Content truncated at 50000 of 200000 bytes. Available sections: 0 (Lead), 1 (History), 2 (Background). To read a specific section, call get-page again with section=N.'
+		);
+	} );
+
+	it( 'renders content-truncated with an empty section list by omitting the sections clause', () => {
+		const info: TruncationInfo = {
+			reason: 'content-truncated',
+			returnedBytes: 50000,
+			totalBytes: 120000,
+			itemNoun: 'wikitext',
+			toolName: 'get-page',
+			sections: [],
+			remedyHint: 'To read a specific section, call get-page again with section=N.'
+		};
+		expect( truncationMarker( info ).text ).toBe(
+			'Content truncated at 50000 of 120000 bytes. To read a specific section, call get-page again with section=N.'
+		);
+	} );
+
 	it( 'renders capped-no-continuation with em dash before narrow hint', () => {
 		const info: TruncationInfo = {
 			reason: 'capped-no-continuation',
@@ -47,6 +93,62 @@ describe( 'truncationMarker', () => {
 		expect( truncationMarker( info ).text ).toBe(
 			'Result capped at 100 matches. Additional matches may exist — narrow the query or raise limit (max 100).'
 		);
+	} );
+} );
+
+describe( 'CONTENT_MAX_BYTES', () => {
+	it( 'is exported and equals 50000', () => {
+		expect( CONTENT_MAX_BYTES ).toBe( 50000 );
+	} );
+} );
+
+describe( 'truncateByBytes', () => {
+	it( 'returns the input unchanged when under the limit', () => {
+		const result = truncateByBytes( 'hello', 100 );
+		expect( result.truncated ).toBe( false );
+		expect( result.text ).toBe( 'hello' );
+		expect( result.returnedBytes ).toBe( 5 );
+		expect( result.totalBytes ).toBe( 5 );
+	} );
+
+	it( 'returns the input unchanged at exactly the limit', () => {
+		const result = truncateByBytes( 'x'.repeat( 100 ), 100 );
+		expect( result.truncated ).toBe( false );
+		expect( result.returnedBytes ).toBe( 100 );
+		expect( result.totalBytes ).toBe( 100 );
+	} );
+
+	it( 'truncates when the input exceeds the limit', () => {
+		const input = 'x'.repeat( 200 );
+		const result = truncateByBytes( input, 100 );
+		expect( result.truncated ).toBe( true );
+		expect( result.returnedBytes ).toBe( 100 );
+		expect( result.totalBytes ).toBe( 200 );
+		expect( result.text.length ).toBe( 100 );
+	} );
+
+	it( 'defaults to CONTENT_MAX_BYTES when no limit is passed', () => {
+		const input = 'x'.repeat( CONTENT_MAX_BYTES + 1 );
+		const result = truncateByBytes( input );
+		expect( result.truncated ).toBe( true );
+		expect( result.returnedBytes ).toBe( CONTENT_MAX_BYTES );
+		expect( result.totalBytes ).toBe( CONTENT_MAX_BYTES + 1 );
+	} );
+
+	it( 'handles a multi-byte UTF-8 character straddling the byte boundary', () => {
+		// '漢' is 3 bytes in UTF-8. Build a buffer whose first 100 bytes split
+		// the final character across the limit so the slice lands mid-sequence.
+		const input = 'x'.repeat( 99 ) + '漢漢';
+		const result = truncateByBytes( input, 100 );
+		expect( result.truncated ).toBe( true );
+		// Buffer#toString('utf8') replaces the partial trailing byte with U+FFFD;
+		// returnedBytes reflects the decoded string's UTF-8 length, which may
+		// exceed the raw 100-byte slice but stays bounded by maxBytes + 2 bytes
+		// of replacement.
+		expect( result.totalBytes ).toBe( 99 + 6 );
+		expect( result.returnedBytes ).toBeLessThanOrEqual( 100 + 2 );
+		// The returned text must decode cleanly as a string (no thrown decode error)
+		expect( typeof result.text ).toBe( 'string' );
 	} );
 } );
 

--- a/tests/tools/compare-pages.test.ts
+++ b/tests/tools/compare-pages.test.ts
@@ -303,6 +303,61 @@ describe( 'compare-pages', () => {
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Page "Bar" not found' );
 	} );
 
+	it( 'truncates oversized diff body with a content-truncated marker', async () => {
+		// Build a diff body large enough that inlineDiffToText yields > 50000 bytes
+		const bigOld = 'a'.repeat( 30000 );
+		const bigNew = 'b'.repeat( 30000 );
+		const bigDiffHtml = [
+			'<table class="diff">',
+			'<tr><td colspan="2" class="diff-lineno">Line 1:</td><td colspan="2" class="diff-lineno">Line 1:</td></tr>',
+			`<tr><td class="diff-marker">-</td><td class="diff-deletedline"><div>${ bigOld }</div></td>`,
+			`<td class="diff-marker">+</td><td class="diff-addedline"><div>${ bigNew }</div></td></tr>`,
+			'</table>'
+		].join( '' );
+		const request = vi.fn().mockResolvedValue( {
+			compare: {
+				fromrevid: 42, fromtitle: 'Foo', fromsize: 100, fromtimestamp: '2026-01-01T00:00:00Z',
+				torevid: 57, totitle: 'Foo', tosize: 100, totimestamp: '2026-01-02T00:00:00Z',
+				body: bigDiffHtml
+			}
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { request } ) as any );
+
+		const result = await handleComparePagesTool( {
+			fromRevision: 42, toRevision: 57
+		} );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 3 );
+		expect( ( result.content[ 1 ] as any ).text ).toHaveLength( 50000 );
+		const marker = ( result.content[ 2 ] as any ).text as string;
+		expect( marker ).toMatch( /^Content truncated at 50000 of \d+ bytes\./ );
+		expect( marker ).toContain( 'compare a narrower revision range or set includeDiff=false' );
+		expect( marker ).not.toContain( 'Available sections' );
+	} );
+
+	it( 'cheap mode (includeDiff=false) emits no content-truncated marker even for oversized changes', async () => {
+		const request = vi.fn().mockResolvedValue( {
+			compare: {
+				fromrevid: 42, fromtitle: 'Foo', fromsize: 100,
+				torevid: 57, totitle: 'Foo', tosize: 100000,
+				diffsize: 99999
+			}
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { request } ) as any );
+
+		const result = await handleComparePagesTool( {
+			fromRevision: 42, toRevision: 57, includeDiff: false
+		} );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 1 );
+		const hasMarker = result.content.some(
+			( c: any ) => c.text?.startsWith( 'Content truncated at' )
+		);
+		expect( hasMarker ).toBe( false );
+	} );
+
 	it( 'cheap mode uses diffsize to detect same-byte-count changes', async () => {
 		const request = vi.fn().mockResolvedValue( {
 			compare: {

--- a/tests/tools/get-page.test.ts
+++ b/tests/tools/get-page.test.ts
@@ -136,6 +136,213 @@ describe( 'get-page', () => {
 		expect( result.content[ 0 ].text ).toContain( 'API error' );
 	} );
 
+	it( 'forwards section as rvsection for source content', async () => {
+		const read = vi.fn().mockResolvedValue( {
+			pageid: 1,
+			title: 'Test Page',
+			revisions: [ {
+				revid: 42,
+				timestamp: '2026-01-01T00:00:00Z',
+				contentmodel: 'wikitext',
+				content: 'Section body'
+			} ]
+		} );
+		const mock = createMockMwn( { read } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Test Page', 'source', false, 2 );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toBe( 'Section body' );
+		expect( read ).toHaveBeenCalledWith( 'Test Page', expect.objectContaining( {
+			rvsection: 2
+		} ) );
+	} );
+
+	it( 'forwards section as parse section for html content', async () => {
+		const request = vi.fn().mockResolvedValue( {
+			parse: { text: '<p>Section HTML</p>' }
+		} );
+		const mock = createMockMwn( { request } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Test Page', 'html', false, 1 );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toBe( '<p>Section HTML</p>' );
+		expect( request ).toHaveBeenCalledWith( expect.objectContaining( {
+			action: 'parse',
+			page: 'Test Page',
+			section: 1
+		} ) );
+	} );
+
+	it( 'rejects section with content="none"', async () => {
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Test Page', 'none', true, 2 );
+
+		expect( result.isError ).toBe( true );
+		expect( result.content[ 0 ].text ).toContain( 'section is not compatible with content="none"' );
+	} );
+
+	it( 'reports the full-page Size in metadata even when section is set (size is revision-level, not section-level)', async () => {
+		// When rvsection=N is combined with rvprop=...|size, MediaWiki returns
+		// the section-scoped content but the whole-revision size. That is the
+		// correct semantic for a "Size:" metadata field ("how big is this page")
+		// and this test pins it against regression.
+		const read = vi.fn().mockResolvedValue( {
+			pageid: 1,
+			title: 'Test Page',
+			revisions: [ {
+				revid: 42,
+				timestamp: '2026-01-01T00:00:00Z',
+				contentmodel: 'wikitext',
+				size: 98765,
+				content: 'Section body'
+			} ]
+		} );
+		const request = vi.fn().mockResolvedValue( {
+			parse: { sections: [ { line: 'History' } ] }
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( createMockMwn( { read, request } ) as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Test Page', 'source', true, 1 );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toContain( 'Size: 98765' );
+		expect( read ).toHaveBeenCalledWith( 'Test Page', expect.objectContaining( {
+			rvsection: 1
+		} ) );
+	} );
+
+	it( 'omits Size from metadata when the revision has no size field', async () => {
+		const mock = createMockMwn( {
+			read: vi.fn().mockResolvedValue( {
+				pageid: 1,
+				title: 'No Size',
+				revisions: [ {
+					revid: 42,
+					timestamp: '2026-01-01T00:00:00Z',
+					contentmodel: 'wikitext'
+				} ]
+			} ),
+			request: vi.fn().mockResolvedValue( { parse: { sections: [] } } )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'No Size', 'none', true );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).not.toContain( 'Size:' );
+	} );
+
+	it( 'metadata=true includes Size and Sections block (section 0 labeled Lead)', async () => {
+		const mock = createMockMwn( {
+			read: vi.fn().mockResolvedValue( {
+				pageid: 1,
+				title: 'Test Page',
+				revisions: [ {
+					revid: 42,
+					timestamp: '2026-01-01T00:00:00Z',
+					contentmodel: 'wikitext',
+					size: 12345
+				} ]
+			} ),
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					sections: [
+						{ line: 'History', number: '1', index: '1' },
+						{ line: 'Background', number: '2', index: '2' }
+					]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Test Page', 'none', true );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content[ 0 ].text ).toContain( 'Size: 12345' );
+		expect( result.content[ 0 ].text ).toContain( 'Sections:\n- 0: Lead\n- 1: History\n- 2: Background' );
+	} );
+
+	it( 'truncates source content over 50000 bytes with a content-truncated marker', async () => {
+		const big = 'x'.repeat( 50001 );
+		const mock = createMockMwn( {
+			read: vi.fn().mockResolvedValue( {
+				pageid: 1,
+				title: 'Big',
+				revisions: [ {
+					revid: 42,
+					timestamp: '2026-01-01T00:00:00Z',
+					contentmodel: 'wikitext',
+					content: big
+				} ]
+			} ),
+			request: vi.fn().mockResolvedValue( {
+				parse: { sections: [ { line: 'History' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Big', 'source', false );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 2 );
+		expect( result.content[ 0 ].text ).toHaveLength( 50000 );
+		expect( result.content[ 1 ].text ).toContain( 'Content truncated at 50000 of 50001 bytes' );
+		expect( result.content[ 1 ].text ).toContain( 'Available sections: 0 (Lead), 1 (History)' );
+		expect( result.content[ 1 ].text ).toContain( 'call get-page again with section=N' );
+	} );
+
+	it( 'does not truncate source content at exactly 50000 bytes', async () => {
+		const exact = 'y'.repeat( 50000 );
+		const mock = createMockMwn( {
+			read: vi.fn().mockResolvedValue( {
+				pageid: 1,
+				title: 'Exact',
+				revisions: [ {
+					revid: 42,
+					timestamp: '2026-01-01T00:00:00Z',
+					contentmodel: 'wikitext',
+					content: exact
+				} ]
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Exact', 'source', false );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 1 );
+		expect( result.content[ 0 ].text ).toHaveLength( 50000 );
+	} );
+
+	it( 'truncates HTML content over 50000 bytes with a content-truncated marker', async () => {
+		const bigHtml = '<p>' + 'x'.repeat( 60000 ) + '</p>';
+		const request = vi.fn()
+			.mockResolvedValueOnce( { parse: { text: bigHtml } } )
+			.mockResolvedValueOnce( { parse: { sections: [ { line: 'Heading' } ] } } );
+		const mock = createMockMwn( { request } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetPageTool } = await import( '../../src/tools/get-page.js' );
+		const result = await handleGetPageTool( 'Huge', 'html', false );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 2 );
+		expect( result.content[ 0 ].text ).toHaveLength( 50000 );
+		expect( result.content[ 1 ].text ).toContain( 'Content truncated at 50000 of ' );
+		expect( result.content[ 1 ].text ).toContain( 'Available sections: 0 (Lead), 1 (Heading)' );
+	} );
+
 	it( 'html+metadata does not duplicate metadata or read call', async () => {
 		const mock = createMockMwn( {
 			read: vi.fn().mockResolvedValue( {

--- a/tests/tools/get-pages.test.ts
+++ b/tests/tools/get-pages.test.ts
@@ -373,4 +373,110 @@ describe( 'get-pages', () => {
 			expect( ( result.content[ 0 ] as any ).text ).toContain( 'read error' );
 		} );
 	} );
+
+	describe( 'byte truncation', () => {
+		it( 'truncates oversized content per page, with the marker inside the per-page block', async () => {
+			const big = 'x'.repeat( 50001 );
+			const small = 'tiny body';
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [
+					massQueryPage( 'Big', 1, 10, big ),
+					massQueryPage( 'Small', 2, 20, small )
+				]
+			} ) );
+			const request = vi.fn()
+				.mockResolvedValueOnce( { parse: { sections: [ { line: 'Overview' } ] } } );
+			vi.mocked( getMwn ).mockResolvedValue(
+				createMockMwn( { massQuery, request } ) as any
+			);
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Big', 'Small' ], 'source', false );
+
+			expect( result.isError ).toBeUndefined();
+			// 2 pages: Big produces [header, source, truncation marker], Small produces [header, source]
+			const texts = result.content.map( ( c: any ) => c.text );
+			const bigHeaderIdx = texts.indexOf( '--- Big ---' );
+			const smallHeaderIdx = texts.indexOf( '--- Small ---' );
+			expect( bigHeaderIdx ).toBeGreaterThanOrEqual( 0 );
+			expect( smallHeaderIdx ).toBeGreaterThan( bigHeaderIdx );
+
+			// Marker appears between the two per-page blocks — i.e. inside Big's block
+			const markerIdx = texts.findIndex( ( t: string ) => t?.startsWith( 'Content truncated at' ) );
+			expect( markerIdx ).toBeGreaterThan( bigHeaderIdx );
+			expect( markerIdx ).toBeLessThan( smallHeaderIdx );
+
+			const markerText = texts[ markerIdx ];
+			expect( markerText ).toContain( 'Content truncated at 50000 of 50001 bytes' );
+			expect( markerText ).toContain( 'Available sections: 0 (Lead), 1 (Overview)' );
+			// Section outline fetched only for the truncated page
+			expect( request ).toHaveBeenCalledTimes( 1 );
+			expect( request ).toHaveBeenCalledWith( expect.objectContaining( {
+				page: 'Big',
+				prop: 'sections'
+			} ) );
+		} );
+
+		it( 'fetches section outlines for multiple truncated pages in parallel, not serially', async () => {
+			const big1 = 'a'.repeat( 60000 );
+			const big2 = 'b'.repeat( 70000 );
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [
+					massQueryPage( 'BigA', 1, 10, big1 ),
+					massQueryPage( 'BigB', 2, 20, big2 )
+				]
+			} ) );
+			// Delay each parse call so a serial implementation would take roughly
+			// 2x a parallel one. We also assert that the second fetch starts
+			// before the first resolves, which is the actual concurrency signal.
+			let inFlight = 0;
+			let maxInFlight = 0;
+			const request = vi.fn().mockImplementation( () => {
+				inFlight += 1;
+				maxInFlight = Math.max( maxInFlight, inFlight );
+				return new Promise( ( resolve ) => {
+					setTimeout( () => {
+						inFlight -= 1;
+						resolve( { parse: { sections: [ { line: 'H' } ] } } );
+					}, 10 );
+				} );
+			} );
+			vi.mocked( getMwn ).mockResolvedValue(
+				createMockMwn( { massQuery, request } ) as any
+			);
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'BigA', 'BigB' ], 'source', false );
+
+			expect( result.isError ).toBeUndefined();
+			expect( request ).toHaveBeenCalledTimes( 2 );
+			expect( maxInFlight ).toBe( 2 );
+			// Both markers present with the expected section list
+			const markers = result.content.filter(
+				( c: any ) => c.text?.startsWith( 'Content truncated at' )
+			);
+			expect( markers ).toHaveLength( 2 );
+		} );
+
+		it( 'does not emit a marker for content at exactly 50000 bytes', async () => {
+			const exact = 'y'.repeat( 50000 );
+			const massQuery = vi.fn().mockResolvedValue( massQueryResponse( {
+				pages: [ massQueryPage( 'Exact', 1, 10, exact ) ]
+			} ) );
+			const request = vi.fn();
+			vi.mocked( getMwn ).mockResolvedValue(
+				createMockMwn( { massQuery, request } ) as any
+			);
+
+			const { handleGetPagesTool } = await import( '../../src/tools/get-pages.js' );
+			const result = await handleGetPagesTool( [ 'Exact' ], 'source', false );
+
+			expect( result.isError ).toBeUndefined();
+			const hasMarker = result.content.some(
+				( c: any ) => c.text?.startsWith( 'Content truncated at' )
+			);
+			expect( hasMarker ).toBe( false );
+			expect( request ).not.toHaveBeenCalled();
+		} );
+	} );
 } );

--- a/tests/tools/parse-wikitext.test.ts
+++ b/tests/tools/parse-wikitext.test.ts
@@ -275,6 +275,47 @@ describe( 'parse-wikitext', () => {
 		expect( result.content[ 0 ].text ).toBe( 'HTML:\n<p>x</p>' );
 	} );
 
+	it( 'truncates HTML over 50000 bytes with a marker between HTML and subsequent metadata blocks', async () => {
+		const bigHtml = '<p>' + 'x'.repeat( 60000 ) + '</p>';
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: {
+					text: bigHtml,
+					parsewarnings: [],
+					categories: [ { sortkey: '', category: 'Foo' } ]
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( result.content ).toHaveLength( 3 );
+		expect( result.content[ 0 ].text!.startsWith( 'HTML:\n' ) ).toBe( true );
+		expect( result.content[ 0 ].text ).toHaveLength( 'HTML:\n'.length + 50000 );
+		expect( result.content[ 1 ].text ).toContain( 'Content truncated at 50000 of 60007 bytes' );
+		expect( result.content[ 1 ].text ).toContain( 'render a smaller wikitext fragment' );
+		expect( result.content[ 1 ].text ).not.toContain( 'Available sections' );
+		expect( result.content[ 2 ].text!.startsWith( 'Categories:' ) ).toBe( true );
+	} );
+
+	it( 'does not emit a marker for HTML at exactly 50000 bytes', async () => {
+		const exact = 'y'.repeat( 50000 );
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				parse: { text: exact, parsewarnings: [] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleParseWikitextTool } = await import( '../../src/tools/parse-wikitext.js' );
+		const result = await handleParseWikitextTool( 'x', undefined, true );
+
+		expect( result.content ).toHaveLength( 1 );
+		expect( result.content[ 0 ].text ).toBe( `HTML:\n${ exact }` );
+	} );
+
 	it( 'emits sections in order: warnings, HTML, displaytitle, categories, links, templates, externallinks', async () => {
 		const mock = createMockMwn( {
 			request: vi.fn().mockResolvedValue( {


### PR DESCRIPTION
Fixes: #30
Closes: #38

## Summary

Follow-up to #279, which established the truncation-signaling pattern for list-like tools and explicitly deferred byte-based guards for the content-heavy tools. This PR fills that gap.

- Extends `src/common/truncation.ts` with a new `content-truncated` variant of the shared marker, a `truncateByBytes()` helper, and a `DEFAULT_CONTENT_MAX_BYTES = 50000` constant (~12.5K tokens at 4 chars/token, half of Anthropic's 25K-token Claude Code default).
- Applies the cap to four content-heavy tools:
  - `get-page` — truncates source or HTML output. Gains a new `section?: number` parameter (0 = lead; 1..N = headings) for MediaWiki-native section navigation. `metadata=true` output gains `Size:` and `Sections:` blocks so a truncated response can link to a specific section in one round trip.
  - `get-pages` — per-page truncation inside each `--- title ---` block. Section outlines for truncated pages are fetched in a single parallel pass (`Promise.all`), not serially.
  - `parse-wikitext` — truncates HTML output; marker sits between HTML and supplementary metadata (no section list — `parse-wikitext` has no persistent page structure to enumerate).
  - `compare-pages` — truncates the diff body; skipped entirely when `includeDiff=false`. Marker carries an `includeDiff=false` remedy hint.
- Cap is configurable via the `MCP_CONTENT_MAX_BYTES` environment variable so deployments can tune it to the target client's context budget. Falls back to the default on unset, empty, non-numeric, or non-positive values.
- Extends the "Result caps and truncation signaling" section of `docs/tool-conventions.md` with the new `content-truncated` marker shape and the env-var resolver contract.

Context for the single-cap-shared-across-four-tools choice: per-request negotiation (MCP [discussion #2211](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2211)) is unratified and no major MCP server ships it today; deployment-wide env var is the dominant pattern (`REST_RESPONSE_SIZE_LIMIT` on `mcp-rest-api`, `MAX_MCP_OUTPUT_TOKENS` on Claude Code).

## Test plan

- [x] `npm test` — 250/250 pass (22 suites); +88 over the 162 baseline.
- [x] `npm run lint` — clean (two pre-existing warnings in `src/common/config.ts` unrelated).
- [x] `npm run build` — clean.
- [x] MCP Inspector CLI smoke tests against a real wiki (en.wikipedia.org):
  - [x] `get-page` on Python (programming language) — truncates at 50000 of 140474 bytes, marker lists all 29 sections (0 Lead + 28 headings).
  - [x] `get-page` with `metadata=true` and `content=none` — metadata block includes `Size: 140474` and the full `Sections:` outline.
  - [x] `get-page` with `section=2` — returns the Design philosophy and features section (~10KB), no marker.
  - [x] `get-pages` on two large pages — 6 content blocks, marker inside each per-page block, per-page section list, different totalBytes per page.
  - [x] `compare-pages` with a huge added-diff — diff truncated at 50000 of 141794 bytes, marker with `includeDiff=false` remedy hint, no section list.
  - [x] `MCP_CONTENT_MAX_BYTES=5000` override on Python — cap respected, marker shows 5000 of 140474 bytes.

## Notes

- The spec at `docs/superpowers/specs/2026-04-21-large-page-content-design.md` drove the design. It's untracked, consistent with this repo's convention for brainstorm/plan artifacts.
- Per-request cap negotiation (per MCP discussion #2211) is intentionally out of scope; it's a moving target and no ratified SEP exists yet.
- Section-aware `update-page` (write-side round-trip) is deferred to its own follow-up — the spec sketches the shape.