### PR TITLE
Add section editing and append/prepend modes to update-page

### DIFF
--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -11,7 +11,7 @@ import { getPageUrl, formatEditComment } from '../common/utils.js';
 export function createPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'create-page',
-		'Creates a new wiki page with the provided content and returns the new page\'s title, page ID, and first revision ID. Fails if a page with the given title already exists; for existing pages, use update-page. The optional contentModel parameter selects a non-default content format (e.g. javascript, css); when omitted, MediaWiki picks the default for the title\'s namespace.',
+		'Creates a new wiki page with the provided content and returns the new page\'s title, page ID, and first revision ID. Fails if a page with the given title already exists; for existing pages, use update-page. The optional contentModel parameter selects a non-default content format (e.g. javascript, css); when omitted, MediaWiki picks the default for the title\'s namespace. For building up a large page across multiple calls, pair create-page with chained update-page(mode=\'append\') calls, each adding a chunk.',
 		{
 			source: z.string().describe( 'Page content in the format specified by the contentModel parameter' ),
 			title: z.string().describe( 'Wiki page title' ),

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -29,7 +29,7 @@ interface ApiEditResponse {
 export function updatePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'update-page',
-		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes.',
+		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, section=N updates a single section (paired with get-page section=N for reads), section=\'new\' appends a new heading section (sectionTitle required), and mode=append/prepend sends only the new text instead of the full page source. Each call is a separate revision; a failed chunk in a chain leaves a partially-updated page — re-fetching latestId between chained calls preserves conflict detection.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
 			source: z.string().describe( 'Replacement content in the existing page\'s content model. Interpreted as that section\'s content only when section is set.' ),

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -29,18 +29,18 @@ interface ApiEditResponse {
 export function updatePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'update-page',
-		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, section=N updates a single section (paired with get-page section=N for reads), section=\'new\' appends a new heading section (sectionTitle required), and mode=append/prepend sends only the new text instead of the full page source. Each call is a separate revision; a failed chunk in a chain leaves a partially-updated page — re-fetching latestId between chained calls preserves conflict detection.',
+		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, three modifiers avoid shipping the full source: section=N edits one section (pairs with get-page section=N for reads), section=\'new\' adds a new heading section, and mode=\'append\' or \'prepend\' sends a delta. Each call is a separate revision; for chains of mode=\'append\' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			source: z.string().describe( 'Replacement content in the existing page\'s content model. Interpreted as that section\'s content only when section is set.' ),
+			source: z.string().describe( 'The content to write, in the existing page\'s content model. Interpreted as the full page by default; as the given section\'s content when section is set; or as a delta (appended or prepended) when mode is set.' ),
 			latestId: z.number().int().positive().optional().describe( 'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
 			comment: z.string().optional().describe( 'Summary of the edit' ),
 			// eslint-disable-next-line es-x/no-set-prototype-union -- z.union, not Set.prototype.union
 			section: z.union( [
 				z.number().int().nonnegative(),
 				z.literal( 'new' )
-			] ).optional().describe( 'Section number to edit (0 = lead; 1..N = existing heading sections) or \'new\' to append a new heading section. When set, source is interpreted as that section\'s content only.' ),
-			mode: z.enum( [ 'append', 'prepend' ] ).optional().describe( 'Treat source as a delta appended to the end (\'append\') or prepended to the start (\'prepend\') of the existing content, rather than replacing it. Each mode=append/prepend call is its own revision.' ),
+			] ).optional().describe( 'Section to edit: 0 (lead), 1..N (existing heading sections), or \'new\' to append a new heading section.' ),
+			mode: z.enum( [ 'append', 'prepend' ] ).optional().describe( 'Adds source to the existing content instead of replacing it: \'append\' to the end, \'prepend\' to the start.' ),
 			sectionTitle: z.string().optional().describe( 'Heading for a new section; required when section=\'new\', rejected otherwise.' )
 		},
 		{

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -2,11 +2,26 @@ import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { ApiEditPageParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { getPageUrl, formatEditComment } from '../common/utils.js';
+
+interface UpdatePageArgs {
+	title: string;
+	source: string;
+	latestId?: number;
+	comment?: string;
+}
+
+interface ApiEditResponse {
+	result?: string;
+	pageid?: number;
+	title?: string;
+	newrevid?: number;
+	newtimestamp?: string;
+	contentmodel?: string;
+}
 
 export function updatePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -25,62 +40,73 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 			idempotentHint: true,
 			openWorldHint: true
 		} as ToolAnnotations,
-		async (
-			{ title, source, latestId, comment }
-		) => handleUpdatePageTool( title, source, latestId, comment )
+		async ( args ) => handleUpdatePageTool( args as UpdatePageArgs )
 	);
 }
 
