### PR TITLE
Gate upload-file on a configured upload-directory allowlist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Accepts a string or an array of strings:
 
 ## Upload directories
 
-The `upload-file` tool reads local files from the server's filesystem and uploads them to the wiki. By default **no directories are allowed**, and every `upload-file` call will return a clear error telling the operator how to configure an allowlist.
+The `upload-file` tool reads local files from the server's filesystem. Uploads are **disabled by default**: the operator must explicitly allowlist one or more directories. Every `upload-file` call returns an error until at least one directory is configured.
 
 Enable uploads by setting one or both of:
 
@@ -107,7 +107,7 @@ Enable uploads by setting one or both of:
 
 Entries from both sources are merged. Each entry is canonicalised with `fs.realpathSync` at startup — if an entry doesn't exist or isn't an absolute path, the server fails to start with a specific error.
 
-At upload time, the supplied `filepath` is validated: it must be absolute, must exist, and its `fs.realpath`-resolved form must sit inside one of the configured directories. Symlink escapes and `..` traversal are rejected. The resolved path (not the caller-supplied one) is passed to the wiki.
+At upload time, the supplied `filepath` must be absolute, must exist, and its symlink-resolved form must sit inside one of the configured directories. Symlinks are followed *before* the allowlist check, so a symlink pointing outside the allowlist is rejected. `..` traversal is also rejected. The resolved (canonical) path — not the caller-supplied one — is what gets uploaded.
 
 > Dynamic client-supplied allow-listing via the MCP Roots protocol is a planned follow-up; today the allowlist is static at startup.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,29 @@ Accepts a string or an array of strings:
 }
 ```
 
+## Upload directories
+
+The `upload-file` tool reads local files from the server's filesystem and uploads them to the wiki. By default **no directories are allowed**, and every `upload-file` call will return a clear error telling the operator how to configure an allowlist.
+
+Enable uploads by setting one or both of:
+
+- **`MCP_UPLOAD_DIRS` env var** — colon-separated list of absolute paths. Example: `MCP_UPLOAD_DIRS=/home/user/uploads:/var/lib/wiki-uploads`.
+- **`uploadDirs` in `config.json`** — array of absolute paths at the top level:
+
+```json
+{
+  "defaultWiki": "my.wiki.org",
+  "uploadDirs": ["/home/user/uploads", "/var/lib/wiki-uploads"],
+  "wikis": { "my.wiki.org": { "...": "..." } }
+}
+```
+
+Entries from both sources are merged. Each entry is canonicalised with `fs.realpathSync` at startup — if an entry doesn't exist or isn't an absolute path, the server fails to start with a specific error.
+
+At upload time, the supplied `filepath` is validated: it must be absolute, must exist, and its `fs.realpath`-resolved form must sit inside one of the configured directories. Symlink escapes and `..` traversal are rejected. The resolved path (not the caller-supplied one) is passed to the wiki.
+
+> Dynamic client-supplied allow-listing via the MCP Roots protocol is a planned follow-up; today the allowlist is static at startup.
+
 ## Per-request bearer token (HTTP transport)
 
 When using the Streamable HTTP transport (`MCP_TRANSPORT=http`), the server accepts a standard OAuth 2.1 `Authorization: Bearer` header on each request, as described in the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization):

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFileSync } from 'child_process';
 
 export interface WikiConfig {
@@ -63,10 +64,17 @@ export interface Config {
 	 * the configured wiki set at startup. Defaults to true.
 	 */
 	allowWikiManagement?: boolean;
+	/**
+	 * Absolute directories from which `upload-file` may read. Merged from
+	 * `config.json` `uploadDirs` and the `MCP_UPLOAD_DIRS` env var. Each entry
+	 * is canonicalised via `fs.realpathSync` at load. Empty → uploads disabled.
+	 */
+	uploadDirs: readonly string[];
 }
 
 export const defaultConfig: Config = {
 	defaultWiki: 'en.wikipedia.org',
+	uploadDirs: [],
 	wikis: {
 		'en.wikipedia.org': {
 			sitename: 'Wikipedia',
@@ -228,6 +236,54 @@ function runExec( raw: unknown, wikiKey: string, fieldName: SecretFieldName ): s
 	return trimmed;
 }
 
+function resolveUploadDirs( rawFromConfig: unknown ): readonly string[] {
+	const fromConfig: string[] = [];
+	if ( rawFromConfig !== undefined ) {
+		if ( !Array.isArray( rawFromConfig ) ) {
+			throw new Error( 'Config error: uploadDirs must be an array of strings' );
+		}
+		for ( const entry of rawFromConfig ) {
+			if ( typeof entry !== 'string' ) {
+				throw new Error( 'Config error: uploadDirs entries must be strings' );
+			}
+			if ( !path.isAbsolute( entry ) ) {
+				throw new Error( `Config error: uploadDirs entry "${ entry }" must be absolute` );
+			}
+			fromConfig.push( entry );
+		}
+	}
+
+	const envRaw = process.env.MCP_UPLOAD_DIRS;
+	const fromEnv: string[] = [];
+	if ( envRaw ) {
+		for ( const entry of envRaw.split( ':' ) ) {
+			if ( entry === '' ) {
+				continue;
+			}
+			if ( !path.isAbsolute( entry ) ) {
+				throw new Error( `Config error: MCP_UPLOAD_DIRS entry "${ entry }" must be absolute` );
+			}
+			fromEnv.push( entry );
+		}
+	}
+
+	const canonicalised: string[] = [];
+	for ( const raw of [ ...fromEnv, ...fromConfig ] ) {
+		let canonical: string;
+		try {
+			canonical = fs.realpathSync( raw );
+		} catch ( err ) {
+			throw new Error(
+				`Config error: realpath failed for uploadDirs entry "${ raw }": ${ ( err as Error ).message }`
+			);
+		}
+		if ( !canonicalised.includes( canonical ) ) {
+			canonicalised.push( canonical );
+		}
+	}
+	return canonicalised;
+}
+
 function resolveWiki( raw: unknown, wikiKey: string ): WikiConfig {
 	if ( typeof raw !== 'object' || raw === null || Array.isArray( raw ) ) {
 		throw new Error( `Config error: wikis.${ wikiKey } must be an object` );
@@ -256,20 +312,21 @@ function resolveConfig( parsed: unknown ): Config {
 	const p = parsed as Record<string, unknown>;
 	const defaultWiki = typeof p.defaultWiki === 'string' ? replaceEnvVars( p.defaultWiki ) : '';
 	const allowWikiManagement = typeof p.allowWikiManagement === 'boolean' ? p.allowWikiManagement : undefined;
+	const uploadDirs = resolveUploadDirs( p.uploadDirs );
 	const rawWikis = p.wikis;
 	if ( typeof rawWikis !== 'object' || rawWikis === null || Array.isArray( rawWikis ) ) {
-		return { defaultWiki, wikis: {}, allowWikiManagement };
+		return { defaultWiki, wikis: {}, allowWikiManagement, uploadDirs };
 	}
 	const wikis: Record<string, WikiConfig> = {};
 	for ( const [ key, rawWiki ] of Object.entries( rawWikis ) ) {
 		wikis[ key ] = resolveWiki( rawWiki, key );
 	}
-	return { defaultWiki, wikis, allowWikiManagement };
+	return { defaultWiki, wikis, allowWikiManagement, uploadDirs };
 }
 
 export function loadConfigFromFile(): Config {
 	if ( !fs.existsSync( configPath ) ) {
-		return defaultConfig;
+		return { ...defaultConfig, uploadDirs: resolveUploadDirs( undefined ) };
 	}
 	const rawData = fs.readFileSync( configPath, 'utf-8' );
 	const parsed = JSON.parse( rawData );

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -274,7 +274,7 @@ function resolveUploadDirs( rawFromConfig: unknown ): readonly string[] {
 			canonical = fs.realpathSync( raw );
 		} catch ( err ) {
 			throw new Error(
-				`Config error: realpath failed for uploadDirs entry "${ raw }": ${ ( err as Error ).message }`
+				`Config error: upload directory "${ raw }" cannot be resolved (${ ( err as Error ).message }). Ensure the directory exists before starting the server.`
 			);
 		}
 		if ( !canonicalised.includes( canonical ) ) {

--- a/src/common/uploadGuard.ts
+++ b/src/common/uploadGuard.ts
@@ -14,9 +14,9 @@ export async function assertAllowedPath(
 ): Promise<string> {
 	if ( allowedDirs.length === 0 ) {
 		throw new UploadValidationError(
-			'this server has no upload directory configured. ' +
-			'Set MCP_UPLOAD_DIRS=/path1:/path2 or add "uploadDirs": ["/path1"] to ' +
-			'config.json to enable uploads.'
+			'uploads are disabled on this server (no upload directories configured). ' +
+			'Ask the operator to set MCP_UPLOAD_DIRS or "uploadDirs" in config.json; ' +
+			'this is not something the model can fix by retrying.'
 		);
 	}
 	if ( !isAbsolute( filepath ) ) {
@@ -30,7 +30,9 @@ export async function assertAllowedPath(
 		resolved = await realpath( filepath );
 	} catch ( err ) {
 		if ( ( err as NodeJS.ErrnoException ).code === 'ENOENT' ) {
-			throw new UploadValidationError( `file not found: ${ filepath }` );
+			throw new UploadValidationError(
+				`file not found at "${ filepath }". Verify the path exists and is inside an allowed upload directory.`
+			);
 		}
 		throw err;
 	}
@@ -41,6 +43,8 @@ export async function assertAllowedPath(
 		}
 	}
 	throw new UploadValidationError(
-		`"${ resolved }" is not allowed by the configured upload directories.`
+		`path "${ resolved }" is outside the allowed upload directories. ` +
+		`Allowed roots: ${ allowedDirs.join( ', ' ) }. ` +
+		'If the caller-supplied path differed, a symlink resolved outside the allowlist.'
 	);
 }

--- a/src/common/uploadGuard.ts
+++ b/src/common/uploadGuard.ts
@@ -1,20 +1,27 @@
 import { realpath } from 'node:fs/promises';
 import { isAbsolute, sep } from 'node:path';
 
+export class UploadValidationError extends Error {
+	public constructor( message: string ) {
+		super( message );
+		this.name = 'UploadValidationError';
+	}
+}
+
 export async function assertAllowedPath(
 	filepath: string,
 	allowedDirs: readonly string[]
 ): Promise<string> {
 	if ( allowedDirs.length === 0 ) {
-		throw new Error(
-			'Upload rejected: this server has no upload directory configured. ' +
+		throw new UploadValidationError(
+			'this server has no upload directory configured. ' +
 			'Set MCP_UPLOAD_DIRS=/path1:/path2 or add "uploadDirs": ["/path1"] to ' +
 			'config.json to enable uploads.'
 		);
 	}
 	if ( !isAbsolute( filepath ) ) {
-		throw new Error(
-			`Upload rejected: provide an absolute path (got "${ filepath }").`
+		throw new UploadValidationError(
+			`provide an absolute path (got "${ filepath }").`
 		);
 	}
 
@@ -23,7 +30,7 @@ export async function assertAllowedPath(
 		resolved = await realpath( filepath );
 	} catch ( err ) {
 		if ( ( err as NodeJS.ErrnoException ).code === 'ENOENT' ) {
-			throw new Error( `Upload rejected: file not found: ${ filepath }` );
+			throw new UploadValidationError( `file not found: ${ filepath }` );
 		}
 		throw err;
 	}
@@ -33,7 +40,7 @@ export async function assertAllowedPath(
 			return resolved;
 		}
 	}
-	throw new Error(
-		`Upload rejected: "${ resolved }" is not allowed by the configured upload directories.`
+	throw new UploadValidationError(
+		`"${ resolved }" is not allowed by the configured upload directories.`
 	);
 }

--- a/src/common/uploadGuard.ts
+++ b/src/common/uploadGuard.ts
@@ -1,0 +1,39 @@
+import { realpath } from 'node:fs/promises';
+import { isAbsolute, sep } from 'node:path';
+
+export async function assertAllowedPath(
+	filepath: string,
+	allowedDirs: readonly string[]
+): Promise<string> {
+	if ( allowedDirs.length === 0 ) {
+		throw new Error(
+			'Upload rejected: this server has no upload directory configured. ' +
+			'Set MCP_UPLOAD_DIRS=/path1:/path2 or add "uploadDirs": ["/path1"] to ' +
+			'config.json to enable uploads.'
+		);
+	}
+	if ( !isAbsolute( filepath ) ) {
+		throw new Error(
+			`Upload rejected: provide an absolute path (got "${ filepath }").`
+		);
+	}
+
+	let resolved: string;
+	try {
+		resolved = await realpath( filepath );
+	} catch ( err ) {
+		if ( ( err as NodeJS.ErrnoException ).code === 'ENOENT' ) {
+			throw new Error( `Upload rejected: file not found: ${ filepath }` );
+		}
+		throw err;
+	}
+
+	for ( const entry of allowedDirs ) {
+		if ( resolved === entry || resolved.startsWith( entry + sep ) ) {
+			return resolved;
+		}
+	}
+	throw new Error(
+		`Upload rejected: "${ resolved }" is not allowed by the configured upload directories.`
+	);
+}

--- a/src/common/wikiService.ts
+++ b/src/common/wikiService.ts
@@ -75,6 +75,10 @@ function isWikiManagementAllowed(): boolean {
 	return config.allowWikiManagement !== false;
 }
 
+function getUploadDirs(): readonly string[] {
+	return config.uploadDirs;
+}
+
 export const wikiService = {
 	getAll,
 	get,
@@ -84,5 +88,6 @@ export const wikiService = {
 	setCurrent,
 	sanitize,
 	reset,
-	isWikiManagementAllowed
+	isWikiManagementAllowed,
+	getUploadDirs
 };

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -14,7 +14,7 @@ import { classifyError, errorResult } from '../common/errorMapping.js';
 export function uploadFileTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'upload-file',
-		'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url.',
+		'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url.',
 		{
 			filepath: z.string().describe( 'File path on the local disk' ),
 			title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -7,7 +7,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
-import { assertAllowedPath } from '../common/uploadGuard.js';
+import { assertAllowedPath, UploadValidationError } from '../common/uploadGuard.js';
 import { formatEditComment } from '../common/utils.js';
 import { classifyError, errorResult } from '../common/errorMapping.js';
 
@@ -42,15 +42,11 @@ export async function handleUploadFileTool(
 	try {
 		resolvedPath = await assertAllowedPath( filepath, wikiService.getUploadDirs() );
 	} catch ( error ) {
-		return {
-			content: [
-				{
-					type: 'text',
-					text: ( error as Error ).message
-				} as TextContent
-			],
-			isError: true
-		};
+		if ( error instanceof UploadValidationError ) {
+			return errorResult( 'invalid_input', `Failed to upload file: ${ error.message }` );
+		}
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to upload file: ${ ( error as Error ).message }` );
 	}
 
 	let data: ApiUploadResponse;

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -7,6 +7,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import { getMwn } from '../common/mwn.js';
 import { wikiService } from '../common/wikiService.js';
