### PR TITLE
Standardise LLM-facing error shapes across tools

### DIFF
--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -172,9 +172,9 @@ Do not interchange these.
 
 #### Common MediaWiki error patterns
 
-Every tool error return is a single text block of the form `category: message`, with `isError: true`. The category is one of a fixed set (see § "Error categories" below) and lets an LLM caller pattern-match the failure class; the message carries human-readable detail. Tool descriptions continue to describe the *conditions* a tool can fail on (e.g. "if the page does not exist") but do not name the category — the taxonomy is documented once, here.
+Each tool error returns as a single text block shaped `category: message`, with `isError: true`. The category lets an LLM caller pattern-match the failure class (see "Error categories" below for the full set); the message carries the detail. Tool descriptions name the *conditions* a tool can fail on (e.g. "if the page does not exist"), never the category — the taxonomy lives only in this section.
 
-- **`badtags`** — a change tag is configured that is not registered or not applicable to this action. Surfaces from write tools when the wiki's `tags` config is misset. Category: `invalid_input`.
+- **`badtags`** — the configured change tag is either unregistered or not applicable to this action. Surfaces from write tools when the wiki's `tags` config is misset. Category: `invalid_input`.
 - **`missingtitle`** — the target page does not exist. Surfaces from `get-page`, `update-page`, `compare-pages`, `get-page-history`. Category: `not_found`.
 - **`nosuchrevid`** — the requested revision ID does not exist. Surfaces from `get-revision`, `compare-pages`. Category: `not_found`.
 
@@ -182,19 +182,19 @@ Example phrasing: `"Returns a wiki page. If the title does not exist, an error i
 
 #### Error categories
 
-Seven categories cover every error a tool emits. The specific message carries detail; the category is the LLM's pattern-match handle.
+Seven categories cover every error a tool emits:
 
 | Category | When it's emitted | Typical LLM response |
 |---|---|---|
-| `not_found` | Target page, revision, section, or file does not exist. | Re-check identifier; search if appropriate. |
-| `permission_denied` | Authed user lacks the permission (including page protection and abuse-filter blocks). | Surface to user; don't retry as same user. |
-| `invalid_input` | Caller supplied incompatible or malformed arguments, or the wiki rejected them as invalid. | Fix the arguments and retry. |
-| `conflict` | Edit conflict (`latestId` mismatch), `create-page` on existing title, or `upload-file` without overwrite. | Re-read latest state; reconcile; retry. |
-| `authentication` | Credentials missing, invalid, or expired. | Re-authenticate; do not retry as anonymous. |
+| `not_found` | Target page, revision, section, or file does not exist. | Re-check the identifier; search if appropriate. |
+| `permission_denied` | The authenticated user lacks the permission (including page protection and abuse-filter blocks). | Surface to the user; don't retry as the same user. |
+| `invalid_input` | Arguments are incompatible or malformed, or the wiki rejected them as invalid. | Fix the arguments and retry. |
+| `conflict` | Edit conflict (`latestId` mismatch), `create-page` on an existing title, or `upload-file` without overwrite. | Re-read the latest state; reconcile; retry. |
+| `authentication` | Credentials are missing, invalid, or expired. | Re-authenticate; don't retry as anonymous. |
 | `rate_limited` | The wiki throttled this caller. | Back off and retry. |
-| `upstream_failure` | Unrecognised MediaWiki error, network failure, read-only mode, or any unrecognised throw shape. | Retry with caution; surface if persistent. |
+| `upstream_failure` | Unclassified MediaWiki error, network failure, read-only mode, or any unexpected throw. | Retry with caution; surface if persistent. |
 
-Unrecognised MW error codes map to `upstream_failure` with the raw message passed through, so information isn't lost at the cost of a coarser category.
+Unrecognised MW error codes fall through to `upstream_failure` with the raw message preserved — information survives, just at a coarser category.
 
 Worked examples:
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -172,13 +172,37 @@ Do not interchange these.
 
 #### Common MediaWiki error patterns
 
-When an LLM invokes a tool that fails with one of these errors, the caller needs to understand what happened. Descriptions for tools that expose these errors should mention the condition (not the error code).
+Every tool error return is a single text block of the form `category: message`, with `isError: true`. The category is one of a fixed set (see § "Error categories" below) and lets an LLM caller pattern-match the failure class; the message carries human-readable detail. Tool descriptions continue to describe the *conditions* a tool can fail on (e.g. "if the page does not exist") but do not name the category — the taxonomy is documented once, here.
 
-- **`badtags`** — a change tag is configured that is not registered or not applicable to this action. Surfaces from write tools when the wiki's `tags` config is misset.
-- **`missingtitle`** — the target page does not exist. Surfaces from `get-page`, `update-page`, `compare-pages`, `get-page-history`.
-- **`nosuchrevid`** — the requested revision ID does not exist. Surfaces from `get-revision`, `compare-pages`.
+- **`badtags`** — a change tag is configured that is not registered or not applicable to this action. Surfaces from write tools when the wiki's `tags` config is misset. Category: `invalid_input`.
+- **`missingtitle`** — the target page does not exist. Surfaces from `get-page`, `update-page`, `compare-pages`, `get-page-history`. Category: `not_found`.
+- **`nosuchrevid`** — the requested revision ID does not exist. Surfaces from `get-revision`, `compare-pages`. Category: `not_found`.
 
 Example phrasing: `"Returns a wiki page. If the title does not exist, an error is returned."` — not `"...a missingtitle error is returned."`
+
+#### Error categories
+
+Seven categories cover every error a tool emits. The specific message carries detail; the category is the LLM's pattern-match handle.
+
+| Category | When it's emitted | Typical LLM response |
+|---|---|---|
+| `not_found` | Target page, revision, section, or file does not exist. | Re-check identifier; search if appropriate. |
+| `permission_denied` | Authed user lacks the permission (including page protection and abuse-filter blocks). | Surface to user; don't retry as same user. |
+| `invalid_input` | Caller supplied incompatible or malformed arguments, or the wiki rejected them as invalid. | Fix the arguments and retry. |
+| `conflict` | Edit conflict (`latestId` mismatch), `create-page` on existing title, or `upload-file` without overwrite. | Re-read latest state; reconcile; retry. |
+| `authentication` | Credentials missing, invalid, or expired. | Re-authenticate; do not retry as anonymous. |
+| `rate_limited` | The wiki throttled this caller. | Back off and retry. |
+| `upstream_failure` | Unrecognised MediaWiki error, network failure, read-only mode, or any non-`Error` throw. | Retry with caution; surface if persistent. |
+
+Unrecognised MW error codes map to `upstream_failure` with the raw message passed through, so information isn't lost at the cost of a coarser category.
+
+Worked examples:
+
+```
+not_found: Page "Example" not found
+invalid_input: Must supply exactly one of fromRevision, fromTitle, fromText
+upstream_failure: readonly — wiki is currently in read-only mode
+```
 
 ### This codebase
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -192,7 +192,7 @@ Seven categories cover every error a tool emits. The specific message carries de
 | `conflict` | Edit conflict (`latestId` mismatch), `create-page` on existing title, or `upload-file` without overwrite. | Re-read latest state; reconcile; retry. |
 | `authentication` | Credentials missing, invalid, or expired. | Re-authenticate; do not retry as anonymous. |
 | `rate_limited` | The wiki throttled this caller. | Back off and retry. |
-| `upstream_failure` | Unrecognised MediaWiki error, network failure, read-only mode, or any non-`Error` throw. | Retry with caution; surface if persistent. |
+| `upstream_failure` | Unrecognised MediaWiki error, network failure, read-only mode, or any unrecognised throw shape. | Retry with caution; surface if persistent. |
 
 Unrecognised MW error codes map to `upstream_failure` with the raw message passed through, so information isn't lost at the cost of a coarser category.
 
@@ -201,7 +201,7 @@ Worked examples:
 ```
 not_found: Page "Example" not found
 invalid_input: Must supply exactly one of fromRevision, fromTitle, fromText
