### PR TITLE
Block SSRF in add-wiki by validating discovery URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.25.2",
 				"express": "^5.1.0",
+				"ipaddr.js": "1.9.1",
 				"mwn": "^3.0.1",
 				"node-fetch": "^3.3.2",
 				"types-mediawiki-api": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"express": "^5.1.0",
+		"ipaddr.js": "1.9.1",
 		"mwn": "^3.0.1",
 		"node-fetch": "^3.3.2",
 		"types-mediawiki-api": "^2.0.0"

--- a/src/common/ssrfGuard.ts
+++ b/src/common/ssrfGuard.ts
@@ -1,0 +1,111 @@
+import { lookup } from 'node:dns/promises';
+import type { LookupAddress } from 'node:dns';
+import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+// eslint-disable-next-line n/no-missing-import
+import ipaddr from 'ipaddr.js';
+
+// ipaddr.js .range() classifies most reserved space correctly, but leaves
+// these as 'unicast' in v1.9.1. We treat them as non-public explicitly.
+const EXTRA_BLOCKED_V4: Record<string, [ipaddr.IPv4, number]> = {
+	benchmarking: [ ipaddr.IPv4.parse( '198.18.0.0' ), 15 ]
+};
+const EXTRA_BLOCKED_V6: Record<string, [ipaddr.IPv6, number]> = {
+	deprecatedSiteLocal: [ ipaddr.IPv6.parse( 'fec0::' ), 10 ],
+	deprecated6bone: [ ipaddr.IPv6.parse( '3ffe::' ), 16 ]
+};
+
+export async function assertPublicDestination(
+	urlString: string
+): Promise<LookupAddress[]> {
+	// MediaWiki's siteinfo.general.server uses protocol-relative URLs (e.g.
+	// '//en.wikipedia.org'). Normalise to https so the guard accepts them.
+	const normalized = urlString.startsWith( '//' ) ? 'https:' + urlString : urlString;
+	const url = new URL( normalized );
+	if ( url.protocol !== 'https:' && url.protocol !== 'http:' ) {
+		throw new Error(
+			`Refusing to fetch URL with unsupported scheme "${ url.protocol }": ${ urlString }`
+		);
+	}
+
+	const hostname = url.hostname.startsWith( '[' ) && url.hostname.endsWith( ']' ) ?
+		url.hostname.slice( 1, -1 ) :
+		url.hostname;
+
+	const addresses = await lookup( hostname, { all: true } );
+	if ( addresses.length === 0 ) {
+		throw new Error(
+			`DNS lookup for "${ hostname }" returned no addresses: ${ normalized }`
+		);
+	}
+	for ( const { address } of addresses ) {
+		assertAddressIsUnicast( address, normalized );
+	}
+	return addresses;
+}
+
+export function buildPinnedAgent(
+	urlString: string,
+	addresses: LookupAddress[]
+): HttpAgent | HttpsAgent {
+	const url = new URL( urlString );
+	// The Agent's lookup is invoked by net.connect for each TCP connection, so
+	// returning our pre-resolved addresses ensures fetch() cannot re-resolve
+	// the hostname into a different (private) address between validation and
+	// connection. SNI and the Host header are derived from the original URL,
+	// so HTTPS and virtual-hosted HTTP still work correctly.
+	//
+	// Pinning assumes direct connections. A future HTTPS_PROXY / CONNECT-tunnel
+	// Agent would bypass this lookup (the proxy resolves the hostname) and
+	// would need its own SSRF defense at the proxy layer.
+	const pinnedLookup = (
+		_hostname: string,
+		options: { all?: boolean },
+		callback: (
+			err: NodeJS.ErrnoException | null,
+			addressOrAll: string | LookupAddress[],
+			family?: number
+		) => void
+	): void => {
+		if ( options.all ) {
+			callback( null, addresses );
+			return;
+		}
+		const first = addresses[ 0 ];
+		callback( null, first.address, first.family );
+	};
+
+	const AgentCtor = url.protocol === 'https:' ? HttpsAgent : HttpAgent;
+	return new AgentCtor( { lookup: pinnedLookup } );
+}
+
+function assertAddressIsUnicast( address: string, urlString: string ): void {
+	let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+	try {
+		parsed = ipaddr.parse( address );
+	} catch {
+		throw new Error(
+			`Refusing to fetch URL resolving to unparseable address "${ address }": ${ urlString }`
+		);
+	}
+
+	if ( parsed.kind() === 'ipv6' && ( parsed as ipaddr.IPv6 ).isIPv4MappedAddress() ) {
+		parsed = ( parsed as ipaddr.IPv6 ).toIPv4Address();
+	}
+
+	const range = parsed.range();
+	if ( range !== 'unicast' ) {
+		throw new Error(
+			`Refusing to fetch URL resolving to non-public address ${ address } (${ range }): ${ urlString }`
+		);
+	}
+
+	const extraMatch = parsed.kind() === 'ipv4' ?
+		ipaddr.subnetMatch( parsed as ipaddr.IPv4, EXTRA_BLOCKED_V4, 'unicast' ) :
+		ipaddr.subnetMatch( parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast' );
+	if ( extraMatch !== 'unicast' ) {
+		throw new Error(
+			`Refusing to fetch URL resolving to non-public address ${ address } (${ extraMatch }): ${ urlString }`
+		);
+	}
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,9 @@
 import fetch, { Response } from 'node-fetch';
 import { USER_AGENT } from '../server.js';
 import { wikiService } from './wikiService.js';
+import { assertPublicDestination, buildPinnedAgent } from './ssrfGuard.js';
+
+const MAX_REDIRECTS = 5;
 
 async function fetchCore(
 	baseUrl: string,
@@ -31,19 +34,43 @@ async function fetchCore(
 		Object.assign( requestHeaders, options.headers );
 	}
 
-	const fetchOptions: { headers: Record<string, string>; method?: string } = {
-		headers: requestHeaders,
-		method: options?.method || 'GET'
-	};
+	let currentUrl = url;
+	let response: Response | undefined;
+	for ( let hop = 0; hop <= MAX_REDIRECTS; hop++ ) {
+		const addresses = await assertPublicDestination( currentUrl );
+		const agent = buildPinnedAgent( currentUrl, addresses );
+		response = await fetch( currentUrl, {
+			headers: requestHeaders,
+			method: options?.method || 'GET',
+			redirect: 'manual',
+			agent
+		} );
 
-	const response = await fetch( url, fetchOptions );
-	if ( !response.ok ) {
-		const errorBody = await response.text().catch( () => 'Could not read error response body' );
+		if ( response.status < 300 || response.status >= 400 ) {
+			break;
+		}
+
+		const location = response.headers.get( 'location' );
+		if ( !location ) {
+			break;
+		}
+
+		if ( hop === MAX_REDIRECTS ) {
+			throw new Error( `Too many redirects (>${ MAX_REDIRECTS }) starting from ${ url }` );
+		}
+
+		currentUrl = new URL( location, currentUrl ).toString();
+	}
+
+	// response is always assigned inside the loop (loop runs at least once).
+	const finalResponse = response as Response;
+	if ( !finalResponse.ok ) {
+		const errorBody = await finalResponse.text().catch( () => 'Could not read error response body' );
 		throw new Error(
-			`HTTP error! status: ${ response.status } for URL: ${ response.url }. Response: ${ errorBody }`
+			`HTTP error! status: ${ finalResponse.status } for URL: ${ finalResponse.url }. Response: ${ errorBody }`
 		);
 	}
-	return response;
+	return finalResponse;
 }
 
 export async function makeApiRequest<T>(

--- a/src/common/wikiDiscovery.ts
+++ b/src/common/wikiDiscovery.ts
@@ -1,4 +1,5 @@
 import { makeApiRequest, fetchPageHtml } from './utils.js';
+import { assertPublicDestination } from './ssrfGuard.js';
 
 const COMMON_SCRIPT_PATHS = [ '/w', '' ];
 
@@ -140,6 +141,11 @@ function parseWikiUrl( wikiUrl: string ): string {
 }
 
 export async function discoverWiki( wikiUrl: string ): Promise<WikiInfo | null> {
+	await assertPublicDestination( wikiUrl );
 	const wikiServer = parseWikiUrl( wikiUrl );
-	return getWikiInfo( wikiServer, wikiUrl );
+	const info = await getWikiInfo( wikiServer, wikiUrl );
+	if ( info !== null ) {
+		await assertPublicDestination( info.server );
+	}
+	return info;
 }

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -24,8 +24,23 @@ export function addWikiTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-async function handleAddWikiTool( server: McpServer, wikiUrl: string ): Promise<CallToolResult> {
-	const wikiInfo = await discoverWiki( wikiUrl );
+export async function handleAddWikiTool(
+	server: McpServer, wikiUrl: string
+): Promise<CallToolResult> {
+	let wikiInfo;
+	try {
+		wikiInfo = await discoverWiki( wikiUrl );
+	} catch ( error ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Failed to add wiki: ${ ( error as Error ).message }`
+				} as TextContent
+			],
+			isError: true
+		};
+	}
 
 	if ( wikiInfo === null ) {
 		return {

--- a/tests/common/ssrfGuard.test.ts
+++ b/tests/common/ssrfGuard.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( 'node:dns/promises', () => ( {
+	lookup: vi.fn()
+} ) );
+
+import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+import { lookup } from 'node:dns/promises';
+import { assertPublicDestination, buildPinnedAgent } from '../../src/common/ssrfGuard.js';
+
+describe( 'ssrfGuard.assertPublicDestination', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'rejects a non-http(s) scheme', async () => {
+		await expect(
+			assertPublicDestination( 'file:///etc/passwd' )
+		).rejects.toThrow( /scheme/i );
+	} );
+
+	it( 'rejects an IPv4 loopback literal', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '127.0.0.1', family: 4 }
+		] );
+		await expect(
+			assertPublicDestination( 'http://127.0.0.1/' )
+		).rejects.toThrow( /127\.0\.0\.1/ );
+	} );
+
+	it( 'rejects the cloud metadata link-local address', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '169.254.169.254', family: 4 }
+		] );
+		await expect(
+			assertPublicDestination( 'http://169.254.169.254/latest/meta-data/' )
+		).rejects.toThrow( /169\.254\.169\.254/ );
+	} );
+
+	it( 'rejects a hostname resolving to RFC1918 space', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '10.0.0.5', family: 4 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://internal.example/' )
+		).rejects.toThrow( /10\.0\.0\.5/ );
+	} );
+
+	it( 'rejects CGNAT and other non-unicast v4 ranges', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '100.64.0.1', family: 4 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://cgnat.example/' )
+		).rejects.toThrow();
+	} );
+
+	it( 'rejects IPv6 loopback', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '::1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'http://[::1]/' )
+		).rejects.toThrow( /::1/ );
+	} );
+
+	it( 'rejects IPv6 unique-local (fc00::/7)', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: 'fd12:3456:789a::1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://ula.example/' )
+		).rejects.toThrow();
+	} );
+
+	it( 'unwraps IPv4-mapped IPv6 and rejects underlying private v4', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '::ffff:127.0.0.1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://mapped.example/' )
+		).rejects.toThrow( /loopback/ );
+	} );
+
+	it( 'rejects when any resolved address is private in a dual-stack result', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '93.184.216.34', family: 4 },
+			{ address: '::1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://dualstack.example/' )
+		).rejects.toThrow( /::1/ );
+	} );
+
+	it( 'returns the resolved addresses for a public hostname', async () => {
+		const addrs = [
+			{ address: '93.184.216.34', family: 4 },
+			{ address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 }
+		];
+		vi.mocked( lookup ).mockResolvedValue( addrs );
+
+		const result = await assertPublicDestination(
+			'https://example.com/wiki/Main_Page'
+		);
+
+		expect( result ).toEqual( addrs );
+	} );
+
+	it( 'rejects IPv4 benchmarking range 198.18.0.0/15 (RFC 2544)', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '198.18.0.1', family: 4 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://bench.example/' )
+		).rejects.toThrow( /198\.18\.0\.1/ );
+	} );
+
+	it( 'rejects deprecated IPv6 site-local fec0::/10', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: 'fec0::1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://sitelocal.example/' )
+		).rejects.toThrow( /fec0::1/ );
+	} );
+
+	it( 'rejects deprecated IPv6 6bone 3ffe::/16', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '3ffe:1234::1', family: 6 }
+		] );
+		await expect(
+			assertPublicDestination( 'https://sixbone.example/' )
+		).rejects.toThrow( /3ffe:1234::1/ );
+	} );
+
+	it( 'accepts a protocol-relative URL (MediaWiki siteinfo shape) by assuming https', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [
+			{ address: '93.184.216.34', family: 4 }
+		] );
+
+		const result = await assertPublicDestination( '//en.wikipedia.org' );
+
+		expect( result ).toEqual( [ { address: '93.184.216.34', family: 4 } ] );
+		expect( lookup ).toHaveBeenCalledWith( 'en.wikipedia.org', { all: true } );
+	} );
+
+	it( 'rejects when DNS lookup returns no addresses', async () => {
+		vi.mocked( lookup ).mockResolvedValue( [] );
+		await expect(
+			assertPublicDestination( 'https://empty.example/' )
+		).rejects.toThrow( /no addresses/i );
+	} );
+
+	it( 'surfaces DNS lookup failures to the caller', async () => {
+		vi.mocked( lookup ).mockRejectedValue(
+			Object.assign( new Error( 'getaddrinfo ENOTFOUND nope.invalid' ), { code: 'ENOTFOUND' } )
+		);
+		await expect(
+			assertPublicDestination( 'https://nope.invalid/' )
+		).rejects.toThrow( /ENOTFOUND/ );
+	} );
+} );
+
+describe( 'ssrfGuard.buildPinnedAgent', () => {
+	const addrs = [
+		{ address: '93.184.216.34', family: 4 as const },
+		{ address: '2606:2800:220::1', family: 6 as const }
+	];
+
+	it( 'returns an https.Agent for an https URL', () => {
+		const agent = buildPinnedAgent( 'https://example.com/', addrs );
+		expect( agent ).toBeInstanceOf( HttpsAgent );
+	} );
+
+	it( 'returns an http.Agent for an http URL', () => {
+		const agent = buildPinnedAgent( 'http://example.com/', addrs );
+		expect( agent ).toBeInstanceOf( HttpAgent );
+		expect( agent ).not.toBeInstanceOf( HttpsAgent );
+	} );
+
+	it( 'lookup returns all pre-resolved addresses when options.all is true', () => {
+		const agent = buildPinnedAgent( 'https://example.com/', addrs );
+		return new Promise<void>( ( resolve, reject ) => {
+			// agent.options.lookup is the function we installed.
+			( agent as unknown as { options: { lookup: Function } } ).options.lookup(
+				'different.example',
+				{ all: true },
+				( err: Error | null, result: unknown ) => {
+					try {
+						expect( err ).toBeNull();
+						expect( result ).toEqual( addrs );
+						resolve();
+					} catch ( e ) {
+						reject( e );
+					}
+				}
+			);
+		} );
+	} );
+
+	it( 'lookup returns the first address when options.all is false', () => {
+		const agent = buildPinnedAgent( 'https://example.com/', addrs );
+		return new Promise<void>( ( resolve, reject ) => {
+			( agent as unknown as { options: { lookup: Function } } ).options.lookup(
+				'different.example',
+				{ all: false },
+				( err: Error | null, address: string, family: number ) => {
+					try {
+						expect( err ).toBeNull();
+						expect( address ).toBe( '93.184.216.34' );
+						expect( family ).toBe( 4 );
+						resolve();
+					} catch ( e ) {
+						reject( e );
+					}
+				}
+			);
+		} );
+	} );
+} );

--- a/tests/common/utils.test.ts
+++ b/tests/common/utils.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Response } from 'node-fetch';
+
+vi.mock( 'node-fetch', async () => {
+	const actual = await vi.importActual<typeof import( 'node-fetch' )>( 'node-fetch' );
+	return {
+		...actual,
+		default: vi.fn()
+	};
+} );
+
+vi.mock( '../../src/common/ssrfGuard.js', () => ( {
+	assertPublicDestination: vi.fn(),
+	buildPinnedAgent: vi.fn()
+} ) );
+
+import fetch from 'node-fetch';
+import { assertPublicDestination, buildPinnedAgent } from '../../src/common/ssrfGuard.js';
+import { makeApiRequest, fetchPageHtml } from '../../src/common/utils.js';
+
+describe( 'utils.fetchCore (via makeApiRequest / fetchPageHtml)', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( assertPublicDestination ).mockResolvedValue( [
+			{ address: '93.184.216.34', family: 4 }
+		] );
+		vi.mocked( buildPinnedAgent ).mockReturnValue( { __pinned: true } as never );
+	} );
+
+	it( 'calls assertPublicDestination with the final URL before fetching', async () => {
+		vi.mocked( fetch ).mockResolvedValueOnce( new Response( '{}', { status: 200 } ) );
+
+		await makeApiRequest( 'https://example.com/w/api.php', { action: 'query' } );
+
+		expect( assertPublicDestination ).toHaveBeenCalledWith(
+			'https://example.com/w/api.php?action=query'
+		);
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://example.com/w/api.php?action=query',
+			expect.objectContaining( { redirect: 'manual' } )
+		);
+	} );
+
+	it( 'pins DNS by passing an Agent built from the resolved addresses to fetch', async () => {
+		const resolved = [ { address: '93.184.216.34', family: 4 as const } ];
+		vi.mocked( assertPublicDestination ).mockResolvedValueOnce( resolved );
+		const pinned = { __pinned: 'v4-agent' } as never;
+		vi.mocked( buildPinnedAgent ).mockReturnValueOnce( pinned );
+		vi.mocked( fetch ).mockResolvedValueOnce( new Response( '{}', { status: 200 } ) );
+
+		await makeApiRequest( 'https://example.com/w/api.php' );
+
+		expect( buildPinnedAgent ).toHaveBeenCalledWith(
+			'https://example.com/w/api.php',
+			resolved
+		);
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://example.com/w/api.php',
+			expect.objectContaining( { agent: pinned } )
+		);
+	} );
+
+	it( 'rebuilds the pinned Agent per redirect hop from fresh resolved addresses', async () => {
+		const firstHop = [ { address: '93.184.216.34', family: 4 as const } ];
+		const secondHop = [ { address: '151.101.1.69', family: 4 as const } ];
+		vi.mocked( assertPublicDestination )
+			.mockResolvedValueOnce( firstHop )
+			.mockResolvedValueOnce( secondHop );
+		const firstAgent = { __pinned: 'first' } as never;
+		const secondAgent = { __pinned: 'second' } as never;
+		vi.mocked( buildPinnedAgent )
+			.mockReturnValueOnce( firstAgent )
+			.mockReturnValueOnce( secondAgent );
+		vi.mocked( fetch )
+			.mockResolvedValueOnce(
+				new Response( null, { status: 302, headers: { Location: 'https://other.example/api.php' } } )
+			)
+			.mockResolvedValueOnce( new Response( '{"ok":true}', { status: 200 } ) );
+
+		await makeApiRequest<{ ok: boolean }>( 'https://start.example/api.php' );
+
+		expect( buildPinnedAgent ).toHaveBeenNthCalledWith( 1, 'https://start.example/api.php', firstHop );
+		expect( buildPinnedAgent ).toHaveBeenNthCalledWith( 2, 'https://other.example/api.php', secondHop );
+		expect( fetch ).toHaveBeenNthCalledWith(
+			1,
+			'https://start.example/api.php',
+			expect.objectContaining( { agent: firstAgent } )
+		);
+		expect( fetch ).toHaveBeenNthCalledWith(
+			2,
+			'https://other.example/api.php',
+			expect.objectContaining( { agent: secondAgent } )
+		);
+	} );
+
+	it( 'throws without calling fetch when the guard rejects the URL', async () => {
+		vi.mocked( assertPublicDestination ).mockRejectedValueOnce(
+			new Error( 'Refusing to fetch URL resolving to non-public address 127.0.0.1 (loopback): http://127.0.0.1/' )
+		);
+
+		await expect(
+			makeApiRequest( 'http://127.0.0.1/w/api.php' )
+		).rejects.toThrow( /non-public/ );
+		expect( fetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetchPageHtml swallows guard rejections and returns null', async () => {
+		vi.mocked( assertPublicDestination ).mockRejectedValueOnce(
+			new Error( 'Refusing to fetch URL with unsupported scheme "file:": file:///etc/passwd' )
+		);
+
+		const result = await fetchPageHtml( 'file:///etc/passwd' );
+
+		expect( result ).toBeNull();
+		expect( fetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'follows a 302 redirect only after the guard approves the Location target', async () => {
+		vi.mocked( fetch )
+			.mockResolvedValueOnce(
+				new Response( null, { status: 302, headers: { Location: 'https://redirected.example/api.php' } } )
+			)
+			.mockResolvedValueOnce( new Response( '{"ok":true}', { status: 200 } ) );
+
+		const result = await makeApiRequest<{ ok: boolean }>( 'https://start.example/api.php' );
+
+		expect( result ).toEqual( { ok: true } );
+		expect( assertPublicDestination ).toHaveBeenNthCalledWith( 1, 'https://start.example/api.php' );
+		expect( assertPublicDestination ).toHaveBeenNthCalledWith( 2, 'https://redirected.example/api.php' );
+		expect( fetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'rejects a redirect whose Location resolves to a private address', async () => {
+		vi.mocked( fetch ).mockResolvedValueOnce(
+			new Response( null, { status: 302, headers: { Location: 'http://169.254.169.254/latest/meta-data/' } } )
+		);
+		vi.mocked( assertPublicDestination )
+			.mockResolvedValueOnce( undefined )
+			.mockRejectedValueOnce(
+				new Error( 'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): http://169.254.169.254/latest/meta-data/' )
+			);
+
+		await expect(
+			makeApiRequest( 'https://start.example/api.php' )
+		).rejects.toThrow( /169\.254\.169\.254/ );
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'resolves a protocol-relative Location against the previous URL before revalidating', async () => {
+		vi.mocked( fetch )
+			.mockResolvedValueOnce(
+				new Response( null, { status: 302, headers: { Location: '//other.example/api.php' } } )
+			)
+			.mockResolvedValueOnce( new Response( '{"ok":true}', { status: 200 } ) );
+
+		await makeApiRequest( 'https://start.example/api.php' );
+
+		expect( assertPublicDestination ).toHaveBeenNthCalledWith( 2, 'https://other.example/api.php' );
+	} );
+
+	it( 'resolves a path-only Location against the previous URL before revalidating', async () => {
+		vi.mocked( fetch )
+			.mockResolvedValueOnce(
+				new Response( null, { status: 302, headers: { Location: '/elsewhere/api.php' } } )
+			)
+			.mockResolvedValueOnce( new Response( '{"ok":true}', { status: 200 } ) );
+
+		await makeApiRequest( 'https://start.example/w/api.php' );
+
+		expect( assertPublicDestination ).toHaveBeenNthCalledWith( 2, 'https://start.example/elsewhere/api.php' );
+	} );
+
+	it( 'caps the redirect chain at five hops', async () => {
+		for ( let i = 0; i < 10; i++ ) {
+			vi.mocked( fetch ).mockResolvedValueOnce(
+				new Response( null, { status: 302, headers: { Location: `https://hop${ i + 1 }.example/` } } )
+			);
+		}
+
+		await expect(
+			makeApiRequest( 'https://start.example/api.php' )
+		).rejects.toThrow( /redirect/i );
+		expect( fetch.mock ? fetch.mock.calls.length : vi.mocked( fetch ).mock.calls.length )
+			.toBeLessThanOrEqual( 6 );
+	} );
+} );

--- a/tests/common/wikiDiscovery.test.ts
+++ b/tests/common/wikiDiscovery.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( '../../src/common/utils.js', () => ( {
+	makeApiRequest: vi.fn(),
+	fetchPageHtml: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/ssrfGuard.js', () => ( {
+	assertPublicDestination: vi.fn()
+} ) );
+
+import { makeApiRequest } from '../../src/common/utils.js';
+import { assertPublicDestination } from '../../src/common/ssrfGuard.js';
+import { discoverWiki } from '../../src/common/wikiDiscovery.js';
+
+describe( 'discoverWiki', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( assertPublicDestination ).mockResolvedValue( undefined );
+	} );
+
+	it( 'validates the supplied URL before any fetch', async () => {
+		vi.mocked( assertPublicDestination ).mockRejectedValueOnce(
+			new Error( 'Refusing to fetch URL resolving to non-public address 10.0.0.1 (private): http://10.0.0.1/' )
+		);
+
+		await expect( discoverWiki( 'http://10.0.0.1/' ) ).rejects.toThrow( /non-public/ );
+		expect( makeApiRequest ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects a discovered server URL that resolves to a private address', async () => {
+		vi.mocked( makeApiRequest ).mockResolvedValue( {
+			query: {
+				general: {
+					sitename: 'Pretend Wiki',
+					scriptpath: '/w',
+					articlepath: '/wiki/$1',
+					server: 'http://10.0.0.42',
+					servername: '10.0.0.42'
+				}
+			}
+		} );
+		vi.mocked( assertPublicDestination )
+			.mockResolvedValueOnce( undefined )
+			.mockRejectedValueOnce(
+				new Error( 'Refusing to fetch URL resolving to non-public address 10.0.0.42 (private): http://10.0.0.42' )
+			);
+
+		await expect(
+			discoverWiki( 'https://public.example/' )
+		).rejects.toThrow( /10\.0\.0\.42/ );
+	} );
+
+	it( 'returns the WikiInfo when both the input URL and the discovered server are public', async () => {
+		vi.mocked( makeApiRequest ).mockResolvedValue( {
+			query: {
+				general: {
+					sitename: 'Public Wiki',
+					scriptpath: '/w',
+					articlepath: '/wiki/$1',
+					server: 'https://public.example',
+					servername: 'public.example'
+				}
+			}
+		} );
+
+		const info = await discoverWiki( 'https://public.example/wiki/Main_Page' );
+
+		expect( info ).toEqual( {
+			sitename: 'Public Wiki',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+			server: 'https://public.example',
+			servername: 'public.example'
+		} );
+	} );
+} );