+import { assertAllowedPath } from '../common/uploadGuard.js';
 import { formatEditComment } from '../common/utils.js';
 import { classifyError, errorResult } from '../common/errorMapping.js';
 
@@ -37,10 +38,25 @@ export async function handleUploadFileTool(
 	filepath: string, title: string, text: string, comment?: string
 ): Promise< CallToolResult > {
 
+	let resolvedPath: string;
+	try {
+		resolvedPath = await assertAllowedPath( filepath, wikiService.getUploadDirs() );
+	} catch ( error ) {
+		return {
+			content: [
+				{
+					type: 'text',
+					text: ( error as Error ).message
+				} as TextContent
+			],
+			isError: true
+		};
+	}
+
 	let data: ApiUploadResponse;
 	try {
 		const mwn = await getMwn();
-		data = await mwn.upload( filepath, title, text, getApiUploadParams( comment ) );
+		data = await mwn.upload( resolvedPath, title, text, getApiUploadParams( comment ) );
 	} catch ( error ) {
 		const { category } = classifyError( error );
 		return errorResult( category, `Failed to upload file: ${ ( error as Error ).message }` );

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -234,6 +234,112 @@ describe( 'loadConfigFromFile', () => {
 		} );
 	} );
 
+	describe( 'uploadDirs', () => {
+		beforeEach( () => {
+			vi.mocked( fs.realpathSync ).mockImplementation( ( p ) => String( p ) );
+		} );
+
+		it( 'defaults to an empty array when neither source is set', async () => {
+			setConfigFile( { defaultWiki: 'w', wikis: { w: baseWiki } } );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [] );
+		} );
+
+		it( 'honours MCP_UPLOAD_DIRS even when no config.json exists', async () => {
+			vi.mocked( fs.existsSync ).mockReturnValue( false );
+			vi.stubEnv( 'MCP_UPLOAD_DIRS', '/x' );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [ '/x' ] );
+		} );
+
+		it( 'parses config.json uploadDirs and canonicalises each entry', async () => {
+			vi.mocked( fs.realpathSync ).mockImplementation( ( p ) => {
+				if ( p === '/home/user/uploads' ) {
+					return '/var/lib/uploads';
+				}
+				return String( p );
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: baseWiki },
+				uploadDirs: [ '/home/user/uploads', '/tmp/incoming' ]
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [
+				'/var/lib/uploads',
+				'/tmp/incoming'
+			] );
+		} );
+
+		it( 'parses MCP_UPLOAD_DIRS env var with colon separator', async () => {
+			vi.stubEnv( 'MCP_UPLOAD_DIRS', '/a:/b' );
+			setConfigFile( { defaultWiki: 'w', wikis: { w: baseWiki } } );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [ '/a', '/b' ] );
+		} );
+
+		it( 'unions config.json and env-var sources, dedup after canonicalisation', async () => {
+			vi.stubEnv( 'MCP_UPLOAD_DIRS', '/a:/b' );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: baseWiki },
+				uploadDirs: [ '/b', '/c' ]
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [ '/a', '/b', '/c' ] );
+		} );
+
+		it( 'treats empty MCP_UPLOAD_DIRS as unset', async () => {
+			vi.stubEnv( 'MCP_UPLOAD_DIRS', '' );
+			setConfigFile( { defaultWiki: 'w', wikis: { w: baseWiki } } );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( loadConfigFromFile().uploadDirs ).toEqual( [] );
+		} );
+
+		it( 'throws when uploadDirs contains a non-string', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: baseWiki },
+				uploadDirs: [ '/a', 42 ]
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow( /uploadDirs/ );
+		} );
+
+		it( 'throws when a config uploadDirs entry is relative', async () => {
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: baseWiki },
+				uploadDirs: [ 'relative/path' ]
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow( /must be absolute/ );
+		} );
+
+		it( 'throws when MCP_UPLOAD_DIRS contains a relative entry', async () => {
+			vi.stubEnv( 'MCP_UPLOAD_DIRS', '/ok:relative' );
+			setConfigFile( { defaultWiki: 'w', wikis: { w: baseWiki } } );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow( /must be absolute/ );
+		} );
+
+		it( 'throws when an entry cannot be canonicalised', async () => {
+			vi.mocked( fs.realpathSync ).mockImplementation( ( p ) => {
+				if ( p === '/does/not/exist' ) {
+					throw Object.assign( new Error( 'ENOENT' ), { code: 'ENOENT' } );
+				}
+				return String( p );
+			} );
+			setConfigFile( {
+				defaultWiki: 'w',
+				wikis: { w: baseWiki },
+				uploadDirs: [ '/does/not/exist' ]
+			} );
+			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
+			expect( () => loadConfigFromFile() ).toThrow( /realpath/ );
+		} );
+	} );
+
 	describe( 'exec credential source', () => {
 		const SENTINEL = 'SENTINEL-NEVER-LEAK';
 

--- a/tests/common/config.test.ts
+++ b/tests/common/config.test.ts
@@ -336,7 +336,7 @@ describe( 'loadConfigFromFile', () => {
 				uploadDirs: [ '/does/not/exist' ]
 			} );
 			const { loadConfigFromFile } = await import( '../../src/common/config.js' );
-			expect( () => loadConfigFromFile() ).toThrow( /realpath/ );
+			expect( () => loadConfigFromFile() ).toThrow( /cannot be resolved/ );
 		} );
 	} );
 

