### PR TITLE
Add Gemini CLI extension manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,20 @@ You should end up with something like the below in your `.claude.json` config:
 ```
 </details>
 
+<details>
+<summary><b>Install in Gemini CLI</b></summary>
+
+Run:
+
+```bash
+gemini extensions install https://github.com/ProfessionalWiki/MediaWiki-MCP-Server
+```
+
+This installs the extension from the latest GitHub Release. To pin a specific version, append `--ref=<tag>` (for example `--ref=v0.6.5`).
+
+See the [Gemini CLI extensions documentation](https://github.com/google-gemini/gemini-cli/tree/main/docs/extensions) for how to update, list, or uninstall extensions.
+</details>
+
 ## Deployment
 
 Running the server as a remote HTTP endpoint for other users has its own configuration requirements — see [docs/deployment.md](docs/deployment.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,7 +21,7 @@ npm version 0.2.0
 This command automatically:
 
 - Updates `package.json` and `package-lock.json`
-- Syncs the version in `server.json`, `mcpb/manifest.json`, and `Dockerfile` (via the `version` script)
+- Syncs the version in `server.json`, `mcpb/manifest.json`, `gemini-extension.json`, and `Dockerfile` (via the `version` script)
 - Creates a git commit
 - Creates a git tag (e.g. `v0.2.0`)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,11 @@
+{
+  "name": "mediawiki-mcp-server",
+  "version": "0.6.5",
+  "description": "MCP server enabling AI clients to interact with any MediaWiki wiki through standard tools",
+  "mcpServers": {
+    "mediawiki": {
+      "command": "npx",
+      "args": ["-y", "@professional-wiki/mediawiki-mcp-server@latest"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"bundle": "npm run build && node scripts/bundle.cjs",
 		"preversion": "npm run preflight",
-		"version": "node scripts/sync-version.cjs && git add server.json mcpb/manifest.json Dockerfile"
+		"version": "node scripts/sync-version.cjs && git add server.json mcpb/manifest.json gemini-extension.json Dockerfile"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.25.2",

--- a/scripts/constants.cjs
+++ b/scripts/constants.cjs
@@ -13,6 +13,7 @@ module.exports = {
 	PACKAGE_JSON_PATH: path.join( ROOT_DIR, 'package.json' ),
 	SERVER_JSON_PATH: path.join( ROOT_DIR, 'server.json' ),
 	MANIFEST_JSON_PATH: path.join( ROOT_DIR, 'mcpb', MANIFEST_FILE ),
+	GEMINI_EXTENSION_JSON_PATH: path.join( ROOT_DIR, 'gemini-extension.json' ),
 	DOCKERFILE_PATH: path.join( ROOT_DIR, 'Dockerfile' ),
 	MCPB_BUNDLE_PATH: path.join( ROOT_DIR, MCPB_FILE )
 };

--- a/scripts/sync-version.cjs
+++ b/scripts/sync-version.cjs
@@ -6,12 +6,14 @@ const {
 	PACKAGE_JSON_PATH,
 	SERVER_JSON_PATH,
 	MANIFEST_JSON_PATH,
+	GEMINI_EXTENSION_JSON_PATH,
 	DOCKERFILE_PATH
 } = require( './constants.cjs' );
 
 const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
 const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
 const manifestJson = JSON.parse( fs.readFileSync( MANIFEST_JSON_PATH, 'utf8' ) );
+const geminiExtensionJson = JSON.parse( fs.readFileSync( GEMINI_EXTENSION_JSON_PATH, 'utf8' ) );
 let dockerfile = fs.readFileSync( DOCKERFILE_PATH, 'utf8' );
 
 const version = packageJson.version;
@@ -22,14 +24,28 @@ serverJson.version = version;
 // Update manifest.json
 manifestJson.version = version;
 
+// Update gemini-extension.json
+geminiExtensionJson.version = version;
+
 // Update Dockerfile
 const versionRegex = /(org\.opencontainers\.image\.version=")[^"]*(")/;
 dockerfile = dockerfile.replace( versionRegex, `$1${ version }$2` );
 
 fs.writeFileSync( SERVER_JSON_PATH, JSON.stringify( serverJson, null, 2 ) + '\n' );
 fs.writeFileSync( MANIFEST_JSON_PATH, JSON.stringify( manifestJson, null, 2 ) + '\n' );
+fs.writeFileSync( GEMINI_EXTENSION_JSON_PATH, JSON.stringify( geminiExtensionJson, null, 2 ) + '\n' );
 fs.writeFileSync( DOCKERFILE_PATH, dockerfile );
+
+// Post-write verification: re-read gemini-extension.json and assert the version round-tripped.
+// Protects against silent sync drift (e.g., a future edit that breaks JSON or forgets the field).
+const geminiVerify = JSON.parse( fs.readFileSync( GEMINI_EXTENSION_JSON_PATH, 'utf8' ) );
+if ( geminiVerify.version !== version ) {
+	throw new Error(
+		`gemini-extension.json version mismatch after sync: expected ${ version }, got ${ geminiVerify.version }`
+	);
+}
 
 console.log( `✓ Updated server.json to version ${ version }` );
 console.log( `✓ Updated manifest.json to version ${ version }` );
+console.log( `✓ Updated gemini-extension.json to version ${ version }` );
 console.log( `✓ Updated Dockerfile to version ${ version }` );


### PR DESCRIPTION
## Summary

- Adds `gemini-extension.json` at the repo root so users can install the MediaWiki MCP Server via `gemini extensions install https://github.com/ProfessionalWiki/MediaWiki-MCP-Server`.
- Thin wrapper — the manifest points Gemini CLI at the existing npm package (`npx -y @professional-wiki/mediawiki-mcp-server@latest`). No `GEMINI.md`, no slash commands, no Gemini-specific behavior. Tool descriptions and annotation hints already convey everything Gemini needs from the running MCP server.
- Extends `scripts/sync-version.cjs` so `npm version <bump>` rewrites the manifest's top-level `version` alongside `server.json`, `mcpb/manifest.json`, and `Dockerfile`, with a post-write assertion that fails the release if the file doesn't round-trip. `package.json`'s `version` script is updated to stage the new file in the release commit.
- README gets a new `<details>` install block; `docs/releasing.md` lists the new synced file.

Versioning: Gemini CLI resolves extension versions from the install source (HEAD of the default branch, or the latest GitHub Release), not from the manifest's `version` field. Since this repo already publishes GitHub Releases, updates work automatically. Users can pin with `--ref=<tag>`.

## Test plan

- [x] `npm test` — 388/388 pass on the feature branch
- [x] `npm run lint` — clean (4 pre-existing warnings unrelated to this change)
- [x] `npm run build` — clean
- [x] `npm run validate:server-json` — clean
- [x] End-to-end smoke: simulated `npm version` bump (package.json → 99.99.99), ran `scripts/sync-version.cjs` + `git add`, confirmed all four target files synced to 99.99.99 and `gemini-extension.json` appeared staged; unwound cleanly.
- [ ] Manual post-release smoke: after the next tagged release, run `gemini extensions install https://github.com/ProfessionalWiki/MediaWiki-MCP-Server` in a Gemini CLI session and invoke a MediaWiki tool against a real wiki.