--- a/tests/tools/add-wiki.test.ts
+++ b/tests/tools/add-wiki.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( '../../src/common/wikiDiscovery.js', () => ( {
+	discoverWiki: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		add: vi.fn()
+	}
+} ) );
+
+import { discoverWiki } from '../../src/common/wikiDiscovery.js';
+
+describe( 'add-wiki', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns an isError tool response when discoverWiki throws (e.g. SSRF rejection)', async () => {
+		vi.mocked( discoverWiki ).mockRejectedValue(
+			new Error( 'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): http://169.254.169.254/' )
+		);
+
+		const { handleAddWikiTool } = await import( '../../src/tools/add-wiki.js' );
+		const server = { sendResourceListChanged: vi.fn() } as unknown as Parameters<typeof handleAddWikiTool>[0];
+		const result = await handleAddWikiTool( server, 'http://169.254.169.254/' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch( /169\.254\.169\.254/ );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes a Server-Side Request Forgery vector in the `add-wiki` tool. Previously, `add-wiki` accepted any client-supplied URL, passed it to `discoverWiki()`, and fetched it via a bare `node-fetch` that followed redirects by default. A malicious MCP client could probe internal services — cloud metadata (`169.254.169.254`), RFC1918, localhost admin panels — with response bodies leaking back through `fetchCore` error strings.

## What changes

- **New `src/common/ssrfGuard.ts`** — `assertPublicDestination(url)` validates the scheme is `http(s)`, DNS-resolves the hostname via `node:dns/promises.lookup({ all: true })`, rejects empty DNS results, and uses `ipaddr.js` to reject any address whose `range()` is not `'unicast'`. Unwraps IPv4-mapped IPv6 before checking. Returns the validated addresses so callers can pin to them.
- **Supplements `range()` with explicit subnet checks** for a few reserved ranges that `ipaddr.js@1.9.1` still classifies as `unicast`.
- **DNS pinning** — `buildPinnedAgent(url, addresses)` constructs a per-request `http.Agent` / `https.Agent` whose `lookup` callback returns exactly the pre-resolved addresses. `fetchCore` passes this Agent to `node-fetch` on every hop, so TCP connect cannot re-resolve the hostname into a different address between validation and connection. SNI and the `Host` header are still derived from the original URL, so HTTPS and virtual-hosted HTTP work correctly.
- **`fetchCore`** calls the guard before every hop, switches to `redirect: 'manual'`, walks redirects itself with a 5-hop cap, and re-validates each `Location` target (including protocol-relative and path-only Location headers, via `new URL(location, currentUrl)`).
- **`discoverWiki`** validates the client-supplied URL up-front **and** re-validates the `server` field returned in MediaWiki's `siteinfo` response. This closes the persisted-injection variant: a wiki that answers with a private `server` URL would otherwise land that URL in `wikiService`, and subsequent tool calls use `mwn` directly (bypassing `fetchCore`).
- **`add-wiki.ts`** exports `handleAddWikiTool` (per AGENTS.md) and wraps `discoverWiki` in `try/catch` so guard rejections surface as clean `isError` tool content rather than a generic MCP error.
- Adds `ipaddr.js@1.9.1` as a direct dep, pinned to the exact version Express already carries transitively via `proxy-addr` — zero-risk add.

## Scope & non-goals

- This fix only addresses the `add-wiki` discovery vector (finding H1 from the internal MCP-spec security audit).
- `upload-file` path-traversal hardening, HTTP default-bind to loopback, and session-to-bearer binding are tracked separately for follow-up PRs.

## Test plan

- [x] `npm test` — 294/294 pass (33 new across 4 test files covering guard, fetchCore, discoverWiki, add-wiki)
- [x] `npm run lint` — clean on new code (2 pre-existing warnings in `config.ts` unrelated to this PR)
- [x] `npm run build` — clean
- [x] Manual smoke test: `add-wiki` against a real public wiki still succeeds
- [x] Manual smoke test: `add-wiki` against a private-IP URL returns a clean `isError` tool response, no internal probe occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)