--- a/tests/common/uploadGuard.test.ts
+++ b/tests/common/uploadGuard.test.ts
@@ -46,14 +46,14 @@ describe( 'uploadGuard.assertAllowedPath', () => {
 		vi.mocked( realpath ).mockResolvedValueOnce( '/etc/passwd' );
 		await expect(
 			assertAllowedPath( '/home/user/uploads/link.jpg', [ '/home/user/uploads' ] )
-		).rejects.toThrow( /not allowed/i );
+		).rejects.toThrow( /outside the allowed upload directories/ );
 	} );
 
 	it( 'rejects a `..` traversal whose realpath escapes the allowlist', async () => {
 		vi.mocked( realpath ).mockResolvedValueOnce( '/home/user/secret.key' );
 		await expect(
 			assertAllowedPath( '/home/user/uploads/../secret.key', [ '/home/user/uploads' ] )
-		).rejects.toThrow( /not allowed/i );
+		).rejects.toThrow( /outside the allowed upload directories/ );
 	} );
 
 	it( 'does not match a sibling directory with a similar prefix', async () => {
@@ -63,7 +63,7 @@ describe( 'uploadGuard.assertAllowedPath', () => {
 				'/home/user/uploads-secret/stuff.key',
 				[ '/home/user/uploads' ]
 			)
-		).rejects.toThrow( /not allowed/i );
+		).rejects.toThrow( /outside the allowed upload directories/ );
 	} );
 
 	it( 'accepts when the resolved path equals the allowlist entry exactly', async () => {

--- a/tests/common/uploadGuard.test.ts
+++ b/tests/common/uploadGuard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( 'node:fs/promises', () => ( {
+	realpath: vi.fn()
+} ) );
+
+import { realpath } from 'node:fs/promises';
+import { assertAllowedPath } from '../../src/common/uploadGuard.js';
+
+describe( 'uploadGuard.assertAllowedPath', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'rejects when allowedDirs is empty', async () => {
+		await expect(
+			assertAllowedPath( '/home/user/file.jpg', [] )
+		).rejects.toThrow( /MCP_UPLOAD_DIRS|uploadDirs/ );
+	} );
+
+	it( 'rejects a relative filepath', async () => {
+		await expect(
+			assertAllowedPath( 'relative/file.jpg', [ '/home/user/uploads' ] )
+		).rejects.toThrow( /absolute path/ );
+	} );
+
+	it( 'rejects a non-existent filepath with a clear message', async () => {
+		vi.mocked( realpath ).mockRejectedValueOnce(
+			Object.assign( new Error( 'ENOENT: no such file' ), { code: 'ENOENT' } )
+		);
+		await expect(
+			assertAllowedPath( '/home/user/missing.jpg', [ '/home/user/uploads' ] )
+		).rejects.toThrow( /file not found/i );
+	} );
+
+	it( 'accepts and returns the canonical path for a file inside an allowed dir', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/home/user/uploads/cat.jpg' );
+		const resolved = await assertAllowedPath(
+			'/home/user/uploads/cat.jpg',
+			[ '/home/user/uploads' ]
+		);
+		expect( resolved ).toBe( '/home/user/uploads/cat.jpg' );
+	} );
+
+	it( 'rejects when a symlink resolves outside the allowlist', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/etc/passwd' );
+		await expect(
+			assertAllowedPath( '/home/user/uploads/link.jpg', [ '/home/user/uploads' ] )
+		).rejects.toThrow( /not allowed/i );
+	} );
+
+	it( 'rejects a `..` traversal whose realpath escapes the allowlist', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/home/user/secret.key' );
+		await expect(
+			assertAllowedPath( '/home/user/uploads/../secret.key', [ '/home/user/uploads' ] )
+		).rejects.toThrow( /not allowed/i );
+	} );
+
+	it( 'does not match a sibling directory with a similar prefix', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/home/user/uploads-secret/stuff.key' );
+		await expect(
+			assertAllowedPath(
+				'/home/user/uploads-secret/stuff.key',
+				[ '/home/user/uploads' ]
+			)
+		).rejects.toThrow( /not allowed/i );
+	} );
+
+	it( 'accepts when the resolved path equals the allowlist entry exactly', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/home/user/uploads' );
+		const resolved = await assertAllowedPath(
+			'/home/user/uploads',
+			[ '/home/user/uploads' ]
+		);
+		expect( resolved ).toBe( '/home/user/uploads' );
+	} );
+
+	it( 'accepts when the file is under any of several allowlist entries', async () => {
+		vi.mocked( realpath ).mockResolvedValueOnce( '/var/lib/photos/b.jpg' );
+		const resolved = await assertAllowedPath(
+			'/var/lib/photos/b.jpg',
+			[ '/home/user/uploads', '/var/lib/photos' ]
+		);
+		expect( resolved ).toBe( '/var/lib/photos/b.jpg' );
+	} );
+} );