+function errorResult( text: string ): CallToolResult {
+	return {
+		content: [ { type: 'text', text } as TextContent ],
+		isError: true
+	};
+}
+
 export async function handleUpdatePageTool(
-	title: string,
-	source: string,
-	latestId?: number,
-	comment?: string
+	args: UpdatePageArgs
 ): Promise<CallToolResult> {
+	const { title, source, latestId, comment } = args;
+
 	try {
 		const mwn = await getMwn();
-		// nocreate: fail if the page does not exist, so a mis-typed
-		// title doesn't silently create a new page.
-		const options: ApiEditPageParams = { nocreate: true };
+		const token = await mwn.getCsrfToken();
+
+		const params: Record<string, string | number | boolean | string[]> = {
+			action: 'edit',
+			title,
+			text: source,
+			summary: formatEditComment( 'update-page', comment ),
+			nocreate: true,
+			token,
+			formatversion: '2'
+		};
 		if ( latestId !== undefined ) {
-			options.baserevid = latestId;
+			params.baserevid = latestId;
 		}
+
 		const { config } = wikiService.getCurrent();
 		if ( config.tags !== null && config.tags !== undefined ) {
-			options.tags = config.tags;
+			params.tags = config.tags;
 		}
-		const result = await mwn.save(
-			title, source,
-			formatEditComment( 'update-page', comment ),
-			options
-		);
 
+		const response = await mwn.request( params );
+		const edit = response?.edit as ApiEditResponse | undefined;
+
+		if ( !edit || edit.result !== 'Success' ) {
+			return errorResult( `Failed to update page: ${ JSON.stringify( edit ?? response ) }` );
+		}
+
+		const resolvedTitle = edit.title ?? title;
 		return {
 			content: [
 				{
 					type: 'text',
-					text: `Page updated successfully: ${ getPageUrl( result.title ) }`
+					text: `Page updated successfully: ${ getPageUrl( resolvedTitle ) }`
 				},
 				{
 					type: 'text',
 					text: [
 						'Page object:',
-						`Page ID: ${ result.pageid }`,
-						`Title: ${ result.title }`,
-						`Latest revision ID: ${ result.newrevid }`,
-						`Latest revision timestamp: ${ result.newtimestamp }`,
-						`Content model: ${ result.contentmodel }`,
-						`HTML URL: ${ getPageUrl( result.title ) }`
+						`Page ID: ${ edit.pageid }`,
+						`Title: ${ resolvedTitle }`,
+						`Latest revision ID: ${ edit.newrevid }`,
+						`Latest revision timestamp: ${ edit.newtimestamp }`,
+						`Content model: ${ edit.contentmodel }`,
+						`HTML URL: ${ getPageUrl( resolvedTitle ) }`
 					].join( '\n' )
 				}
 			]
 		};
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to update page: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		return errorResult( `Failed to update page: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -12,6 +12,7 @@ interface UpdatePageArgs {
 	source: string;
 	latestId?: number;
 	comment?: string;
+	section?: number;
 }
 
 interface ApiEditResponse {
@@ -29,9 +30,10 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 		'Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes.',
 		{
 			title: z.string().describe( 'Wiki page title' ),
-			source: z.string().describe( 'Replacement page content in the existing page\'s content model' ),
+			source: z.string().describe( 'Replacement content in the existing page\'s content model. Interpreted as that section\'s content only when section is set.' ),
 			latestId: z.number().int().positive().optional().describe( 'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
-			comment: z.string().optional().describe( 'Summary of the edit' )
+			comment: z.string().optional().describe( 'Summary of the edit' ),
+			section: z.number().int().nonnegative().optional().describe( 'Section number to edit (0 = lead; 1..N = existing heading sections). When set, source is interpreted as that section\'s content only.' )
 		},
 		{
 			title: 'Update page',
@@ -54,7 +56,7 @@ function errorResult( text: string ): CallToolResult {
 export async function handleUpdatePageTool(
 	args: UpdatePageArgs
 ): Promise<CallToolResult> {
-	const { title, source, latestId, comment } = args;
+	const { title, source, latestId, comment, section } = args;
 
 	try {
 		const mwn = await getMwn();
@@ -76,6 +78,10 @@ export async function handleUpdatePageTool(
 		const { config } = wikiService.getCurrent();
 		if ( config.tags !== null && config.tags !== undefined ) {
 			params.tags = config.tags;
+		}
+
+		if ( section !== undefined ) {
+			params.section = String( section );
 		}
 
 		const response = await mwn.request( params );
@@ -107,6 +113,10 @@ export async function handleUpdatePageTool(
 			]
 		};
 	} catch ( error ) {
-		return errorResult( `Failed to update page: ${ ( error as Error ).message }` );
+		const msg = ( error as Error ).message;
+		if ( /nosuchsection/i.test( msg ) ) {
+			return errorResult( `Section ${ section } does not exist` );
+		}
+		return errorResult( `Failed to update page: ${ msg }` );
 	}
 }

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -13,6 +13,7 @@ interface UpdatePageArgs {
 	latestId?: number;
 	comment?: string;
 	section?: number | 'new';
+	mode?: 'append' | 'prepend';
 	sectionTitle?: string;
 }
 
@@ -39,6 +40,7 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 				z.number().int().nonnegative(),
 				z.literal( 'new' )
 			] ).optional().describe( 'Section number to edit (0 = lead; 1..N = existing heading sections) or \'new\' to append a new heading section. When set, source is interpreted as that section\'s content only.' ),
+			mode: z.enum( [ 'append', 'prepend' ] ).optional().describe( 'Treat source as a delta appended to the end (\'append\') or prepended to the start (\'prepend\') of the existing content, rather than replacing it. Each mode=append/prepend call is its own revision.' ),
 			sectionTitle: z.string().optional().describe( 'Heading for a new section; required when section=\'new\', rejected otherwise.' )
 		},
 		{
@@ -62,8 +64,11 @@ function errorResult( text: string ): CallToolResult {
 export async function handleUpdatePageTool(
 	args: UpdatePageArgs
 ): Promise<CallToolResult> {
-	const { title, source, latestId, comment, section, sectionTitle } = args;
+	const { title, source, latestId, comment, section, mode, sectionTitle } = args;
 
+	if ( section === 'new' && mode !== undefined ) {
+		return errorResult( 'mode is not compatible with section=\'new\'' );
+	}
 	if ( section === 'new' && sectionTitle === undefined ) {
 		return errorResult( 'sectionTitle is required when section=\'new\'' );
 	}
@@ -78,12 +83,18 @@ export async function handleUpdatePageTool(
 		const params: Record<string, string | number | boolean | string[]> = {
 			action: 'edit',
 			title,
-			text: source,
 			summary: formatEditComment( 'update-page', comment ),
 			nocreate: true,
 			token,
 			formatversion: '2'
 		};
+		if ( mode === 'append' ) {
+			params.appendtext = source;
+		} else if ( mode === 'prepend' ) {
+			params.prependtext = source;
+		} else {
+			params.text = source;
+		}
 		if ( latestId !== undefined ) {
 			params.baserevid = latestId;
 		}

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -12,7 +12,8 @@ interface UpdatePageArgs {
 	source: string;
 	latestId?: number;
 	comment?: string;
-	section?: number;
+	section?: number | 'new';
+	sectionTitle?: string;
 }
 
 interface ApiEditResponse {
@@ -33,7 +34,12 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 			source: z.string().describe( 'Replacement content in the existing page\'s content model. Interpreted as that section\'s content only when section is set.' ),
 			latestId: z.number().int().positive().optional().describe( 'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.' ),
 			comment: z.string().optional().describe( 'Summary of the edit' ),
-			section: z.number().int().nonnegative().optional().describe( 'Section number to edit (0 = lead; 1..N = existing heading sections). When set, source is interpreted as that section\'s content only.' )
+			// eslint-disable-next-line es-x/no-set-prototype-union -- z.union, not Set.prototype.union
+			section: z.union( [
+				z.number().int().nonnegative(),
+				z.literal( 'new' )
+			] ).optional().describe( 'Section number to edit (0 = lead; 1..N = existing heading sections) or \'new\' to append a new heading section. When set, source is interpreted as that section\'s content only.' ),
+			sectionTitle: z.string().optional().describe( 'Heading for a new section; required when section=\'new\', rejected otherwise.' )
 		},
 		{
 			title: 'Update page',
@@ -56,7 +62,14 @@ function errorResult( text: string ): CallToolResult {
 export async function handleUpdatePageTool(
 	args: UpdatePageArgs
 ): Promise<CallToolResult> {
-	const { title, source, latestId, comment, section } = args;
+	const { title, source, latestId, comment, section, sectionTitle } = args;
+
+	if ( section === 'new' && sectionTitle === undefined ) {
+		return errorResult( 'sectionTitle is required when section=\'new\'' );
+	}
+	if ( sectionTitle !== undefined && section !== 'new' ) {
+		return errorResult( 'sectionTitle is only valid when section=\'new\'' );
+	}
 
 	try {
 		const mwn = await getMwn();
@@ -82,6 +95,9 @@ export async function handleUpdatePageTool(
 
 		if ( section !== undefined ) {
 			params.section = String( section );
+		}
+		if ( sectionTitle !== undefined ) {
+			params.sectiontitle = sectionTitle;
 		}
 
 		const response = await mwn.request( params );
@@ -115,7 +131,8 @@ export async function handleUpdatePageTool(
 	} catch ( error ) {
 		const msg = ( error as Error ).message;
 		if ( /nosuchsection/i.test( msg ) ) {
-			return errorResult( `Section ${ section } does not exist` );
+			const label = section === undefined ? 'unknown' : String( section );
+			return errorResult( `Section ${ label } does not exist` );
 		}
 		return errorResult( `Failed to update page: ${ msg }` );
 	}

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -180,5 +180,52 @@ describe( 'update-page', () => {
 			expect( result.isError ).toBe( true );
 			expect( result.content[ 0 ].text ).toBe( 'Section 99 does not exist' );
 		} );
+
+		it( 'forwards section=\'new\' with sectionTitle as sectiontitle', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( {
+				title: 'My Page', source: 'body', section: 'new', sectionTitle: 'History'
+			} );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( {
+				section: 'new',
+				sectiontitle: 'History',
+				text: 'body'
+			} );
+		} );
+
+		it( 'rejects section=\'new\' without sectionTitle', async () => {
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'body', section: 'new'
+			} );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'sectionTitle is required when section=\'new\'' );
+		} );
+
+		it( 'rejects sectionTitle when section is a number', async () => {
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'body', section: 2, sectionTitle: 'History'
+			} );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'sectionTitle is only valid when section=\'new\'' );
+		} );
+
+		it( 'rejects sectionTitle when section is undefined', async () => {
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'body', sectionTitle: 'History'
+			} );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'sectionTitle is only valid when section=\'new\'' );
+		} );
 	} );
 } );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -14,149 +14,133 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 import { getMwn } from '../../src/common/mwn.js';
 import { wikiService } from '../../src/common/wikiService.js';
 
+function successResponse( overrides: Record<string, unknown> = {} ) {
+	return {
+		edit: {
+			result: 'Success',
+			pageid: 5,
+			title: 'My Page',
+			contentmodel: 'wikitext',
+			oldrevid: 41,
+			newrevid: 42,
+			newtimestamp: '2026-01-02T00:00:00Z',
+			...overrides
+		}
+	};
+}
+
+function mockEdit( response: unknown = successResponse() ) {
+	return createMockMwn( {
+		request: vi.fn().mockResolvedValue( response ),
+		getCsrfToken: vi.fn().mockResolvedValue( 'csrf-token' )
+	} );
+}
+
 describe( 'update-page', () => {
-	beforeEach( () => { vi.clearAllMocks(); } );
-
-	it( 'calls mwn.save() with baserevid for conflict detection', async () => {
-		const mock = createMockMwn( {
-			save: vi.fn().mockResolvedValue( {
-				result: 'Success', pageid: 5, title: 'My Page',
-				contentmodel: 'wikitext', oldrevid: 41, newrevid: 42,
-				newtimestamp: '2026-01-02T00:00:00Z'
-			} )
-		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
-
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		const result = await handleUpdatePageTool( 'My Page', 'Updated content', 41, 'edit summary' );
-
-		expect( result.isError ).toBeUndefined();
-		expect( result.content[ 0 ].text ).toContain( 'Page updated successfully' );
-		expect( mock.save ).toHaveBeenCalledWith(
-			'My Page', 'Updated content',
-			expect.stringContaining( 'edit summary' ),
-			expect.objectContaining( { baserevid: 41, nocreate: true } )
-		);
+	beforeEach( () => {
+		vi.clearAllMocks();
 	} );
 
-	it( 'calls mwn.save() without baserevid when latestId is omitted', async () => {
-		const mock = createMockMwn( {
-			save: vi.fn().mockResolvedValue( {
-				result: 'Success', pageid: 5, title: 'My Page',
-				contentmodel: 'wikitext', oldrevid: 41, newrevid: 42,
-				newtimestamp: '2026-01-02T00:00:00Z'
-			} )
+	describe( 'full-page replacement', () => {
+		it( 'sends text=source with nocreate and baserevid for conflict detection', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'Updated content', latestId: 41, comment: 'edit summary'
+			} );
+
+			expect( result.isError ).toBeUndefined();
+			expect( result.content[ 0 ].text ).toContain( 'Page updated successfully' );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( {
+				action: 'edit',
+				title: 'My Page',
+				text: 'Updated content',
+				nocreate: true,
+				baserevid: 41,
+				token: 'csrf-token'
+			} );
+			expect( params.summary ).toContain( 'edit summary' );
 		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
 
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		const result = await handleUpdatePageTool( 'My Page', 'Updated content', undefined, 'edit summary' );
+		it( 'omits baserevid when latestId is not supplied', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
 
-		expect( result.isError ).toBeUndefined();
-		expect( result.content[ 0 ].text ).toContain( 'Page updated successfully' );
-		expect( mock.save ).toHaveBeenCalledWith(
-			'My Page', 'Updated content',
-			expect.stringContaining( 'edit summary' ),
-			expect.objectContaining( { nocreate: true } )
-		);
-		const options = mock.save.mock.calls[ 0 ][ 3 ];
-		expect( options ).not.toHaveProperty( 'baserevid' );
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( { title: 'My Page', source: 'content' } );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).not.toHaveProperty( 'baserevid' );
+		} );
+
+		it( 'returns error when the API response lacks a Success result', async () => {
+			const mock = mockEdit( { edit: { result: 'Failure', code: 'abusefilter-disallowed' } } );
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( { title: 'My Page', source: 'content' } );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'Failed to update page' );
+		} );
+
+		it( 'returns error when mwn.request throws', async () => {
+			const mock = mockEdit();
+			mock.request = vi.fn().mockRejectedValue( new Error( 'Edit conflict' ) );
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( { title: 'My Page', source: 'content', latestId: 41 } );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'Edit conflict' );
+		} );
+
+		it( 'surfaces the missingtitle error from mwn when page does not exist', async () => {
+			const mock = mockEdit();
+			mock.request = vi.fn().mockRejectedValue( new Error( "The page you specified doesn't exist." ) );
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( { title: 'Does Not Exist', source: 'content', latestId: 1 } );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( "doesn't exist" );
+		} );
 	} );
 
-	it( 'returns error on failure', async () => {
-		const mock = createMockMwn( {
-			save: vi.fn().mockRejectedValue( new Error( 'Edit conflict' ) )
+	describe( 'tags', () => {
+		it( 'forwards configured array tags', async () => {
+			vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
+				key: 'test-wiki',
+				config: {
+					server: 'https://test.wiki',
+					articlepath: '/wiki',
+					scriptpath: '/w',
+					tags: [ 'mcp-server', 'automated' ]
+				}
+			} as ReturnType<typeof wikiService.getCurrent> );
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( { title: 'Tagged', source: 'content' } );
+
+			expect( mock.request.mock.calls[ 0 ][ 0 ] ).toHaveProperty( 'tags', [ 'mcp-server', 'automated' ] );
 		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
 
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		const result = await handleUpdatePageTool( 'My Page', 'content', 41 );
+		it( 'omits tags when not configured', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
 
-		expect( result.isError ).toBe( true );
-		expect( result.content[ 0 ].text ).toContain( 'Edit conflict' );
-	} );
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( { title: 'Untagged', source: 'content' } );
 
-	it( 'surfaces the missingtitle error from mwn when page does not exist', async () => {
-		const mock = createMockMwn( {
-			save: vi.fn().mockRejectedValue( new Error( 'The page you specified doesn\'t exist.' ) )
+			expect( mock.request.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'tags' );
 		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
-
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		const result = await handleUpdatePageTool( 'Does Not Exist', 'content', 1 );
-
-		expect( result.isError ).toBe( true );
-		expect( result.content[ 0 ].text ).toContain( 'doesn\'t exist' );
-	} );
-
-	it( 'forwards configured array tags to mwn.save()', async () => {
-		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
-			key: 'test-wiki',
-			config: {
-				server: 'https://test.wiki',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				tags: [ 'mcp-server', 'automated' ]
-			}
-		} as ReturnType<typeof wikiService.getCurrent> );
-
-		const mock = createMockMwn( {
-			save: vi.fn().mockResolvedValue( {
-				result: 'Success', pageid: 7, title: 'Tagged Page',
-				contentmodel: 'wikitext', oldrevid: 50, newrevid: 51,
-				newtimestamp: '2026-01-02T00:00:00Z'
-			} )
-		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
-
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		await handleUpdatePageTool( 'Tagged Page', 'content', 50, 'summary' );
-
-		const opts = mock.save.mock.calls[ 0 ][ 3 ];
-		expect( opts ).toHaveProperty( 'tags', [ 'mcp-server', 'automated' ] );
-	} );
-
-	it( 'omits tags from save options when not configured', async () => {
-		const mock = createMockMwn( {
-			save: vi.fn().mockResolvedValue( {
-				result: 'Success', pageid: 8, title: 'Untagged',
-				contentmodel: 'wikitext', oldrevid: 60, newrevid: 61,
-				newtimestamp: '2026-01-02T00:00:00Z'
-			} )
-		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
-
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		await handleUpdatePageTool( 'Untagged', 'content', undefined, 'summary' );
-
-		const opts = mock.save.mock.calls[ 0 ][ 3 ];
-		expect( opts ).not.toHaveProperty( 'tags' );
-	} );
-
-	it( 'treats null tags as unset on save', async () => {
-		vi.mocked( wikiService.getCurrent ).mockReturnValueOnce( {
-			key: 'test-wiki',
-			config: {
-				server: 'https://test.wiki',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				tags: null
-			}
-		} as ReturnType<typeof wikiService.getCurrent> );
-
-		const mock = createMockMwn( {
-			save: vi.fn().mockResolvedValue( {
-				result: 'Success', pageid: 9, title: 'Null Tagged',
-				contentmodel: 'wikitext', oldrevid: 70, newrevid: 71,
-				newtimestamp: '2026-01-02T00:00:00Z'
-			} )
-		} );
-		vi.mocked( getMwn ).mockResolvedValue( mock as any );
-
-		const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
-		await handleUpdatePageTool( 'Null Tagged', 'content', undefined, 'summary' );
-
-		const opts = mock.save.mock.calls[ 0 ][ 3 ];
-		expect( opts ).not.toHaveProperty( 'tags' );
 	} );
 } );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -143,4 +143,42 @@ describe( 'update-page', () => {
 			expect( mock.request.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'tags' );
 		} );
 	} );
+
+	describe( 'section editing', () => {
+		it( 'forwards section=2 as section=\'2\' with text=source', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'new section body', section: 2
+			} );
+
+			expect( result.isError ).toBeUndefined();
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( { section: '2', text: 'new section body' } );
+		} );
+
+		it( 'forwards section=0 (lead) as section=\'0\'', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( { title: 'My Page', source: 'lead', section: 0 } );
+
+			expect( mock.request.mock.calls[ 0 ][ 0 ] ).toMatchObject( { section: '0' } );
+		} );
+
+		it( 'maps nosuchsection error to a friendly message', async () => {
+			const mock = mockEdit();
+			mock.request = vi.fn().mockRejectedValue( new Error( 'nosuchsection: There is no section 99.' ) );
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( { title: 'My Page', source: 'x', section: 99 } );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toBe( 'Section 99 does not exist' );
+		} );
+	} );
 } );

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -228,4 +228,60 @@ describe( 'update-page', () => {
 			expect( result.content[ 0 ].text ).toContain( 'sectionTitle is only valid when section=\'new\'' );
 		} );
 	} );
+
+	describe( 'append/prepend mode', () => {
+		it( 'mode=append sends appendtext=source and omits text', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( {
+				title: 'My Page', source: '\n* New entry', mode: 'append'
+			} );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( { appendtext: '\n* New entry' } );
+			expect( params ).not.toHaveProperty( 'text' );
+			expect( params ).not.toHaveProperty( 'prependtext' );
+		} );
+
+		it( 'mode=prepend sends prependtext=source and omits text', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( {
+				title: 'My Page', source: 'intro\n', mode: 'prepend'
+			} );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( { prependtext: 'intro\n' } );
+			expect( params ).not.toHaveProperty( 'text' );
+			expect( params ).not.toHaveProperty( 'appendtext' );
+		} );
+
+		it( 'mode=append composes with section=2', async () => {
+			const mock = mockEdit();
+			vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			await handleUpdatePageTool( {
+				title: 'My Page', source: '\n* row', section: 2, mode: 'append'
+			} );
+
+			const params = mock.request.mock.calls[ 0 ][ 0 ];
+			expect( params ).toMatchObject( { section: '2', appendtext: '\n* row' } );
+			expect( params ).not.toHaveProperty( 'text' );
+		} );
+
+		it( 'rejects mode combined with section=\'new\'', async () => {
+			const { handleUpdatePageTool } = await import( '../../src/tools/update-page.js' );
+			const result = await handleUpdatePageTool( {
+				title: 'My Page', source: 'body', section: 'new', sectionTitle: 'History', mode: 'append'
+			} );
+
+			expect( result.isError ).toBe( true );
+			expect( result.content[ 0 ].text ).toContain( 'mode is not compatible with section=\'new\'' );
+		} );
+	} );
 } );


### PR DESCRIPTION
## Summary

Write-side counterpart to #283's content truncation, closing the large-page read/write loop: the LLM no longer has to ship the full page source in a tool call when editing a large page.

- `update-page` gains three new optional parameters:
  - `section?: number | 'new'` — edit one existing section by index (0 = lead; 1..N = heading sections), or `'new'` to create a new heading section.
  - `mode?: 'append' | 'prepend'` — send `source` as a delta (new text only) via MediaWiki's `appendtext` / `prependtext`, instead of replacing the whole page.
  - `sectionTitle?: string` — heading for a new section; required when `section='new'` and rejected otherwise.
- Composable: `section=N + mode='append'` appends to the end of section N. All other combinations are handled by three pre-API validation rules (rejected before any API call):
  - `section='new' + mode` → `"mode is not compatible with section='new'"`
  - `section='new'` without `sectionTitle` → `"sectionTitle is required when section='new'"`
  - `sectionTitle` with a non-`'new'` section → `"sectionTitle is only valid when section='new'"`
- Internal refactor: swapped `mwn.save` (which hardcodes `text: content`) for `mwn.request({action:'edit',...})` + explicit CSRF token, matching the existing `compare-pages` pattern. Backward-compatible for all existing call shapes.
- Error mapping: `/nosuchsection/i` → `"Section N does not exist"` (follows the `compare-pages` `nosuchrevid` precedent). Non-Success `edit.result` (e.g. abuse-filter denials) surfaced as `isError: true`.
- `create-page` schema unchanged; its description gains one sentence pointing callers with large new pages to the recipe `create-page(first chunk) → chained update-page(mode='append')`.
- `update-page` description documents all three modifiers, closes the loop with `get-page section=N` for reads, and flags the partial-failure caveat for chained append workflows.

Spec explored and designed via the superpowers brainstorming + writing-plans flow before implementation; execution via subagent-driven development with two-stage review after each task.

## Test plan

- [x] `npm test` — 261/261 tests pass (was 250 on master; +11 new across section/mode/sectionTitle and validation cases)
- [x] `npm run lint` — clean (two pre-existing `config.ts` security warnings unrelated)
- [x] `npm run build` — clean
- [x] Final code review — "Ready to merge: Yes", zero Critical, zero Important issues
- [x] MCP Inspector CLI end-to-end against `test.pro.wiki`:
  - [x] `tools/list` schema exposes `section`, `mode`, `sectionTitle` with correct types and descriptions
  - [x] `create-page` seeds a multi-section test page
  - [x] `section=1` replaces only History, leaves Lead + Background untouched
  - [x] `mode='append'` adds to end of whole page
  - [x] `mode='prepend'` adds to start of whole page
  - [x] `section=2 + mode='append'` composes — text lands at end of Background, not end of page
  - [x] `section='new' + sectionTitle='References'` creates a new heading section
  - [x] `section='new'` without `sectionTitle` → client-side error, no API call
  - [x] `section='new' + mode='append'` → client-side error, no API call
  - [x] `section=999` → `"Section 999 does not exist"` (mapped from MediaWiki's `rvnosuchsection`)
  - [x] Full-page replace with no new params — backward compat preserved

## Notes

- Spec at `docs/superpowers/specs/2026-04-23-section-aware-update-page-design.md` and plan at `docs/superpowers/plans/2026-04-23-section-aware-update-page.md` (untracked per repo convention).
- Conflict detection unchanged: MediaWiki's `basetimestamp` check via `latestId` continues to work page-wide. For section edits, MediaWiki auto-merges non-overlapping concurrent changes, so section-aware conflict detection comes for free.
- Per-request response-size negotiation (MCP discussion #2211) remains out of scope — still unratified.
- Six commits on the branch (five feature tasks + one description-cleanup pass). Squashable at merge time if preferred.

Closes #40