### PR TITLE
Add get-recent-changes tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `get-page` | Fetch a wiki page. | - |
 | `get-page-history` | List recent revisions of a wiki page. | - |
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). | - |
+| `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and noise flags (up to 50 per call, paginated via `continue`). | - |
 | `get-revision` | Fetch a specific revision of a page. | - |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. | - |
 | `remove-wiki` | Remove a wiki resource. Disabled when `allowWikiManagement` is `false`. | - |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `get-page` | Fetch a wiki page. | - |
 | `get-page-history` | List recent revisions of a wiki page. | - |
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). | - |
-| `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and noise flags (up to 50 per call, paginated via `continue`). | - |
+| `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and hide flags (up to 50 per call, paginated via `continue`). | - |
 | `get-revision` | Fetch a specific revision of a page. | - |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. | - |
 | `remove-wiki` | Remove a wiki resource. Disabled when `allowWikiManagement` is `false`. | - |

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -39,7 +39,7 @@ const inputSchema = {
 	hideAnon: z.boolean().optional().describe( 'Omit edits by anonymous users' ),
 	hideRedirects: z.boolean().optional().describe( 'Omit changes whose target is a redirect' ),
 	hidePatrolled: z.boolean().optional().describe(
-		'Omit patrolled edits (requires patrol rights on the wiki)'
+		'Omit patrolled edits. Requires patrol rights.'
 	),
 	continue: z.string().optional().describe(
 		"Continuation token from a prior call's truncation marker"
@@ -172,7 +172,7 @@ function formatChange( change: RecentChange ): TextContent {
 export function getRecentChangesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-recent-changes',
-		'Returns recent change events on a wiki (edits and page creations by default; log actions, categorizations, and external changes via types), newest first, in segments of 50. Each row includes title, timestamp, user, revision IDs, size change, flags (minor/bot/new/anon), tags, and change type. Filter by timestamp window, namespaces, user, change tag, or noise flags (hideBots/hideMinor/hideAnon/hideRedirects/hidePatrolled). Paginate with the continue token from the truncation marker. For a single page\'s revision history, use get-page-history.',
+		'Returns recent change events, newest first, in segments of 50. Defaults to edits and page creations; set types to include log actions, categorizations, or external changes. Each row includes title, timestamp, user, revision IDs, size change, flags (minor/bot/new/anon), tags, and change type. Filter by timestamp window, namespaces, user, change tag, or hide flags (hideBots/hideMinor/hideAnon/hideRedirects/hidePatrolled). Paginate with the continue token from the truncation marker. For a single page\'s revision history, use get-page-history.',
 		inputSchema,
 		{
 			title: 'Get recent changes',
@@ -260,7 +260,7 @@ export async function handleGetRecentChangesTool(
 			return {
 				content: [ {
 					type: 'text',
-					text: 'No recent changes matched the given filters'
+					text: 'No recent changes matched the filters'
 				} as TextContent ]
 			};
 		}

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -261,9 +261,25 @@ export async function handleGetRecentChangesTool(
 		const response = await mwn.request( params );
 		const changes = ( response.query?.recentchanges ?? [] ) as RecentChange[];
 
+		if ( changes.length === 0 ) {
+			return {
+				content: [ {
+					type: 'text',
+					text: 'No recent changes matched the given filters'
+				} as TextContent ]
+			};
+		}
+
 		const content: TextContent[] = changes.map( formatChange );
 
-		const truncation: TruncationInfo | null = null; // Task 3 wires this.
+		const nextCursor: string | undefined = response.continue?.rccontinue;
+		const truncation: TruncationInfo | null = nextCursor ? {
+			reason: 'more-available',
+			returnedCount: changes.length,
+			itemNoun: 'changes',
+			toolName: 'get-recent-changes',
+			continueWith: { param: 'continue', value: nextCursor }
+		} : null;
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -8,7 +8,7 @@ import { appendTruncationMarker, type TruncationInfo } from '../common/truncatio
 import { classifyError, errorResult } from '../common/errorMapping.js';
 
 const RC_LIMIT = 50;
-const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo|patrolled';
+const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo';
 
 const RcType = z.enum( [ 'edit', 'new', 'log', 'categorize', 'external' ] );
 
@@ -41,6 +41,9 @@ const inputSchema = {
 	hidePatrolled: z.boolean().optional().describe(
 		'Omit patrolled edits. Requires patrol rights.'
 	),
+	showPatrolStatus: z.boolean().optional().describe(
+		'Include per-row patrol status; adds an "Unpatrolled: yes" line to unpatrolled rows. Requires patrol rights.'
+	),
 	continue: z.string().optional().describe(
 		"Continuation token from a prior call's truncation marker"
 	)
@@ -59,6 +62,7 @@ type RecentChangesArgs = {
 	hideAnon?: boolean;
 	hideRedirects?: boolean;
 	hidePatrolled?: boolean;
+	showPatrolStatus?: boolean;
 	continue?: string;
 };
 
@@ -80,7 +84,6 @@ interface RecentChange {
 	bot?: boolean;
 	new?: boolean;
 	redirect?: boolean;
-	patrolled?: boolean;
 	unpatrolled?: boolean;
 	tags?: string[];
 	logtype?: string;
@@ -172,7 +175,7 @@ function formatChange( change: RecentChange ): TextContent {
 export function getRecentChangesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-recent-changes',
-		'Returns recent change events, newest first, in segments of 50. Defaults to edits and page creations; set types to include log actions, categorizations, or external changes. Each row includes title, timestamp, user, revision IDs, size change, flags (minor/bot/new/anon), tags, and change type. Filter by timestamp window, namespaces, user, change tag, or hide flags (hideBots/hideMinor/hideAnon/hideRedirects/hidePatrolled). Paginate with the continue token from the truncation marker. For a single page\'s revision history, use get-page-history.',
+		'Returns recent change events, newest first, in segments of 50. Defaults to edits and page creations; set types to include log actions, categorizations, or external changes. Each row includes title, timestamp, user, revision IDs, size change, flags (minor/bot/new/anon), tags, and change type. Filter by timestamp window, namespaces, user, change tag, or hide flags (hideBots/hideMinor/hideAnon/hideRedirects/hidePatrolled). Pass showPatrolStatus to include per-row patrol state (requires patrol rights). Paginate with the continue token from the truncation marker. For a single page\'s revision history, use get-page-history.',
 		inputSchema,
 		{
 			title: 'Get recent changes',
@@ -217,13 +220,15 @@ export async function handleGetRecentChangesTool(
 
 		const types = args.types ?? [ 'edit', 'new' ];
 
+		const rcprop = args.showPatrolStatus ? `${ RC_PROP }|patrolled` : RC_PROP;
+
 		const params: Record<string, string | number | boolean> = {
 			action: 'query',
 			list: 'recentchanges',
 			rctype: types.join( '|' ),
 			rclimit: RC_LIMIT,
 			rcdir: 'older',
-			rcprop: RC_PROP,
+			rcprop,
 			formatversion: '2'
 		};
 

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -5,6 +5,7 @@ import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontext
 /* eslint-enable n/no-missing-import */
 import { getMwn } from '../common/mwn.js';
 import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
 
 const RC_LIMIT = 50;
 const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo|patrolled';
@@ -208,13 +209,7 @@ export async function handleGetRecentChangesTool(
 	args: RecentChangesArgs
 ): Promise<CallToolResult> {
 	if ( args.user && args.excludeUser ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: 'Cannot use both user and excludeUser at the same time'
-			} as TextContent ],
-			isError: true
-		};
+		return errorResult( 'invalid_input', 'user and excludeUser are mutually exclusive' );
 	}
 
 	try {
@@ -283,12 +278,7 @@ export async function handleGetRecentChangesTool(
 
 		return { content: appendTruncationMarker( content, truncation ) };
 	} catch ( error ) {
-		return {
-			content: [ {
-				type: 'text',
-				text: `Failed to retrieve recent changes: ${ ( error as Error ).message }`
-			} as TextContent ],
-			isError: true
-		};
+		const { category } = classifyError( error );
+		return errorResult( category, `Failed to retrieve recent changes: ${ ( error as Error ).message }` );
 	}
 }

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -61,6 +61,113 @@ type RecentChangesArgs = {
 	continue?: string;
 };
 
+interface RecentChange {
+	type: 'edit' | 'new' | 'log' | 'categorize' | 'external';
+	title: string;
+	timestamp: string;
+	user?: string;
+	userid?: number;
+	anon?: boolean;
+	userhidden?: boolean;
+	commenthidden?: boolean;
+	revid?: number;
+	old_revid?: number;
+	newlen?: number;
+	oldlen?: number;
+	comment?: string;
+	minor?: boolean;
+	bot?: boolean;
+	new?: boolean;
+	redirect?: boolean;
+	patrolled?: boolean;
+	unpatrolled?: boolean;
+	tags?: string[];
+	logtype?: string;
+	logaction?: string;
+	logparams?: Record<string, unknown>;
+}
+
+function formatUser( change: RecentChange ): string {
+	if ( change.userhidden ) {
+		return 'User: (hidden)';
+	}
+	if ( change.anon ) {
+		return `User: ${ change.user } (anonymous)`;
+	}
+	return `User: ${ change.user } (ID: ${ change.userid })`;
+}
+
+function formatFlags( change: RecentChange ): string | undefined {
+	const flags: string[] = [];
+	if ( change.minor ) {
+		flags.push( 'minor' );
+	}
+	if ( change.bot ) {
+		flags.push( 'bot' );
+	}
+	if ( change.new ) {
+		flags.push( 'new' );
+	}
+	if ( change.anon ) {
+		flags.push( 'anon' );
+	}
+	return flags.length > 0 ? `Flags: ${ flags.join( ', ' ) }` : undefined;
+}
+
+function formatLogParams( params: Record<string, unknown> ): string {
+	return Object.entries( params )
+		.map( ( [ key, value ] ) => `${ key }=${ Array.isArray( value ) ? value.join( '|' ) : String( value ) }` )
+		.join( ', ' );
+}
+
+function formatChange( change: RecentChange ): TextContent {
+	const lines: string[] = [
+		`Type: ${ change.type }`,
+		`Title: ${ change.title }`,
+		`Timestamp: ${ change.timestamp }`,
+		formatUser( change )
+	];
+
+	if ( change.type !== 'log' && change.revid !== undefined ) {
+		const fromSuffix = change.old_revid && change.old_revid !== 0 ?
+			` (from ${ change.old_revid })` :
+			'';
+		lines.push( `Revision: ${ change.revid }${ fromSuffix }` );
+	}
+
+	if ( change.type !== 'log' && change.newlen !== undefined ) {
+		const delta = change.newlen - ( change.oldlen ?? 0 );
+		const sign = delta >= 0 ? '+' : '';
+		lines.push( `Size: ${ change.newlen } bytes (${ sign }${ delta })` );
+	}
+
+	if ( !change.commenthidden && change.comment ) {
+		lines.push( `Comment: ${ change.comment }` );
+	}
+
+	if ( change.type === 'log' && change.logtype && change.logaction ) {
+		const paramsStr = change.logparams && Object.keys( change.logparams ).length > 0 ?
+			` (${ formatLogParams( change.logparams ) })` :
+			'';
+		lines.push( `Log: ${ change.logtype }/${ change.logaction }${ paramsStr }` );
+	}
+
+	const flagsLine = formatFlags( change );
+	if ( flagsLine ) {
+		lines.push( flagsLine );
+	}
+
+	if ( change.tags && change.tags.length > 0 ) {
+		lines.push( `Tags: ${ change.tags.join( ', ' ) }` );
+	}
+
+	if ( change.unpatrolled === true ) {
+		lines.push( 'Unpatrolled: yes' );
+	}
+
+	return { type: 'text', text: lines.join( '\n' ) };
+}
+
 export function getRecentChangesTool( server: McpServer ): RegisteredTool {
 	return server.tool(
 		'get-recent-changes',
@@ -152,13 +259,9 @@ export async function handleGetRecentChangesTool(
 		}
 
 		const response = await mwn.request( params );
-		const changes = ( response.query?.recentchanges ?? [] ) as unknown[];
+		const changes = ( response.query?.recentchanges ?? [] ) as RecentChange[];
 
-		// Minimal placeholder formatter — Task 2 replaces this.
-		const content: TextContent[] = changes.map( ( _c ): TextContent => ( {
-			type: 'text',
-			text: 'change'
-		} ) );
+		const content: TextContent[] = changes.map( formatChange );
 
 		const truncation: TruncationInfo | null = null; // Task 3 wires this.
 

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, TextContent, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+/* eslint-enable n/no-missing-import */
+import { getMwn } from '../common/mwn.js';
+import { appendTruncationMarker, type TruncationInfo } from '../common/truncation.js';
+
+const RC_LIMIT = 50;
+const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo|patrolled';
+
+const RcType = z.enum( [ 'edit', 'new', 'log', 'categorize', 'external' ] );
+
+const inputSchema = {
+	since: z.string().optional().describe(
+		'ISO 8601 timestamp — only return changes at or after this time'
+	),
+	until: z.string().optional().describe(
+		'ISO 8601 timestamp — only return changes at or before this time'
+	),
+	namespace: z.array( z.number().int().nonnegative() ).nonempty().optional().describe(
+		'Namespace IDs to restrict the feed to — e.g. [0, 1] for main and talk'
+	),
+	types: z.array( RcType ).nonempty().optional().describe(
+		'Event types to include. Defaults to edit and new (content changes only).'
+	),
+	user: z.string().optional().describe(
+		'Username — return only changes by this user. Mutually exclusive with excludeUser.'
+	),
+	excludeUser: z.string().optional().describe(
+		'Username — exclude changes by this user. Mutually exclusive with user.'
+	),
+	tag: z.string().optional().describe(
+		'Change tag — return only changes carrying this tag'
+	),
+	hideBots: z.boolean().optional().describe( 'Omit bot-flagged edits' ),
+	hideMinor: z.boolean().optional().describe( 'Omit minor-flagged edits' ),
+	hideAnon: z.boolean().optional().describe( 'Omit edits by anonymous users' ),
+	hideRedirects: z.boolean().optional().describe( 'Omit changes whose target is a redirect' ),
+	hidePatrolled: z.boolean().optional().describe(
+		'Omit patrolled edits (requires patrol rights on the wiki)'
+	),
+	continue: z.string().optional().describe(
+		"Continuation token from a prior call's truncation marker"
+	)
+};
+
+type RecentChangesArgs = {
+	since?: string;
+	until?: string;
+	namespace?: number[];
+	types?: z.infer<typeof RcType>[];
+	user?: string;
+	excludeUser?: string;
+	tag?: string;
+	hideBots?: boolean;
+	hideMinor?: boolean;
+	hideAnon?: boolean;
+	hideRedirects?: boolean;
+	hidePatrolled?: boolean;
+	continue?: string;
+};
+
+export function getRecentChangesTool( server: McpServer ): RegisteredTool {
+	return server.tool(
+		'get-recent-changes',
+		'Returns recent change events on a wiki (edits and page creations by default; log actions, categorizations, and external changes via types), newest first, in segments of 50. Each row includes title, timestamp, user, revision IDs, size change, flags (minor/bot/new/anon), tags, and change type. Filter by timestamp window, namespaces, user, change tag, or noise flags (hideBots/hideMinor/hideAnon/hideRedirects/hidePatrolled). Paginate with the continue token from the truncation marker. For a single page\'s revision history, use get-page-history.',
+		inputSchema,
+		{
+			title: 'Get recent changes',
+			readOnlyHint: true,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true
+		} as ToolAnnotations,
+		async ( args ) => handleGetRecentChangesTool( args as RecentChangesArgs )
+	);
+}
+
+function buildRcShow( args: RecentChangesArgs ): string | undefined {
+	const parts: string[] = [];
+	if ( args.hideBots ) {
+		parts.push( '!bot' );
+	}
+	if ( args.hideMinor ) {
+		parts.push( '!minor' );
+	}
+	if ( args.hideAnon ) {
+		parts.push( '!anon' );
+	}
+	if ( args.hideRedirects ) {
+		parts.push( '!redirect' );
+	}
+	if ( args.hidePatrolled ) {
+		parts.push( '!patrolled' );
+	}
+	return parts.length > 0 ? parts.join( '|' ) : undefined;
+}
+
+export async function handleGetRecentChangesTool(
+	args: RecentChangesArgs
+): Promise<CallToolResult> {
+	if ( args.user && args.excludeUser ) {
+		return {
+			content: [ {
+				type: 'text',
+				text: 'Cannot use both user and excludeUser at the same time'
+			} as TextContent ],
+			isError: true
+		};
+	}
+
+	try {
+		const mwn = await getMwn();
+
+		const types = args.types ?? [ 'edit', 'new' ];
+
+		const params: Record<string, string | number | boolean> = {
+			action: 'query',
+			list: 'recentchanges',
+			rctype: types.join( '|' ),
+			rclimit: RC_LIMIT,
+			rcdir: 'older',
+			rcprop: RC_PROP,
+			formatversion: '2'
+		};
+
+		if ( args.since !== undefined ) {
+			params.rcend = args.since;
+		}
+		if ( args.until !== undefined ) {
+			params.rcstart = args.until;
+		}
+		if ( args.namespace && args.namespace.length > 0 ) {
+			params.rcnamespace = args.namespace.join( '|' );
+		}
+		if ( args.user !== undefined ) {
+			params.rcuser = args.user;
+		}
+		if ( args.excludeUser !== undefined ) {
+			params.rcexcludeuser = args.excludeUser;
+		}
+		if ( args.tag !== undefined ) {
+			params.rctag = args.tag;
+		}
+		const rcshow = buildRcShow( args );
+		if ( rcshow !== undefined ) {
+			params.rcshow = rcshow;
+		}
+		if ( args.continue !== undefined ) {
+			params.rccontinue = args.continue;
+		}
+
+		const response = await mwn.request( params );
+		const changes = ( response.query?.recentchanges ?? [] ) as unknown[];
+
+		// Minimal placeholder formatter — Task 2 replaces this.
+		const content: TextContent[] = changes.map( ( _c ): TextContent => ( {
+			type: 'text',
+			text: 'change'
+		} ) );
+
+		const truncation: TruncationInfo | null = null; // Task 3 wires this.
+
+		return { content: appendTruncationMarker( content, truncation ) };
+	} catch ( error ) {
+		return {
+			content: [ {
+				type: 'text',
+				text: `Failed to retrieve recent changes: ${ ( error as Error ).message }`
+			} as TextContent ],
+			isError: true
+		};
+	}
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import { deletePageTool } from './delete-page.js';
 import { getRevisionTool } from './get-revision.js';
 import { undeletePageTool } from './undelete-page.js';
 import { getCategoryMembersTool } from './get-category-members.js';
+import { getRecentChangesTool } from './get-recent-changes.js';
 import { searchPageByPrefixTool } from './search-page-by-prefix.js';
 import { parseWikitextTool } from './parse-wikitext.js';
 import { comparePagesTool } from './compare-pages.js';
@@ -32,6 +33,7 @@ const toolRegistrars: [ string, ToolRegistrar ][] = [
 	[ 'get-page', getPageTool ],
 	[ 'get-pages', getPagesTool ],
 	[ 'get-page-history', getPageHistoryTool ],
+	[ 'get-recent-changes', getRecentChangesTool ],
 	[ 'search-page', searchPageTool ],
 	[ 'add-wiki', addWikiTool ],
 	[ 'remove-wiki', removeWikiTool ],

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -422,7 +422,7 @@ describe( 'get-recent-changes — truncation and empty results', () => {
 		expect( result.isError ).toBeUndefined();
 		expect( result.content ).toHaveLength( 1 );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
-			'No recent changes matched the given filters'
+			'No recent changes matched the filters'
 		);
 	} );
 } );

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -127,7 +127,7 @@ describe( 'get-recent-changes — handler validation', () => {
 
 		expect( result.isError ).toBe( true );
 		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain(
-			'Cannot use both user and excludeUser at the same time'
+			'invalid_input: user and excludeUser are mutually exclusive'
 		);
 		expect( mock.request ).not.toHaveBeenCalled();
 	} );

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( { getMwn: vi.fn() } ) );
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo|patrolled';
+
+function mockRequest( response: unknown ) {
+	const mock = createMockMwn( {
+		request: vi.fn().mockResolvedValue( response )
+	} );
+	vi.mocked( getMwn ).mockResolvedValue( mock as any );
+	return mock;
+}
+
+describe( 'get-recent-changes — parameter mapping', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'issues a default query with rctype=edit|new, rclimit=50, rcdir=older, full rcprop', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( {} );
+
+		expect( mock.request ).toHaveBeenCalledWith( expect.objectContaining( {
+			action: 'query',
+			list: 'recentchanges',
+			rctype: 'edit|new',
+			rclimit: 50,
+			rcdir: 'older',
+			rcprop: RC_PROP,
+			formatversion: '2'
+		} ) );
+	} );
+
+	it( 'maps since to rcend and until to rcstart (rcdir=older walks rcstart→rcend)', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { since: '2026-01-01T00:00:00Z', until: '2026-02-01T00:00:00Z' } );
+
+		const call = mock.request.mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( {
+			rcend: '2026-01-01T00:00:00Z',
+			rcstart: '2026-02-01T00:00:00Z'
+		} );
+	} );
+
+	it( 'pipe-joins namespace array into rcnamespace', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { namespace: [ 0, 1, 14 ] } );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rcnamespace ).toBe( '0|1|14' );
+	} );
+
+	it( 'pipe-joins types array into rctype', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { types: [ 'log', 'categorize' ] } );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rctype ).toBe( 'log|categorize' );
+	} );
+
+	it( 'maps user and tag through to rcuser and rctag', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { user: 'Alice', tag: 'mobile-edit' } );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			rcuser: 'Alice',
+			rctag: 'mobile-edit'
+		} );
+	} );
+
+	it( 'maps excludeUser to rcexcludeuser', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { excludeUser: 'Bob' } );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rcexcludeuser ).toBe( 'Bob' );
+	} );
+
+	it( 'composes hide flags into a pipe-joined rcshow', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( {
+			hideBots: true, hideMinor: true, hideAnon: true,
+			hideRedirects: false, hidePatrolled: false
+		} );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rcshow ).toBe( '!bot|!minor|!anon' );
+	} );
+
+	it( 'omits rcshow when no hide flags are set', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( {} );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rcshow ).toBeUndefined();
+	} );
+
+	it( 'maps continue token to rccontinue', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( { continue: '20260101123456|1234567' } );
+
+		expect( mock.request.mock.calls[ 0 ][ 0 ].rccontinue ).toBe( '20260101123456|1234567' );
+	} );
+} );
+
+describe( 'get-recent-changes — handler validation', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'rejects user + excludeUser combined without issuing an API call', async () => {
+		const mock = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( { user: 'Alice', excludeUser: 'Bob' } );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain(
+			'Cannot use both user and excludeUser at the same time'
+		);
+		expect( mock.request ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'get-recent-changes — error handling', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'surfaces API errors as isError with a wrapped message', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockRejectedValue( new Error( 'badtimestamp' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( { since: 'garbage' } );
+
+		expect( result.isError ).toBe( true );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toContain(
+			'Failed to retrieve recent changes: badtimestamp'
+		);
+	} );
+} );

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -13,7 +13,7 @@ vi.mock( '../../src/common/wikiService.js', () => ( {
 
 import { getMwn } from '../../src/common/mwn.js';
 
-const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo|patrolled';
+const RC_PROP = 'user|userid|comment|flags|timestamp|title|ids|sizes|tags|loginfo';
 
 function mockRequest( response: unknown ) {
 	const mock = createMockMwn( {
@@ -108,6 +108,17 @@ describe( 'get-recent-changes — parameter mapping', () => {
 		expect( mock.request.mock.calls[ 0 ][ 0 ].rcshow ).toBeUndefined();
 	} );
 
+	it( 'appends patrolled to rcprop only when showPatrolStatus is set', async () => {
+		const mockOff = mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		await handleGetRecentChangesTool( {} );
+		expect( mockOff.request.mock.calls[ 0 ][ 0 ].rcprop ).toBe( RC_PROP );
+
+		const mockOn = mockRequest( { query: { recentchanges: [] } } );
+		await handleGetRecentChangesTool( { showPatrolStatus: true } );
+		expect( mockOn.request.mock.calls[ 0 ][ 0 ].rcprop ).toBe( `${ RC_PROP }|patrolled` );
+	} );
+
 	it( 'maps continue token to rccontinue', async () => {
 		const mock = mockRequest( { query: { recentchanges: [] } } );
 		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
@@ -171,8 +182,7 @@ describe( 'get-recent-changes — formatter', () => {
 				comment: 'typo fix',
 				minor: true,
 				bot: true,
-				tags: [ 'mobile-edit' ],
-				unpatrolled: true
+				tags: [ 'mobile-edit' ]
 			} ] }
 		} );
 		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
@@ -188,7 +198,6 @@ describe( 'get-recent-changes — formatter', () => {
 		expect( text ).toContain( 'Comment: typo fix' );
 		expect( text ).toContain( 'Flags: minor, bot' );
 		expect( text ).toContain( 'Tags: mobile-edit' );
-		expect( text ).toContain( 'Unpatrolled: yes' );
 	} );
 
 	it( 'omits Flags, Tags, Comment, and Unpatrolled lines when absent', async () => {
@@ -342,7 +351,7 @@ describe( 'get-recent-changes — formatter', () => {
 		expect( text ).not.toContain( 'Comment:' );
 	} );
 
-	it( 'omits the Unpatrolled line for patrolled edits', async () => {
+	it( 'renders Unpatrolled: yes when unpatrolled is set on the row', async () => {
 		mockRequest( {
 			query: { recentchanges: [ {
 				type: 'edit',
@@ -355,16 +364,40 @@ describe( 'get-recent-changes — formatter', () => {
 				newlen: 100,
 				oldlen: 90,
 				comment: '',
-				patrolled: true,
+				tags: [],
+				unpatrolled: true
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( { showPatrolStatus: true } );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'Unpatrolled: yes' );
+	} );
+
+	it( 'omits the Unpatrolled line when unpatrolled is not set', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Foo',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Alice',
+				userid: 42,
+				revid: 100,
+				old_revid: 99,
+				newlen: 100,
+				oldlen: 90,
+				comment: '',
 				tags: []
 			} ] }
 		} );
 		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
-		const result = await handleGetRecentChangesTool( {} );
+		const result = await handleGetRecentChangesTool( { showPatrolStatus: true } );
 
 		const text = ( result.content[ 0 ] as { text: string } ).text;
 		expect( text ).not.toContain( 'Unpatrolled' );
 	} );
+
 } );
 
 describe( 'get-recent-changes — truncation and empty results', () => {

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -151,3 +151,218 @@ describe( 'get-recent-changes — error handling', () => {
 		);
 	} );
 } );
+
+describe( 'get-recent-changes — formatter', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'renders an edit row with all optional fields', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Help:Foo',
+				ns: 12,
+				timestamp: '2026-01-01T12:34:56Z',
+				user: 'Alice',
+				userid: 42,
+				revid: 1234567,
+				old_revid: 1234500,
+				newlen: 1523,
+				oldlen: 1500,
+				comment: 'typo fix',
+				minor: true,
+				bot: true,
+				tags: [ 'mobile-edit' ],
+				unpatrolled: true
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'Type: edit' );
+		expect( text ).toContain( 'Title: Help:Foo' );
+		expect( text ).toContain( 'Timestamp: 2026-01-01T12:34:56Z' );
+		expect( text ).toContain( 'User: Alice (ID: 42)' );
+		expect( text ).toContain( 'Revision: 1234567 (from 1234500)' );
+		expect( text ).toContain( 'Size: 1523 bytes (+23)' );
+		expect( text ).toContain( 'Comment: typo fix' );
+		expect( text ).toContain( 'Flags: minor, bot' );
+		expect( text ).toContain( 'Tags: mobile-edit' );
+		expect( text ).toContain( 'Unpatrolled: yes' );
+	} );
+
+	it( 'omits Flags, Tags, Comment, and Unpatrolled lines when absent', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Foo',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Bob',
+				userid: 7,
+				revid: 100,
+				old_revid: 99,
+				newlen: 100,
+				oldlen: 100,
+				comment: '',
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).not.toContain( 'Flags:' );
+		expect( text ).not.toContain( 'Tags:' );
+		expect( text ).not.toContain( 'Comment:' );
+		expect( text ).not.toContain( 'Unpatrolled:' );
+		expect( text ).toContain( 'Size: 100 bytes (+0)' );
+	} );
+
+	it( 'renders a new-page row without the (from ...) suffix and with positive delta', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'new',
+				title: 'Brand New',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Carol',
+				userid: 3,
+				revid: 500,
+				old_revid: 0,
+				newlen: 240,
+				oldlen: 0,
+				comment: 'created',
+				new: true,
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'Type: new' );
+		expect( text ).toContain( 'Revision: 500' );
+		expect( text ).not.toContain( '(from' );
+		expect( text ).toContain( 'Size: 240 bytes (+240)' );
+		expect( text ).toContain( 'Flags: new' );
+	} );
+
+	it( 'renders a log row with Log line and logparams, no Revision or Size', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'log',
+				title: 'User:BadActor',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Admin',
+				userid: 1,
+				comment: 'Vandalism-only account',
+				logtype: 'block',
+				logaction: 'block',
+				logparams: { duration: 'infinity', flags: [ 'nocreate' ] },
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( { types: [ 'log' ] } );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'Type: log' );
+		expect( text ).toContain( 'Log: block/block (' );
+		expect( text ).toContain( 'duration=infinity' );
+		expect( text ).not.toContain( 'Revision:' );
+		expect( text ).not.toContain( 'Size:' );
+	} );
+
+	it( 'renders a log row with no logparams as a bare Log line', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'log',
+				title: 'Example',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Admin',
+				userid: 1,
+				comment: '',
+				logtype: 'patrol',
+				logaction: 'patrol',
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( { types: [ 'log' ] } );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'Log: patrol/patrol' );
+		expect( text ).not.toContain( 'Log: patrol/patrol (' );
+	} );
+
+	it( 'renders an anon edit as User: <IP> (anonymous)', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Foo',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: '192.0.2.1',
+				anon: true,
+				revid: 100,
+				old_revid: 99,
+				newlen: 100,
+				oldlen: 90,
+				comment: '',
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'User: 192.0.2.1 (anonymous)' );
+		expect( text ).not.toContain( '(ID:' );
+		expect( text ).toContain( 'Flags: anon' );
+	} );
+
+	it( 'renders hidden user as User: (hidden) and drops hidden comment line', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Foo',
+				timestamp: '2026-01-01T00:00:00Z',
+				userhidden: true,
+				commenthidden: true,
+				revid: 100,
+				old_revid: 99,
+				newlen: 100,
+				oldlen: 90,
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).toContain( 'User: (hidden)' );
+		expect( text ).not.toContain( 'Comment:' );
+	} );
+
+	it( 'omits the Unpatrolled line for patrolled edits', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit',
+				title: 'Foo',
+				timestamp: '2026-01-01T00:00:00Z',
+				user: 'Alice',
+				userid: 42,
+				revid: 100,
+				old_revid: 99,
+				newlen: 100,
+				oldlen: 90,
+				comment: '',
+				patrolled: true,
+				tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const text = ( result.content[ 0 ] as { text: string } ).text;
+		expect( text ).not.toContain( 'Unpatrolled' );
+	} );
+} );

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -366,3 +366,63 @@ describe( 'get-recent-changes — formatter', () => {
 		expect( text ).not.toContain( 'Unpatrolled' );
 	} );
 } );
+
+describe( 'get-recent-changes — truncation and empty results', () => {
+	beforeEach( () => { vi.clearAllMocks(); } );
+
+	it( 'appends a more-available marker when rccontinue is present', async () => {
+		const rows = Array.from( { length: 2 }, ( _, i ) => ( {
+			type: 'edit',
+			title: `Page ${ i }`,
+			timestamp: '2026-01-01T00:00:00Z',
+			user: 'Alice',
+			userid: 42,
+			revid: 100 + i,
+			old_revid: 99 + i,
+			newlen: 100,
+			oldlen: 100,
+			comment: '',
+			tags: []
+		} ) );
+		mockRequest( {
+			query: { recentchanges: rows },
+			continue: { rccontinue: '20260101000000|1234', continue: '-||' }
+		} );
+
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		const last = result.content[ result.content.length - 1 ] as { text: string };
+		expect( last.text ).toBe(
+			'More results available. Returned 2 changes. To fetch the next segment, call get-recent-changes again with continue="20260101000000|1234".'
+		);
+	} );
+
+	it( 'does not append a marker when rccontinue is absent', async () => {
+		mockRequest( {
+			query: { recentchanges: [ {
+				type: 'edit', title: 'Foo', timestamp: '2026-01-01T00:00:00Z',
+				user: 'A', userid: 1, revid: 100, old_revid: 99,
+				newlen: 100, oldlen: 100, comment: '', tags: []
+			} ] }
+		} );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		for ( const block of result.content ) {
+			expect( ( block as { text: string } ).text ).not.toContain( 'More results available' );
+		}
+	} );
+
+	it( 'returns a single "no matches" message for empty results', async () => {
+		mockRequest( { query: { recentchanges: [] } } );
+		const { handleGetRecentChangesTool } = await import( '../../src/tools/get-recent-changes.js' );
+		const result = await handleGetRecentChangesTool( {} );
+
+		expect( result.isError ).toBeUndefined();
+		expect( result.content ).toHaveLength( 1 );
+		expect( ( result.content[ 0 ] as { text: string } ).text ).toBe(
+			'No recent changes matched the given filters'
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

- Adds a new read-only MCP tool `get-recent-changes` that wraps MediaWiki's `list=recentchanges`, exposing the full filter surface (timestamp window, namespaces, user/excludeUser, change tag, event types, five hide flags) and opaque continuation.
- Routes content-change events (edits, page creations) by default; callers can opt into log actions, categorizations, and external changes via `types`.
- Renders each row into a uniform text block with type-specific tails (edit/new: revision + size delta; log: `Log: type/action (params)`; anon/hidden user variants).
- Paginates with the standard `more-available` truncation marker shape; emits a single explanatory block on empty results; routes handler and upstream errors through the shared `errorResult` / `classifyError` helpers introduced by #287.

## Relationship to issue #258

Issue #258 asked for a primitive to discover pages under a prefix changed since timestamp X. During design we pivoted from a narrow prefix-scoped tool to a general recent-changes feed, since:

- MediaWiki's `list=recentchanges` already covers the sync use case when combined with client-side title-prefix filtering (`namespace` + `since`, dedupe by title).
- The same primitive unlocks patrolling, audit, user-activity review, and \"what happened lately\" workflows that a prefix-scoped tool would not address.
- Tradeoff: on high-churn wikis a prefix-scoped sync pays to pull rows that get filtered out client-side, since MediaWiki has no server-side prefix filter on `recentchanges`. Mitigations — narrow time windows + per-call pagination — come for free. A dedicated prefix-scoped variant can be added later if demand appears; YAGNI until then.

## Test plan

- [x] `npm test` — 386/386 passing (22 new tests covering parameter mapping, mutex validation, per-row formatting for every event/user variant, truncation marker, empty result, and error wrapping).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] Manual smoke via `npm run inspector` against a live wiki (call with no args, with `since`, with `types=['log']`, with a `continue` token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)