--- a/tests/common/wikiService.test.ts
+++ b/tests/common/wikiService.test.ts
@@ -16,6 +16,7 @@ function setConfig( config: Partial<Config> ): void {
 						scriptpath: '/w'
 					}
 				},
+				uploadDirs: [],
 				...config
 			} )
 		};
@@ -43,5 +44,23 @@ describe( 'wikiService.isWikiManagementAllowed', () => {
 		setConfig( { allowWikiManagement: false } );
 		const { wikiService } = await import( '../../src/common/wikiService.js' );
 		expect( wikiService.isWikiManagementAllowed() ).toBe( false );
+	} );
+} );
+
+describe( 'wikiService.getUploadDirs', () => {
+	beforeEach( () => {
+		vi.resetModules();
+	} );
+
+	it( 'returns an empty array when no uploadDirs are configured', async () => {
+		setConfig( { uploadDirs: [] } );
+		const { wikiService } = await import( '../../src/common/wikiService.js' );
+		expect( wikiService.getUploadDirs() ).toEqual( [] );
+	} );
+
+	it( 'returns the configured uploadDirs list', async () => {
+		setConfig( { uploadDirs: [ '/var/lib/uploads', '/tmp/incoming' ] } );
+		const { wikiService } = await import( '../../src/common/wikiService.js' );
+		expect( wikiService.getUploadDirs() ).toEqual( [ '/var/lib/uploads', '/tmp/incoming' ] );
 	} );
 } );

