### PR TITLE
Bump @modelcontextprotocol/sdk floor to ^1.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.6.5",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.25.2",
+				"@modelcontextprotocol/sdk": "^1.29.0",
 				"express": "^5.1.0",
 				"ipaddr.js": "1.9.1",
 				"mwn": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"version": "node scripts/sync-version.cjs && git add server.json mcpb/manifest.json gemini-extension.json Dockerfile"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.25.2",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"express": "^5.1.0",
 		"ipaddr.js": "1.9.1",
 		"mwn": "^3.0.1",


### PR DESCRIPTION
## Summary

- Raises the `@modelcontextprotocol/sdk` floor from `^1.25.2` to `^1.29.0` so `npm install` on a fresh checkout cannot resolve to an SDK version that predates full MCP 2025-11-25 spec support.
- The lockfile was already pinned to 1.29.0 and that's what CI tests against; this only aligns the declared floor with reality.
- 1.29.0 advertises `LATEST_PROTOCOL_VERSION = 2025-11-25`.

## Why

`^1.25.2` allowed downstream installs to land on 1.25.2, which shipped before the 2025-11-25 protocol work rolled through the SDK across 1.26–1.29. That meant a drift window where a freshly-installed server could advertise an older protocol than what we develop and test against.

No source changes are needed — the SDK's 1.x API surface has stayed additive across these minors.

## Test plan

- [x] `npm run preflight` passes end-to-end (install, lint, server.json validation, 436 tests, build, bundle with manifest validation)
- [x] `LATEST_PROTOCOL_VERSION` on the installed SDK reports `2025-11-25`