### PR TITLE
Set instructions on the MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,12 @@ const packageInfo = createRequire( import.meta.url )( '../package.json' ) as { v
 const SERVER_NAME: string = 'mediawiki-mcp-server';
 const SERVER_VERSION: string = packageInfo.version;
 
+const SERVER_INSTRUCTIONS: string = `Tools and resources for working with one or more MediaWiki wikis. Each configured wiki appears as an \`mcp://wikis/{wikiKey}\` resource. Tool calls target the currently selected wiki; pass an \`mcp://wikis/{wikiKey}\` URI to \`set-wiki\` to switch, and the selection persists until changed.
+
+Writes, deletes, and uploads use the caller's \`Authorization: Bearer\` token when present, falling back to credentials configured on the active wiki.
+
+Tool errors fall into seven categories: \`not_found\`, \`permission_denied\`, \`invalid_input\`, \`conflict\`, \`authentication\`, \`rate_limited\`, and \`upstream_failure\`. Reads that exceed a per-call cap return a truncation marker describing what was returned and how to fetch the rest.`;
+
 export const createServer = (): McpServer => {
 	const server = new McpServer(
 		{
@@ -28,7 +34,8 @@ export const createServer = (): McpServer => {
 				tools: {
 					listChanged: true
 				}
-			}
+			},
+			instructions: SERVER_INSTRUCTIONS
 		}
 	);
 


### PR DESCRIPTION
## Summary

Sets the `McpServer` `instructions` field — shown to clients during `initialize` and read by the model when first encountering the server. Previously unset, so a caller arriving via Claude Desktop or a similar host had no orientation beyond per-tool descriptions.

## What's in the instructions

Three short paragraphs covering only what the model can act on and would otherwise need to infer:

- The **multi-wiki resource model** and how `set-wiki` switches the active wiki — the single most-likely-to-be-missed concept for any caller targeting a specific wiki.
- The **bearer-then-static-credentials** auth fallback so the model knows which identity its writes act as.
- The **seven-category error taxonomy** and the **truncation marker** convention for capped reads.

Voice matches `docs/tool-conventions.md` — descriptive third-person, no imperative model-directed instructions. The text avoids referencing operator-side config keys (`defaultWiki`, `allowWikiManagement`) that the LLM cannot inspect, and skips explaining tool visibility (`tools/list` is authoritative).

## Test plan

- [x] `npm run preflight` passes (31 test files, 451 tests, lint clean of new errors, build, bundle, manifest validation)
- [x] No behavior change for tools or transports — this is a single string declaration on `ServerOptions`

## Coordination

Touches only `src/server.ts`. No collisions with #293 (tool refactor) or other in-flight branches.