--- a/tests/tools/upload-file.test.ts
+++ b/tests/tools/upload-file.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} ),
+		getUploadDirs: vi.fn().mockReturnValue( [ '/home/user/uploads' ] )
+	}
+} ) );
+
+vi.mock( '../../src/common/uploadGuard.js', () => ( {
+	assertAllowedPath: vi.fn()
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+import { wikiService } from '../../src/common/wikiService.js';
+import { assertAllowedPath } from '../../src/common/uploadGuard.js';
+
+describe( 'upload-file', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.mocked( wikiService.getUploadDirs ).mockReturnValue( [ '/home/user/uploads' ] );
+	} );
+
+	it( 'returns isError and does not call mwn.upload when the guard rejects the filepath', async () => {
+		vi.mocked( assertAllowedPath ).mockRejectedValue(
+			new Error( 'Upload rejected: "/etc/passwd" is not allowed by the configured upload directories.' )
+		);
+		const mock = createMockMwn( { upload: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUploadFileTool } = await import( '../../src/tools/upload-file.js' );
+		const result = await handleUploadFileTool( '/etc/passwd', 'File:Shadow', 'body' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch( /Upload rejected/ );
+		expect( mock.upload ).not.toHaveBeenCalled();
+	} );
+
+	it( 'passes the realpath-resolved filepath to mwn.upload on success', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockResolvedValue( { result: 'Success', filename: 'Cat.jpg' } )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUploadFileTool } = await import( '../../src/tools/upload-file.js' );
+		const result = await handleUploadFileTool(
+			'/home/user/uploads/cat.jpg',
+			'File:Cat.jpg',
+			'A cat.'
+		);
+
+		expect( result.isError ).toBeUndefined();
+		expect( mock.upload ).toHaveBeenCalledWith(
+			'/var/lib/uploads/cat.jpg',
+			'File:Cat.jpg',
+			'A cat.',
+			expect.any( Object )
+		);
+	} );
+
+	it( 'passes the configured uploadDirs allowlist to the guard', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/home/user/uploads/x.jpg' );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockResolvedValue( { result: 'Success' } )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUploadFileTool } = await import( '../../src/tools/upload-file.js' );
+		await handleUploadFileTool( '/home/user/uploads/x.jpg', 'File:X', 'body' );
+
+		expect( assertAllowedPath ).toHaveBeenCalledWith(
+			'/home/user/uploads/x.jpg',
+			[ '/home/user/uploads' ]
+		);
+	} );
+} );

