### PR TITLE
Set title and description on the MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 	},
 	"type": "module",
 	"files": [
-		"dist"
+		"dist",
+		"server.json"
 	],
 	"main": "dist/index.js",
 	"bin": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,10 +9,13 @@ import { registerAllResources } from './resources/index.js';
 import { reconcileToolsForActiveWiki } from './tools/reconcile.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
-const packageInfo = createRequire( import.meta.url )( '../package.json' ) as { version: string };
+const serverInfo = createRequire( import.meta.url )( '../server.json' ) as {
+	title: string;
+	description: string;
+	version: string;
+};
 
 const SERVER_NAME: string = 'mediawiki-mcp-server';
-const SERVER_VERSION: string = packageInfo.version;
 
 const SERVER_INSTRUCTIONS: string = `Tools and resources for working with one or more MediaWiki wikis. Each configured wiki appears as an \`mcp://wikis/{wikiKey}\` resource. Tool calls target the currently selected wiki; pass an \`mcp://wikis/{wikiKey}\` URI to \`set-wiki\` to switch, and the selection persists until changed.
 
@@ -24,7 +27,9 @@ export const createServer = (): McpServer => {
 	const server = new McpServer(
 		{
 			name: SERVER_NAME,
-			version: SERVER_VERSION
+			title: serverInfo.title,
+			version: serverInfo.version,
+			description: serverInfo.description
 		},
 		{
 			capabilities: {
@@ -55,4 +60,4 @@ export const createServer = (): McpServer => {
 	return server;
 };
 
-export const USER_AGENT: string = `${ SERVER_NAME }/${ SERVER_VERSION }`;
+export const USER_AGENT: string = `${ SERVER_NAME }/${ serverInfo.version }`;


### PR DESCRIPTION
## Summary

Sets `Implementation.title` and `Implementation.description` on the `McpServer`. Both became part of the `Implementation` schema in the most recent spec revision; `description` was added explicitly to align with the MCP registry's `server.json` format, so this PR makes `server.json` the runtime source of truth for all three Implementation strings — `title`, `description`, and `version`.

## Changes

- `src/server.ts` loads `server.json` via `createRequire` and reads `title`, `description`, and `version` from it. The previous `package.json` require is dropped.
- `package.json` adds `server.json` to the `files` array so it ships with the npm package; previously `files: ["dist"]` excluded it.
- `package.json.version` remains the upstream source — `scripts/sync-version.cjs` continues to propagate it into `server.json` (and the other release-tracked files) on `npm version`.

## Why

For MCP hosts and tooling that connect to the server without going through the registry (Inspector, locally-built dev binaries, custom integrations), `Implementation.title` and `description` are the only metadata channel. Sourcing them from `server.json` rather than hardcoding strings means the registry-published metadata and the runtime-advertised metadata cannot drift.

## Test plan

- [x] `npm run preflight` passes (31 test files, 451 tests, lint, validate, build, bundle, manifest)