-upstream_failure: readonly — wiki is currently in read-only mode
+upstream_failure: Failed to create page: The wiki is currently in read-only mode.
 ```
 
 ### This codebase

--- a/src/common/errorMapping.ts
+++ b/src/common/errorMapping.ts
@@ -1,0 +1,98 @@
+/* eslint-disable n/no-missing-import */
+import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+
+export type ErrorCategory =
+	| 'not_found'
+	| 'permission_denied'
+	| 'invalid_input'
+	| 'conflict'
+	| 'upstream_failure'
+	| 'rate_limited'
+	| 'authentication';
+
+const MW_CODE_TO_CATEGORY: Record<string, ErrorCategory> = {
+	// not_found
+	missingtitle: 'not_found',
+	nosuchrevid: 'not_found',
+	nosuchsection: 'not_found',
+	nofile: 'not_found',
+	// permission_denied
+	permissiondenied: 'permission_denied',
+	protectedpage: 'permission_denied',
+	protectedtitle: 'permission_denied',
+	cascadeprotected: 'permission_denied',
+	cantcreate: 'permission_denied',
+	readapidenied: 'permission_denied',
+	writeapidenied: 'permission_denied',
+	blocked: 'permission_denied',
+	'abusefilter-disallowed': 'permission_denied',
+	'abusefilter-warning': 'permission_denied',
+	// invalid_input
+	invalidtitle: 'invalid_input',
+	invalidparammix: 'invalid_input',
+	badvalue: 'invalid_input',
+	baddatatype: 'invalid_input',
+	paramempty: 'invalid_input',
+	badtags: 'invalid_input',
+	// conflict
+	editconflict: 'conflict',
+	articleexists: 'conflict',
+	fileexists: 'conflict',
+	'fileexists-no-change': 'conflict',
+	// authentication
+	notloggedin: 'authentication',
+	badtoken: 'authentication',
+	mustbeloggedin: 'authentication',
+	assertuserfailed: 'authentication',
+	assertbotfailed: 'authentication',
+	// rate_limited
+	ratelimited: 'rate_limited',
+	// upstream_failure (explicit; unknown codes also fall through here)
+	readonly: 'upstream_failure'
+};
+
+// mwn sometimes surfaces codes only inside the error message, not on .code.
+// These patterns infer a canonical code from the message, which then routes
+// through MW_CODE_TO_CATEGORY.
+const MESSAGE_FALLBACK_PATTERNS: readonly ( readonly [ RegExp, string ] )[] = [
+	[ /\bmissingtitle\b/i, 'missingtitle' ],
+	[ /\bnosuchrevid\b/i, 'nosuchrevid' ],
+	[ /\bnosuchsection\b/i, 'nosuchsection' ],
+	[ /\beditconflict\b/i, 'editconflict' ],
+	[ /\bratelimited\b/i, 'ratelimited' ]
+];
+
+export function classifyError( err: unknown ): { category: ErrorCategory; code?: string } {
+	if ( err !== null && typeof err === 'object' ) {
+		const code = ( err as { code?: unknown } ).code;
+		if ( typeof code === 'string' ) {
+			const mapped = MW_CODE_TO_CATEGORY[ code ];
+			if ( mapped ) {
+				return { category: mapped, code };
+			}
+			if ( /^internal_api_error_/.test( code ) ) {
+				return { category: 'upstream_failure', code };
+			}
+		}
+		const message = ( err as { message?: unknown } ).message;
+		if ( typeof code !== 'string' && typeof message === 'string' ) {
+			for ( const [ pattern, inferredCode ] of MESSAGE_FALLBACK_PATTERNS ) {
+				if ( pattern.test( message ) ) {
+					return {
+						category: MW_CODE_TO_CATEGORY[ inferredCode ],
+						code: inferredCode
+					};
+				}
+			}
+		}
+	}
+	return { category: 'upstream_failure' };
+}
+
+export function errorResult( category: ErrorCategory, message: string ): CallToolResult {
+	return {
+		content: [ { type: 'text', text: `${ category }: ${ message }` } as TextContent ],
+		isError: true
+	};
+}

--- a/src/common/ssrfGuard.ts
+++ b/src/common/ssrfGuard.ts
@@ -5,6 +5,13 @@ import { Agent as HttpsAgent } from 'node:https';
 // eslint-disable-next-line n/no-missing-import
 import ipaddr from 'ipaddr.js';
 
+export class SsrfValidationError extends Error {
+	public constructor( message: string ) {
+		super( message );
+		this.name = 'SsrfValidationError';
+	}
+}
+
 // ipaddr.js .range() classifies most reserved space correctly, but leaves
 // these as 'unicast' in v1.9.1. We treat them as non-public explicitly.
 const EXTRA_BLOCKED_V4: Record<string, [ipaddr.IPv4, number]> = {
@@ -23,7 +30,7 @@ export async function assertPublicDestination(
 	const normalized = urlString.startsWith( '//' ) ? 'https:' + urlString : urlString;
 	const url = new URL( normalized );
 	if ( url.protocol !== 'https:' && url.protocol !== 'http:' ) {
-		throw new Error(
+		throw new SsrfValidationError(
 			`Refusing to fetch URL with unsupported scheme "${ url.protocol }": ${ urlString }`
 		);
 	}
@@ -34,7 +41,7 @@ export async function assertPublicDestination(
 
 	const addresses = await lookup( hostname, { all: true } );
 	if ( addresses.length === 0 ) {
-		throw new Error(
+		throw new SsrfValidationError(
 			`DNS lookup for "${ hostname }" returned no addresses: ${ normalized }`
 		);
 	}
@@ -84,7 +91,7 @@ function assertAddressIsUnicast( address: string, urlString: string ): void {
 	try {
 		parsed = ipaddr.parse( address );
 	} catch {
-		throw new Error(
+		throw new SsrfValidationError(
 			`Refusing to fetch URL resolving to unparseable address "${ address }": ${ urlString }`
 		);
 	}
@@ -95,7 +102,7 @@ function assertAddressIsUnicast( address: string, urlString: string ): void {
 
 	const range = parsed.range();
 	if ( range !== 'unicast' ) {
-		throw new Error(
+		throw new SsrfValidationError(
 			`Refusing to fetch URL resolving to non-public address ${ address } (${ range }): ${ urlString }`
 		);
 	}
@@ -104,7 +111,7 @@ function assertAddressIsUnicast( address: string, urlString: string ): void {
 		ipaddr.subnetMatch( parsed as ipaddr.IPv4, EXTRA_BLOCKED_V4, 'unicast' ) :
 		ipaddr.subnetMatch( parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast' );
 	if ( extraMatch !== 'unicast' ) {
-		throw new Error(
+		throw new SsrfValidationError(
 			`Refusing to fetch URL resolving to non-public address ${ address } (${ extraMatch }): ${ urlString }`
 		);
 	}

--- a/src/common/wikiService.ts
+++ b/src/common/wikiService.ts
@@ -8,6 +8,13 @@ type DeepReadonly<T> = {
 	readonly [P in keyof T]: T[P] extends object ? DeepReadonly<T[P]> : T[P];
 };
 
+export class DuplicateWikiKeyError extends Error {
+	public constructor( key: string ) {
+		super( `Wiki "${ key }" already exists in configuration` );
+		this.name = 'DuplicateWikiKeyError';
+	}
+}
+
 const config = loadConfigFromFile();
 
 let currentWikiKey: string = config.defaultWiki;
@@ -32,7 +39,7 @@ function add( key: string, wikiConfig: WikiConfig ): void {
 	}
 
 	if ( config.wikis[ key ] ) {
-		throw new Error( `Wiki "${ key }" already exists in configuration` );
+		throw new DuplicateWikiKeyError( key );
 	}
 
 	config.wikis[ key ] = wikiConfig;

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { wikiService } from '../common/wikiService.js';
 import { discoverWiki } from '../common/wikiDiscovery.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function addWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -43,15 +44,10 @@ export async function handleAddWikiTool(
 	}
 
 	if ( wikiInfo === null ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: 'Failed to determine wiki info. Please ensure the URL is correct and the wiki is accessible.'
-				} as TextContent
-			],
-			isError: true
-		};
+		return errorResult(
+			'upstream_failure',
+			'Failed to determine wiki info. Please ensure the URL is correct and the wiki is accessible.'
+		);
 	}
 
 	try {
@@ -76,14 +72,7 @@ export async function handleAddWikiTool(
 			]
 		};
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Failed to add wiki: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to add wiki: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
-import { wikiService } from '../common/wikiService.js';
+import { wikiService, DuplicateWikiKeyError } from '../common/wikiService.js';
 import { discoverWiki } from '../common/wikiDiscovery.js';
 import { classifyError, errorResult } from '../common/errorMapping.js';
 
@@ -72,6 +72,9 @@ export async function handleAddWikiTool(
 			]
 		};
 	} catch ( error ) {
+		if ( error instanceof DuplicateWikiKeyError ) {
+			return errorResult( 'conflict', error.message );
+		}
 		const { category } = classifyError( error );
 		return errorResult( category, `Failed to add wiki: ${ ( error as Error ).message }` );
 	}

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -6,6 +6,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 import { wikiService, DuplicateWikiKeyError } from '../common/wikiService.js';
 import { discoverWiki } from '../common/wikiDiscovery.js';
 import { classifyError, errorResult } from '../common/errorMapping.js';
+import { SsrfValidationError } from '../common/ssrfGuard.js';
 
 export function addWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -32,15 +33,11 @@ export async function handleAddWikiTool(
 	try {
 		wikiInfo = await discoverWiki( wikiUrl );
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Failed to add wiki: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		if ( error instanceof SsrfValidationError ) {
+			return errorResult( 'invalid_input', `Failed to add wiki: ${ error.message }` );
+		}
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to add wiki: ${ ( error as Error ).message }` );
 	}
 
 	if ( wikiInfo === null ) {

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -9,6 +9,7 @@ import {
 	truncationMarker,
 	truncateByBytes
 } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 interface ComparePagesArgs {
 	fromRevision?: number;
@@ -57,13 +58,6 @@ export function comparePagesTool( server: McpServer ): RegisteredTool {
 		} as ToolAnnotations,
 		async ( args ) => handleComparePagesTool( args as ComparePagesArgs )
 	);
-}
-
-function errorResult( text: string ): CallToolResult {
-	return {
-		content: [ { type: 'text', text } as TextContent ],
-		isError: true
-	};
 }
 
 function countSide( side: Side, args: ComparePagesArgs ): number {
@@ -145,14 +139,14 @@ export async function handleComparePagesTool(
 ): Promise<CallToolResult> {
 	const fromError = validateSide( 'from', args );
 	if ( fromError ) {
-		return errorResult( fromError );
+		return errorResult( 'invalid_input', fromError );
 	}
 	const toError = validateSide( 'to', args );
 	if ( toError ) {
-		return errorResult( toError );
+		return errorResult( 'invalid_input', toError );
 	}
 	if ( args.fromText !== undefined && args.toText !== undefined ) {
-		return errorResult( 'Cannot compare supplied text against supplied text' );
+		return errorResult( 'invalid_input', 'Cannot compare supplied text against supplied text' );
 	}
 
 	const includeDiff = args.includeDiff ?? true;
@@ -171,7 +165,7 @@ export async function handleComparePagesTool(
 		const compare = response.compare as CompareResponse | undefined;
 
 		if ( !compare ) {
-			return errorResult( 'Failed to compare pages: no compare result returned' );
+			return errorResult( 'upstream_failure', 'Failed to compare pages: no compare result returned' );
 		}
 
 		const anchorTitle = compare.fromtitle ?? compare.totitle;
@@ -227,23 +221,28 @@ export async function handleComparePagesTool(
 
 		return { content: results };
 	} catch ( error ) {
+		const { category, code } = classifyError( error );
 		const msg = ( error as Error ).message;
-		if ( /nosuchrevid/i.test( msg ) ) {
+		if ( code === 'nosuchrevid' ) {
 			const idMatch = msg.match( /\b(\d+)\b/ );
-			if ( idMatch ) {
-				return errorResult( `Revision ${ idMatch[ 1 ] } not found` );
-			}
-			return errorResult( `Revision not found: ${ msg }` );
-		}
-		if ( /missingtitle/i.test( msg ) ) {
-			const titleMatch = msg.match( /["'`]([^"'`]+)["'`]/ );
-			const missingTitle = titleMatch?.[ 1 ] ?? args.fromTitle ?? args.toTitle;
+			const id = idMatch?.[ 1 ] ?? (
+				args.fromRevision !== undefined ? String( args.fromRevision ) :
+					args.toRevision !== undefined ? String( args.toRevision ) :
+						undefined
+			);
 			return errorResult(
-				missingTitle ?
-					`Page "${ missingTitle }" not found` :
-					`Page not found: ${ msg }`
+				'not_found',
+				id !== undefined ? `Revision ${ id } not found` : 'Revision not found'
 			);
 		}
-		return errorResult( `Failed to compare pages: ${ msg }` );
+		if ( code === 'missingtitle' ) {
+			const titleMatch = msg.match( /["'`]([^"'`]+)["'`]/ );
+			const title = titleMatch?.[ 1 ] ?? args.fromTitle ?? args.toTitle;
+			return errorResult(
+				'not_found',
+				title !== undefined ? `Page "${ title }" not found` : 'Page not found'
+			);
+		}
+		return errorResult( category, `Failed to compare pages: ${ msg }` );
 	}
 }

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -225,11 +225,13 @@ export async function handleComparePagesTool(
 		const msg = ( error as Error ).message;
 		if ( code === 'nosuchrevid' ) {
 			const idMatch = msg.match( /\b(\d+)\b/ );
-			const id = idMatch?.[ 1 ] ?? (
-				args.fromRevision !== undefined ? String( args.fromRevision ) :
-					args.toRevision !== undefined ? String( args.toRevision ) :
-						undefined
-			);
+			let id: string | undefined = idMatch?.[ 1 ];
+			if ( id === undefined && args.fromRevision !== undefined ) {
+				id = String( args.fromRevision );
+			}
+			if ( id === undefined && args.toRevision !== undefined ) {
+				id = String( args.toRevision );
+			}
 			return errorResult(
 				'not_found',
 				id !== undefined ? `Revision ${ id } not found` : 'Revision not found'

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiEditPageParams } from 'types-mediawiki-api';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { getPageUrl, formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function createPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -74,11 +75,7 @@ export async function handleCreatePageTool(
 			]
 		};
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to create page: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to create page: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -50,7 +50,7 @@ export async function handleDeletePageTool(
 		);
 	} catch ( error ) {
 		const { category } = classifyError( error );
-		return errorResult( category, `Delete failed: ${ ( error as Error ).message }` );
+		return errorResult( category, `Failed to delete page: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -8,6 +8,7 @@ import type { ApiDeleteParams } from 'types-mediawiki-api';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function deletePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -48,15 +49,8 @@ export async function handleDeletePageTool(
 			options
 		);
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Delete failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Delete failed: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -99,6 +99,6 @@ export async function handleGetCategoryMembersTool(
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
 		const { category } = classifyError( error );
-		return errorResult( category, `Get category members failed: ${ ( error as Error ).message }` );
+		return errorResult( category, `Failed to retrieve category members: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 enum CategoryMemberType {
 	file = 'file',
@@ -97,12 +98,7 @@ export async function handleGetCategoryMembersTool(
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: `Get category members failed: ${ ( error as Error ).message }`
-			} as TextContent ],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Get category members failed: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-file.ts
+++ b/src/tools/get-file.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import type { ApiPage, ImageInfo } from 'mwn';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function getFileTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -42,23 +43,13 @@ export async function handleGetFileTool( title: string ): Promise<CallToolResult
 		const page = response.query?.pages?.[ 0 ] as ApiPage | undefined;
 
 		if ( !page || page.missing ) {
-			return {
-				content: [
-					{ type: 'text', text: `File "${ title }" not found` } as TextContent
-				],
-				isError: true
-			};
+			return errorResult( 'not_found', `File "${ title }" not found` );
 		}
 
 		const info: ImageInfo | undefined = page.imageinfo?.[ 0 ];
 
 		if ( !info ) {
-			return {
-				content: [
-					{ type: 'text', text: `No file info available for "${ title }"` } as TextContent
-				],
-				isError: true
-			};
+			return errorResult( 'not_found', `No file info available for "${ title }"` );
 		}
 
 		return {
@@ -82,11 +73,7 @@ export async function handleGetFileTool( title: string ): Promise<CallToolResult
 			]
 		};
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to retrieve file data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve file data: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -6,6 +6,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 import { getMwn } from '../common/mwn.js';
 import type { ApiPage, ApiRevision } from 'mwn';
 import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 const PAGE_HISTORY_LIMIT = 20;
 
@@ -39,13 +40,7 @@ export async function handleGetPageHistoryTool(
 	filter?: string
 ): Promise<CallToolResult> {
 	if ( olderThan && newerThan ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: 'Cannot use both olderThan and newerThan at the same time'
-			} ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'Cannot use both olderThan and newerThan at the same time' );
 	}
 
 	try {
@@ -81,13 +76,7 @@ export async function handleGetPageHistoryTool(
 		const page = response.query?.pages?.[ 0 ] as ApiPage | undefined;
 
 		if ( page?.missing ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: `Page "${ title }" not found`
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult( 'not_found', `Page "${ title }" not found` );
 		}
 
 		const revisions: ApiRevision[] = page?.revisions ?? [];
@@ -142,11 +131,7 @@ export async function handleGetPageHistoryTool(
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to retrieve page history: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve page history: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -40,7 +40,7 @@ export async function handleGetPageHistoryTool(
 	filter?: string
 ): Promise<CallToolResult> {
 	if ( olderThan && newerThan ) {
-		return errorResult( 'invalid_input', 'Cannot use both olderThan and newerThan at the same time' );
+		return errorResult( 'invalid_input', 'olderThan and newerThan are mutually exclusive' );
 	}
 
 	try {

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -12,6 +12,7 @@ import {
 	truncateByBytes,
 	type TruncationInfo
 } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function getPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -93,22 +94,10 @@ export async function handleGetPageTool(
 	section?: number
 ): Promise<CallToolResult> {
 	if ( content === ContentFormat.none && !metadata ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: 'When content is set to "none", metadata must be true'
-			} ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'When content is set to "none", metadata must be true' );
 	}
 	if ( section !== undefined && content === ContentFormat.none ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: 'section is not compatible with content="none"'
-			} ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'section is not compatible with content="none"' );
 	}
 
 	try {
@@ -133,13 +122,7 @@ export async function handleGetPageTool(
 			const page = await mwn.read( title, readParams );
 
 			if ( page.missing ) {
-				return {
-					content: [ {
-						type: 'text',
-						text: `Page "${ title }" not found`
-					} as TextContent ],
-					isError: true
-				};
+				return errorResult( 'not_found', `Page "${ title }" not found` );
 			}
 
 			const rev = page.revisions?.[ 0 ];
@@ -221,14 +204,7 @@ export async function handleGetPageTool(
 
 		return { content: results };
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Failed to retrieve page data: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve page data: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -10,6 +10,7 @@ import {
 	truncationMarker,
 	truncateByBytes
 } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 const MAX_TITLES = 50;
 
@@ -124,22 +125,13 @@ export async function handleGetPagesTool(
 	followRedirects: boolean = true
 ): Promise<CallToolResult> {
 	if ( titles.length === 0 ) {
-		return {
-			content: [ { type: 'text', text: 'titles must contain at least one entry' } as TextContent ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'titles must contain at least one entry' );
 	}
 	if ( titles.length > MAX_TITLES ) {
-		return {
-			content: [ { type: 'text', text: `titles must contain at most ${ MAX_TITLES } entries` } as TextContent ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', `titles must contain at most ${ MAX_TITLES } entries` );
 	}
 	if ( content === BatchContentFormat.none && !metadata ) {
-		return {
-			content: [ { type: 'text', text: 'When content is set to "none", metadata must be true' } as TextContent ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'When content is set to "none", metadata must be true' );
 	}
 
 	try {
@@ -301,12 +293,7 @@ export async function handleGetPagesTool(
 
 		return { content: results };
 	} catch ( error ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: `Failed to retrieve pages: ${ ( error as Error ).message }`
-			} as TextContent ],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve pages: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -7,6 +7,7 @@ import { getMwn } from '../common/mwn.js';
 import type { ApiPage, ApiRevision } from 'mwn';
 import { getPageUrl } from '../common/utils.js';
 import { ContentFormat } from '../common/contentFormat.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function getRevisionTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -54,13 +55,7 @@ export async function handleGetRevisionTool(
 	revisionId: number, content: ContentFormat, metadata: boolean
 ): Promise<CallToolResult> {
 	if ( content === ContentFormat.none && !metadata ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: 'When content is set to "none", metadata must be true'
-			} ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'When content is set to "none", metadata must be true' );
 	}
 
 	try {
@@ -87,13 +82,7 @@ export async function handleGetRevisionTool(
 			const rev: ApiRevision | undefined = page?.revisions?.[ 0 ];
 
 			if ( !rev || !page ) {
-				return {
-					content: [ {
-						type: 'text',
-						text: `Revision ${ revisionId } not found`
-					} as TextContent ],
-					isError: true
-				};
+				return errorResult( 'not_found', `Revision ${ revisionId } not found` );
 			}
 
 			if ( needsMetadata ) {
@@ -127,14 +116,7 @@ export async function handleGetRevisionTool(
 
 		return { content: results };
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Failed to retrieve revision data: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve revision data: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -8,6 +8,7 @@ import {
 	truncationMarker,
 	truncateByBytes
 } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 const DEFAULT_TITLE = 'API';
 
@@ -144,12 +145,7 @@ export async function handleParseWikitextTool(
 
 		return { content: results };
 	} catch ( error ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: `Failed to preview wikitext: ${ ( error as Error ).message }`
-			} ],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to preview wikitext: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/remove-wiki.ts
+++ b/src/tools/remove-wiki.ts
@@ -33,7 +33,7 @@ async function handleRemoveWikiTool( server: McpServer, uri: string ): Promise<C
 
 		const wikiToRemove = wikiService.get( wikiKey );
 		if ( !wikiToRemove ) {
-			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources.` );
+			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources` );
 		}
 
 		if ( wikiService.getCurrent().key === wikiKey ) {

--- a/src/tools/remove-wiki.ts
+++ b/src/tools/remove-wiki.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { wikiService } from '../common/wikiService.js';
 import { removeMwnInstance } from '../common/mwn.js';
 import { removeLicenseCache } from '../resources/index.js';
 import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wikiResource.js';
+import { errorResult } from '../common/errorMapping.js';
 
 export function removeWikiTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -32,23 +33,14 @@ async function handleRemoveWikiTool( server: McpServer, uri: string ): Promise<C
 
 		const wikiToRemove = wikiService.get( wikiKey );
 		if ( !wikiToRemove ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: `mcp://wikis/${ wikiKey } not found in MCP resources.`
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources.` );
 		}
 
 		if ( wikiService.getCurrent().key === wikiKey ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: 'Cannot remove the currently active wiki. Please set a different wiki as the active wiki before removing this one.'
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult(
+				'conflict',
+				'Cannot remove the currently active wiki. Please set a different wiki as the active wiki before removing this one.'
+			);
 		}
 
 		wikiService.remove( wikiKey );
@@ -60,17 +52,11 @@ async function handleRemoveWikiTool( server: McpServer, uri: string ): Promise<C
 			content: [ {
 				type: 'text',
 				text: `${ wikiToRemove.sitename } (mcp://wikis/${ wikiKey }) has been removed from MCP resources.`
-			} as TextContent ]
+			} ]
 		};
 	} catch ( error ) {
 		if ( error instanceof InvalidWikiResourceUriError ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: error.message
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult( 'invalid_input', error.message );
 		}
 		throw error;
 	}

--- a/src/tools/search-page-by-prefix.ts
+++ b/src/tools/search-page-by-prefix.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 interface AllPagesEntry {
 	pageid: number;
@@ -79,11 +80,7 @@ export async function handleSearchPageByPrefixTool(
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to retrieve search data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve search data: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -7,6 +7,7 @@ import { getMwn } from '../common/mwn.js';
 import type { ApiSearchResult } from 'mwn';
 import { getPageUrl } from '../common/utils.js';
 import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function searchPageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -79,11 +80,7 @@ export async function handleSearchPageTool(
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
-		return {
-			content: [
-				{ type: 'text', text: `Failed to retrieve search data: ${ ( error as Error ).message }` } as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve search data: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/set-wiki.ts
+++ b/src/tools/set-wiki.ts
@@ -39,7 +39,7 @@ async function handleSetWikiTool(
 		const { wikiKey } = parseWikiResourceUri( uri );
 
 		if ( !wikiService.get( wikiKey ) ) {
-			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources.` );
+			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources` );
 		}
 
 		wikiService.setCurrent( wikiKey );

--- a/src/tools/set-wiki.ts
+++ b/src/tools/set-wiki.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { wikiService } from '../common/wikiService.js';
 import type { WikiConfig } from '../common/config.js';
 import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../common/wikiResource.js';
+import { errorResult } from '../common/errorMapping.js';
 
 export type OnActiveWikiChanged = ( activeWiki: Readonly<WikiConfig> ) => void;
 
@@ -38,13 +39,7 @@ async function handleSetWikiTool(
 		const { wikiKey } = parseWikiResourceUri( uri );
 
 		if ( !wikiService.get( wikiKey ) ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: `mcp://wikis/${ wikiKey } not found in MCP resources.`
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult( 'invalid_input', `mcp://wikis/${ wikiKey } not found in MCP resources.` );
 		}
 
 		wikiService.setCurrent( wikiKey );
@@ -55,17 +50,11 @@ async function handleSetWikiTool(
 			content: [ {
 				type: 'text',
 				text: `Wiki set to ${ newConfig.sitename } (${ newConfig.server })`
-			} as TextContent ]
+			} ]
 		};
 	} catch ( error ) {
 		if ( error instanceof InvalidWikiResourceUriError ) {
-			return {
-				content: [ {
-					type: 'text',
-					text: error.message
-				} as TextContent ],
-				isError: true
-			};
+			return errorResult( 'invalid_input', error.message );
 		}
 		throw error;
 	}

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -8,6 +8,7 @@ import type { ApiUndeleteParams } from 'types-mediawiki-api';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function undeletePageTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -48,15 +49,8 @@ export async function handleUndeletePageTool(
 			options
 		);
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Undelete failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Undelete failed: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -50,7 +50,7 @@ export async function handleUndeletePageTool(
 		);
 	} catch ( error ) {
 		const { category } = classifyError( error );
-		return errorResult( category, `Undelete failed: ${ ( error as Error ).message }` );
+		return errorResult( category, `Failed to undelete page: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
 /* eslint-disable n/no-missing-import */
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { getPageUrl, formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 interface UpdatePageArgs {
 	title: string;
@@ -54,26 +55,19 @@ export function updatePageTool( server: McpServer ): RegisteredTool {
 	);
 }
 
-function errorResult( text: string ): CallToolResult {
-	return {
-		content: [ { type: 'text', text } as TextContent ],
-		isError: true
-	};
-}
-
 export async function handleUpdatePageTool(
 	args: UpdatePageArgs
 ): Promise<CallToolResult> {
 	const { title, source, latestId, comment, section, mode, sectionTitle } = args;
 
 	if ( section === 'new' && mode !== undefined ) {
-		return errorResult( 'mode is not compatible with section=\'new\'' );
+		return errorResult( 'invalid_input', 'mode is not compatible with section=\'new\'' );
 	}
 	if ( section === 'new' && sectionTitle === undefined ) {
-		return errorResult( 'sectionTitle is required when section=\'new\'' );
+		return errorResult( 'invalid_input', 'sectionTitle is required when section=\'new\'' );
 	}
 	if ( sectionTitle !== undefined && section !== 'new' ) {
-		return errorResult( 'sectionTitle is only valid when section=\'new\'' );
+		return errorResult( 'invalid_input', 'sectionTitle is only valid when section=\'new\'' );
 	}
 
 	try {
@@ -115,7 +109,7 @@ export async function handleUpdatePageTool(
 		const edit = response?.edit as ApiEditResponse | undefined;
 
 		if ( !edit || edit.result !== 'Success' ) {
-			return errorResult( `Failed to update page: ${ JSON.stringify( edit ?? response ) }` );
+			return errorResult( 'upstream_failure', `Failed to update page: ${ JSON.stringify( edit ?? response ) }` );
 		}
 
 		const resolvedTitle = edit.title ?? title;
@@ -140,11 +134,12 @@ export async function handleUpdatePageTool(
 			]
 		};
 	} catch ( error ) {
+		const { category, code } = classifyError( error );
 		const msg = ( error as Error ).message;
-		if ( /nosuchsection/i.test( msg ) ) {
+		if ( code === 'nosuchsection' ) {
 			const label = section === undefined ? 'unknown' : String( section );
-			return errorResult( `Section ${ label } does not exist` );
+			return errorResult( 'not_found', `Section ${ label } does not exist` );
 		}
-		return errorResult( `Failed to update page: ${ msg }` );
+		return errorResult( category, `Failed to update page: ${ msg }` );
 	}
 }

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -49,12 +49,12 @@ export async function handleUploadFileFromUrlTool(
 		if ( errorMessage.includes( 'copyuploaddisabled' ) ) {
 			return errorResult(
 				'invalid_input',
-				'Upload failed: Upload by URL is disabled for this wiki. Please download the image from the URL to the local disk first, then use the upload-file tool to upload it from the local file path.'
+				'Upload by URL is disabled on this wiki. Download the file locally, then use upload-file with the local file path.'
 			);
 		}
 
 		const { category } = classifyError( error );
-		return errorResult( category, `Upload failed: ${ ( error as Error ).message }` );
+		return errorResult( category, `Failed to upload file: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -8,6 +8,7 @@ import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -46,26 +47,14 @@ export async function handleUploadFileFromUrlTool(
 		// Prevent the LLM from attempting to find an existing image on the wiki
 		// after failing to upload by URL.
 		if ( errorMessage.includes( 'copyuploaddisabled' ) ) {
-			return {
-				content: [
-					{
-						type: 'text',
-						text: 'Upload failed: Upload by URL is disabled for this wiki. Please download the image from the URL to the local disk first, then use the upload-file tool to upload it from the local file path.'
-					} as TextContent
-				],
-				isError: true
-			};
+			return errorResult(
+				'invalid_input',
+				'Upload failed: Upload by URL is disabled for this wiki. Please download the image from the URL to the local disk first, then use the upload-file tool to upload it from the local file path.'
+			);
 		}
 
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Upload failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Upload failed: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -43,7 +43,7 @@ export async function handleUploadFileTool(
 		data = await mwn.upload( filepath, title, text, getApiUploadParams( comment ) );
 	} catch ( error ) {
 		const { category } = classifyError( error );
-		return errorResult( category, `Upload failed: ${ ( error as Error ).message }` );
+		return errorResult( category, `Failed to upload file: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -8,6 +8,7 @@ import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
 import { formatEditComment } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 export function uploadFileTool( server: McpServer ): RegisteredTool {
 	return server.tool(
@@ -41,15 +42,8 @@ export async function handleUploadFileTool(
 		const mwn = await getMwn();
 		data = await mwn.upload( filepath, title, text, getApiUploadParams( comment ) );
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: `Upload failed: ${ ( error as Error ).message }`
-				} as TextContent
-			],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Upload failed: ${ ( error as Error ).message }` );
 	}
 
 	return {

--- a/tests/common/errorMapping.test.ts
+++ b/tests/common/errorMapping.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { ErrorCategory } from '../../src/common/errorMapping.js';
+import { classifyError, errorResult } from '../../src/common/errorMapping.js';
+import { createMockMwnError } from '../helpers/mock-mwn-error.js';
+
+describe( 'classifyError', () => {
+	describe( 'maps MW .code to category', () => {
+		const cases: Array<[ string, ErrorCategory ]> = [
+			[ 'missingtitle', 'not_found' ],
+			[ 'nosuchrevid', 'not_found' ],
+			[ 'nosuchsection', 'not_found' ],
+			[ 'nofile', 'not_found' ],
+			[ 'permissiondenied', 'permission_denied' ],
+			[ 'protectedpage', 'permission_denied' ],
+			[ 'protectedtitle', 'permission_denied' ],
+			[ 'cascadeprotected', 'permission_denied' ],
+			[ 'cantcreate', 'permission_denied' ],
+			[ 'readapidenied', 'permission_denied' ],
+			[ 'writeapidenied', 'permission_denied' ],
+			[ 'blocked', 'permission_denied' ],
+			[ 'abusefilter-disallowed', 'permission_denied' ],
+			[ 'abusefilter-warning', 'permission_denied' ],
+			[ 'invalidtitle', 'invalid_input' ],
+			[ 'invalidparammix', 'invalid_input' ],
+			[ 'badvalue', 'invalid_input' ],
+			[ 'baddatatype', 'invalid_input' ],
+			[ 'paramempty', 'invalid_input' ],
+			[ 'badtags', 'invalid_input' ],
+			[ 'editconflict', 'conflict' ],
+			[ 'articleexists', 'conflict' ],
+			[ 'fileexists', 'conflict' ],
+			[ 'fileexists-no-change', 'conflict' ],
+			[ 'notloggedin', 'authentication' ],
+			[ 'badtoken', 'authentication' ],
+			[ 'mustbeloggedin', 'authentication' ],
+			[ 'assertuserfailed', 'authentication' ],
+			[ 'assertbotfailed', 'authentication' ],
+			[ 'ratelimited', 'rate_limited' ],
+			[ 'readonly', 'upstream_failure' ]
+		];
+
+		for ( const [ code, expectedCategory ] of cases ) {
+			it( `${ code } → ${ expectedCategory }`, () => {
+				const err = createMockMwnError( code );
+				expect( classifyError( err ) ).toEqual( {
+					category: expectedCategory,
+					code
+				} );
+			} );
+		}
+	} );
+
+	it( 'maps internal_api_error_* codes to upstream_failure', () => {
+		const err = createMockMwnError( 'internal_api_error_DBQueryError' );
+		expect( classifyError( err ) ).toEqual( {
+			category: 'upstream_failure',
+			code: 'internal_api_error_DBQueryError'
+		} );
+	} );
+
+	it( 'falls back to upstream_failure for unknown codes', () => {
+		const err = createMockMwnError( 'somethingnew', 'A new kind of error' );
+		expect( classifyError( err ) ).toEqual( { category: 'upstream_failure' } );
+	} );
+
+	it( 'regex fallback picks up codes embedded in message when .code is absent', () => {
+		const err = new Error( 'The API returned: missingtitle — page not present' );
+		expect( classifyError( err ) ).toEqual( {
+			category: 'not_found',
+			code: 'missingtitle'
+		} );
+	} );
+
+	it( 'prefers .code over message regex when both are present', () => {
+		const err = createMockMwnError(
+			'ratelimited',
+			'something about missingtitle in the message'
+		);
+		expect( classifyError( err ) ).toEqual( {
+			category: 'rate_limited',
+			code: 'ratelimited'
+		} );
+	} );
+
+	it.each( [
+		[ 'null', null ],
+		[ 'undefined', undefined ],
+		[ 'string', 'oops' ],
+		[ 'plain object without code', {} ],
+		[ 'number', 42 ]
+	] )( 'non-Error value (%s) → upstream_failure without code', ( _label, value ) => {
+		expect( classifyError( value ) ).toEqual( { category: 'upstream_failure' } );
+	} );
+} );
+
+describe( 'errorResult', () => {
+	it( 'builds prose-prefix CallToolResult with isError', () => {
+		const result = errorResult( 'not_found', 'Page "Foo" not found' );
+		expect( result ).toEqual( {
+			isError: true,
+			content: [ { type: 'text', text: 'not_found: Page "Foo" not found' } ]
+		} );
+	} );
+
+	it( 'preserves colons in messages', () => {
+		const result = errorResult(
+			'upstream_failure',
+			'Failed to fetch: connection refused'
+		);
+		expect( result.content[ 0 ] ).toEqual( {
+			type: 'text',
+			text: 'upstream_failure: Failed to fetch: connection refused'
+		} );
+	} );
+} );

--- a/tests/helpers/mock-mwn-error.ts
+++ b/tests/helpers/mock-mwn-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Constructs an MwnError-shaped object for tests that need to simulate a
+ * specific MediaWiki API failure without pulling in mwn's runtime.
+ */
+export function createMockMwnError(
+	code: string,
+	message?: string
+): Error & { code: string; info?: string } {
+	const err = new Error(
+		message ?? `${ code }: mock MediaWiki error`
+	) as Error & { code: string; info?: string };
+	err.code = code;
+	err.info = message ?? `mock info for ${ code }`;
+	return err;
+}

--- a/tests/tools/add-wiki.test.ts
+++ b/tests/tools/add-wiki.test.ts
@@ -4,22 +4,32 @@ vi.mock( '../../src/common/wikiDiscovery.js', () => ( {
 	discoverWiki: vi.fn()
 } ) );
 
-vi.mock( '../../src/common/wikiService.js', () => ( {
-	wikiService: {
-		add: vi.fn()
-	}
-} ) );
+vi.mock( '../../src/common/wikiService.js', async () => {
+	const actual = await vi.importActual<typeof import( '../../src/common/wikiService.js' )>(
+		'../../src/common/wikiService.js'
+	);
+	return {
+		...actual,
+		wikiService: {
+			add: vi.fn()
+		}
+	};
+} );
 
 import { discoverWiki } from '../../src/common/wikiDiscovery.js';
+import { wikiService, DuplicateWikiKeyError } from '../../src/common/wikiService.js';
+import { SsrfValidationError } from '../../src/common/ssrfGuard.js';
 
 describe( 'add-wiki', () => {
 	beforeEach( () => {
 		vi.clearAllMocks();
 	} );
 
-	it( 'returns an isError tool response when discoverWiki throws (e.g. SSRF rejection)', async () => {
+	it( 'categorises SSRF rejections as invalid_input', async () => {
 		vi.mocked( discoverWiki ).mockRejectedValue(
-			new Error( 'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): http://169.254.169.254/' )
+			new SsrfValidationError(
+				'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): http://169.254.169.254/'
+			)
 		);
 
 		const { handleAddWikiTool } = await import( '../../src/tools/add-wiki.js' );
@@ -27,6 +37,45 @@ describe( 'add-wiki', () => {
 		const result = await handleAddWikiTool( server, 'http://169.254.169.254/' );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch( /169\.254\.169\.254/ );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch(
+			/^invalid_input: Failed to add wiki:.*169\.254\.169\.254/
+		);
+	} );
+
+	it( 'categorises duplicate-wiki-key failures as conflict', async () => {
+		vi.mocked( discoverWiki ).mockResolvedValue( {
+			servername: 'example.org',
+			sitename: 'Example',
+			server: 'https://example.org',
+			articlepath: '/wiki',
+			scriptpath: '/w'
+		} );
+		vi.mocked( wikiService.add ).mockImplementation( () => {
+			throw new DuplicateWikiKeyError( 'example.org' );
+		} );
+
+		const { handleAddWikiTool } = await import( '../../src/tools/add-wiki.js' );
+		const server = { sendResourceListChanged: vi.fn() } as unknown as Parameters<typeof handleAddWikiTool>[0];
+		const result = await handleAddWikiTool( server, 'https://example.org/' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
+			'conflict: Wiki "example.org" already exists in configuration'
+		);
+	} );
+
+	it( 'categorises unexpected discoverWiki errors as upstream_failure', async () => {
+		vi.mocked( discoverWiki ).mockRejectedValue(
+			new Error( 'Connection refused' )
+		);
+
+		const { handleAddWikiTool } = await import( '../../src/tools/add-wiki.js' );
+		const server = { sendResourceListChanged: vi.fn() } as unknown as Parameters<typeof handleAddWikiTool>[0];
+		const result = await handleAddWikiTool( server, 'https://example.org/' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch(
+			/^upstream_failure: Failed to add wiki: Connection refused/
+		);
 	} );
 } );

--- a/tests/tools/compare-pages.test.ts
+++ b/tests/tools/compare-pages.test.ts
@@ -155,7 +155,7 @@ describe( 'compare-pages', () => {
 		const result = await handleComparePagesTool( { toRevision: 57 } );
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Must supply exactly one of fromRevision, fromTitle, fromText'
+			'invalid_input: Must supply exactly one of fromRevision, fromTitle, fromText'
 		);
 	} );
 
@@ -165,7 +165,7 @@ describe( 'compare-pages', () => {
 		} );
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Only one of fromRevision, fromTitle, fromText may be supplied'
+			'invalid_input: Only one of fromRevision, fromTitle, fromText may be supplied'
 		);
 	} );
 
@@ -175,7 +175,7 @@ describe( 'compare-pages', () => {
 		} );
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Cannot compare supplied text against supplied text'
+			'invalid_input: Cannot compare supplied text against supplied text'
 		);
 	} );
 
@@ -188,7 +188,7 @@ describe( 'compare-pages', () => {
 		} );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Revision 99999 not found' );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'not_found: Revision 99999 not found' );
 	} );
 
 	it( 'maps missingtitle errors to a friendly message', async () => {
@@ -200,7 +200,7 @@ describe( 'compare-pages', () => {
 		} );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Page "Nope" not found' );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'not_found: Page "Nope" not found' );
 	} );
 
 	it( 'returns a generic error message for other API failures', async () => {
@@ -213,7 +213,7 @@ describe( 'compare-pages', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Failed to compare pages: Connection refused'
+			'upstream_failure: Failed to compare pages: Connection refused'
 		);
 	} );
 
@@ -223,7 +223,7 @@ describe( 'compare-pages', () => {
 		} );
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Only one of toRevision, toTitle, toText may be supplied'
+			'invalid_input: Only one of toRevision, toTitle, toText may be supplied'
 		);
 	} );
 
@@ -275,7 +275,7 @@ describe( 'compare-pages', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'Failed to compare pages: no compare result returned'
+			'upstream_failure: Failed to compare pages: no compare result returned'
 		);
 	} );
 
@@ -288,7 +288,7 @@ describe( 'compare-pages', () => {
 		} );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Revision 99999 not found' );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'not_found: Revision 99999 not found' );
 	} );
 
 	it( 'parses the correct title when missingtitle message quotes it', async () => {
@@ -300,7 +300,7 @@ describe( 'compare-pages', () => {
 		} );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'Page "Bar" not found' );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe( 'not_found: Page "Bar" not found' );
 	} );
 
 	it( 'truncates oversized diff body with a content-truncated marker', async () => {

--- a/tests/tools/parse-wikitext.test.ts
+++ b/tests/tools/parse-wikitext.test.ts
@@ -120,7 +120,7 @@ describe( 'parse-wikitext', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( result.content[ 0 ].text ).toBe(
-			'Failed to preview wikitext: Network down'
+			'upstream_failure: Failed to preview wikitext: Network down'
 		);
 	} );
 

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -178,7 +178,7 @@ describe( 'update-page', () => {
 			const result = await handleUpdatePageTool( { title: 'My Page', source: 'x', section: 99 } );
 
 			expect( result.isError ).toBe( true );
-			expect( result.content[ 0 ].text ).toBe( 'Section 99 does not exist' );
+			expect( result.content[ 0 ].text ).toBe( 'not_found: Section 99 does not exist' );
 		} );
 
 		it( 'forwards section=\'new\' with sectionTitle as sectiontitle', async () => {


### PR DESCRIPTION
Closes #277.

## Summary

- Introduces `src/common/errorMapping.ts` with a 7-category taxonomy (`not_found`, `permission_denied`, `invalid_input`, `conflict`, `upstream_failure`, `rate_limited`, `authentication`), a pure `classifyError(err)` classifier that prefers `MwnError.code`, and an `errorResult(category, message)` builder that emits `isError: true` with a `category: message` prose-prefix text block.
- Converts all 19 tool handlers in `src/tools/` to route errors through `classifyError` + `errorResult`. After this change, `grep -rn "isError: true" src/tools/` is empty: every error emission flows through the shared helper.
- Documents the category taxonomy once in `docs/tool-conventions.md` Part 2 (new "Error categories" subsection). Individual tool descriptions continue to describe conditions, not category names — matching the existing style rule.
- Introduces two typed error classes so specific failures map to the right categories: `DuplicateWikiKeyError` (`src/common/wikiService.ts`) → `conflict`, and `SsrfValidationError` (`src/common/ssrfGuard.ts`) → `invalid_input`.

## Design

Key decisions:

- **Prose prefix only, no structuredContent** in this PR. The internal helper already produces `{ category, message }` in structured form; #278 can wire it into `structuredContent` with zero call-site churn.
- **Tool-specific message refinement stays in the tool.** `compare-pages` still extracts the failing revision ID / title from the MW message; `update-page` still surfaces the section number. The classifier is pure (no side-effects, no tool awareness).
- **`.code` is the primary classification signal.** Regex on `.message` is a reliability fallback for the small set of codes mwn may surface only in the message (gated on `.code` being absent so it can never override a typed code).

## Test Plan

- [x] `npm test` — 27 files / 339 tests passing.
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in `src/common/config.ts` unrelated).
- [x] `npm run build` — clean.
- [x] `grep -rn "isError: true" src/tools/` — empty, confirming full conversion.
- [x] Exhaustive unit coverage of `classifyError` in `tests/common/errorMapping.test.ts`: every code in the taxonomy table, `internal_api_error_*` prefix, unknown-code fallback, regex fallback, `.code`-wins-over-message priority, and non-Error inputs.
- [x] `tests/tools/add-wiki.test.ts` locks in SSRF → `invalid_input`, duplicate-wiki-key → `conflict`, and unknown errors → `upstream_failure`.