--- a/tests/tools/upload-file.test.ts
+++ b/tests/tools/upload-file.test.ts
@@ -15,13 +15,19 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 	}
 } ) );
 
-vi.mock( '../../src/common/uploadGuard.js', () => ( {
-	assertAllowedPath: vi.fn()
-} ) );
+vi.mock( '../../src/common/uploadGuard.js', async () => {
+	const actual = await vi.importActual<typeof import( '../../src/common/uploadGuard.js' )>(
+		'../../src/common/uploadGuard.js'
+	);
+	return {
+		...actual,
+		assertAllowedPath: vi.fn()
+	};
+} );
 
 import { getMwn } from '../../src/common/mwn.js';
 import { wikiService } from '../../src/common/wikiService.js';
-import { assertAllowedPath } from '../../src/common/uploadGuard.js';
+import { assertAllowedPath, UploadValidationError } from '../../src/common/uploadGuard.js';
 
 describe( 'upload-file', () => {
 	beforeEach( () => {
@@ -29,9 +35,11 @@ describe( 'upload-file', () => {
 		vi.mocked( wikiService.getUploadDirs ).mockReturnValue( [ '/home/user/uploads' ] );
 	} );
 
-	it( 'returns isError and does not call mwn.upload when the guard rejects the filepath', async () => {
+	it( 'categorises UploadValidationError as invalid_input and does not call mwn.upload', async () => {
 		vi.mocked( assertAllowedPath ).mockRejectedValue(
-			new Error( 'Upload rejected: "/etc/passwd" is not allowed by the configured upload directories.' )
+			new UploadValidationError(
+				'"/etc/passwd" is not allowed by the configured upload directories.'
+			)
 		);
 		const mock = createMockMwn( { upload: vi.fn() } );
 		vi.mocked( getMwn ).mockResolvedValue( mock as any );
@@ -40,7 +48,26 @@ describe( 'upload-file', () => {
 		const result = await handleUploadFileTool( '/etc/passwd', 'File:Shadow', 'body' );
 
 		expect( result.isError ).toBe( true );
-		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch( /Upload rejected/ );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch(
+			/^invalid_input: Failed to upload file:.*not allowed/
+		);
+		expect( mock.upload ).not.toHaveBeenCalled();
+	} );
+
+	it( 'categorises unexpected guard errors via classifyError', async () => {
+		vi.mocked( assertAllowedPath ).mockRejectedValue(
+			new Error( 'Connection refused' )
+		);
+		const mock = createMockMwn( { upload: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUploadFileTool } = await import( '../../src/tools/upload-file.js' );
+		const result = await handleUploadFileTool( '/home/user/uploads/x.jpg', 'File:X', 'body' );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toMatch(
+			/^upstream_failure: Failed to upload file: Connection refused/
+		);
 		expect( mock.upload ).not.toHaveBeenCalled();
 	} );
 


### PR DESCRIPTION
## Summary

Adds an allowlist to the `upload-file` tool so that only files inside explicitly configured directories can be uploaded to the wiki. Uploads are **disabled by default** — the operator must opt in by naming one or more directories via `MCP_UPLOAD_DIRS` env var or a top-level `uploadDirs` array in `config.json`. Without configuration, `upload-file` returns a clear error directing the LLM to ask the operator to configure.

## What changes

- **New `src/common/uploadGuard.ts`** — `assertAllowedPath(filepath, allowedDirs)` validates that the caller-supplied path is absolute, exists, and (after `fs.realpath`) sits inside one of the configured directories. Returns the resolved path on success. Throws a typed `UploadValidationError` on rejection. Pure validator, no config dependency — mirrors the shape of `ssrfGuard.ts`.
- **Config support** in `src/common/config.ts`: new required `uploadDirs: readonly string[]` field, populated from the union of `MCP_UPLOAD_DIRS` (colon-separated absolute paths) and a top-level `uploadDirs` array in `config.json`. Each entry is `fs.realpathSync`-canonicalised at load; invalid entries (non-string, relative, non-existent) fail startup with a specific operator-facing error.
- **`wikiService.getUploadDirs()`** accessor exposes the loaded list, parallel to the existing `isWikiManagementAllowed()`.
- **`upload-file` tool handler** calls the guard, routes `UploadValidationError` through `errorResult('invalid_input', …)` to match the post-#287 error convention, and passes the realpath-resolved path — not the caller-supplied input — to `mwn.upload` so the file we validated is the file we upload.
- **Tool description** updated to name the allowlist constraint up-front so LLMs don't probe disallowed paths before the rejection error surfaces.
- **Error messages** written for the three audiences that read them: the LLM deciding whether to retry (empty-allowlist flagged as not-model-fixable; path-outside-allowlist lists allowed roots), the operator debugging a misconfigured entry (drops syscall jargon), and docs readers onboarding (the new `docs/configuration.md` section leads with "disabled by default").

## Scope & non-goals

- MCP Roots protocol support (client-supplied allow-listing) is a tracked follow-up — today the allowlist is static at startup.
- `upload-file-from-url` is untouched; it asks MediaWiki to fetch the remote URL, and any guarding lives on the wiki side (`$wgCopyUploadsDomains`).
- Per-wiki upload-dir scoping is not implemented; the allowlist is global. Additive if a real use case surfaces.

## Test plan

- [x] `npm test` — 364/364 pass (25 new across uploadGuard, config, wikiService, and upload-file suites)
- [x] `npm run lint` — 0 errors (4 `security/detect-non-literal-fs-filename` warnings on the validated-path call sites, same class as the existing warnings in `config.ts`)
- [x] `npm run build` — clean
- [x] `npm run validate:server-json` — valid
- [x] Manual smoke: empty allowlist returns the "ask the operator" message; relative path rejected; non-existent file rejected cleanly; path outside allowlist names the allowed roots and hints at symlink escape; valid path resolves and is forwarded to `mwn.upload`.
- [x] After merge: reverify against a local wiki by uploading an allowed file (golden path) and a disallowed path (rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)