### PR TITLE
Add CHANGELOG and automate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,20 @@ jobs:
             git push origin HEAD:master
           fi
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node scripts/extract-changelog-section.cjs "$VERSION" > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::Empty CHANGELOG section for $VERSION"
+            exit 1
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           files: '*.mcpb'
-          generate_release_notes: true
+          body_path: release-notes.md
 
       - name: Install MCP Publisher
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking changes
+
+- HTTP transport now binds to `127.0.0.1` by default and validates the `Host` header. Deployments that exposed the server externally must explicitly set the bind address and trusted hosts. (#291)
+- Streamable HTTP transport now validates the `Origin` header on incoming requests. Browser clients without an allowed origin will be rejected.
+- All tool output has been reshaped to plain prose with unified field names. Clients that parsed the previous structured output need to be updated. (#293)
+- Tool error shapes have been standardised. Clients that pattern-matched the previous error strings need to be updated. (#287)
+- Smithery integration has been removed. Use the documented stdio, MCPB, or HTTP transports instead.
+
+### Added
+
+- `compare-pages` tool for server-side wikitext diffs.
+- `parse-wikitext` tool for previewing rendered output, including categories, links, templates, and display title.
+- `get-pages` tool for batched page fetches.
+- `get-recent-changes` tool. (#289)
+- Section editing and append/prepend modes on `update-page`. (#284)
+- Per-request OAuth2 bearer token passthrough for HTTP transport, allowing each client to act as its own wiki user. (#282)
+- Per-wiki `readOnly` configuration and a hosted deployment recipe. (#274)
+- `allowWikiManagement` config option to disable `add-wiki` and `remove-wiki`. (#270)
+- Configurable change tag for MCP-originated edits. (#271)
+- `exec` credential source and fail-fast environment variable resolution for config secrets. (#269)
+- MCP logging capability with a structured logger.
+- `MCP_CONTENT_MAX_BYTES` environment variable for tuning the byte cap on read-tool output.
+- Environment variable substitution in config files.
+- Gemini CLI extension manifest. (#290)
+- Server title, description, and instructions surfaced over MCP.
+
+### Changed
+
+- All tools migrated from the MediaWiki REST API to the `mwn` Action API. (#235)
+- Tool descriptions rewritten under a new style guide.
+- `latestId` is now optional on `update-page`.
+- Content model is auto-detected by MediaWiki on page creation.
+- Truncation is now signalled by `search-page`, `search-page-by-prefix`, `get-page-history`, and `get-category-members` when results are capped.
+- `get-category-members` caps at 500 results with opaque cursor pagination, applied after filtering.
+- `search-page` forwards the `limit` parameter only when explicitly set.
+- `@modelcontextprotocol/sdk` floor bumped to `^1.29.0`.
+- Documentation reorganised by audience. (#280)
+
+### Security
+
+- HTTP transport binds to `127.0.0.1` by default with `Host`-header validation. (#291)
+- Streamable HTTP transport validates the `Origin` header on incoming requests.
+- HTTP sessions are bound to the bearer token used to initialise them. (#292)
+- `add-wiki` blocks SSRF by validating discovery URLs.
+- `upload-file` is gated behind a configurable upload-directory allowlist. (#288)
+- `SECURITY.md` added with the disclosure policy.
+- Transitive dependencies bumped to patched versions.
+
+### Removed
+
+- Smithery integration.
+
+[Unreleased]: https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/compare/v0.6.5...HEAD

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,11 @@
 
 How to cut a new release of the MediaWiki MCP Server. Maintainers only.
 
-## 1. Create a release with `npm version`
+## 1. Review the CHANGELOG
+
+[CHANGELOG.md](../CHANGELOG.md) accumulates entries under `## [Unreleased]` as PRs land. Before tagging, review that section, polish the wording, and commit any prose tweaks. The Unreleased entries become the GitHub Release body verbatim.
+
+## 2. Create a release with `npm version`
 
 ```sh
 # For patch release (0.1.1 → 0.1.2)
@@ -22,12 +26,13 @@ This command automatically:
 
 - Updates `package.json` and `package-lock.json`
 - Syncs the version in `server.json`, `mcpb/manifest.json`, `gemini-extension.json`, and `Dockerfile` (via the `version` script)
+- Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [<version>] - <today>` and refreshes the link references
 - Creates a git commit
 - Creates a git tag (e.g. `v0.2.0`)
 
 The `preversion` hook runs `npm run preflight` first (install, lint, server.json validation, test, build, bundle) and aborts the release if any step fails.
 
-## 2. Push to GitHub
+## 3. Push to GitHub
 
 ```sh
 git push origin master --follow-tags
@@ -35,6 +40,6 @@ git push origin master --follow-tags
 
 The `release` GitHub workflow triggers automatically on the tag and:
 
-- Builds the `.mcpb` bundle and attaches it to a new [GitHub Release](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases).
+- Builds the `.mcpb` bundle and attaches it to a new [GitHub Release](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases), using the new `CHANGELOG.md` section as the release body.
 - Publishes the package to [NPM](https://www.npmjs.com/package/@professional-wiki/mediawiki-mcp-server).
 - Publishes to the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.professionalwiki/mediawiki-mcp-server).

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"bundle": "npm run build && node scripts/bundle.cjs",
 		"preversion": "npm run preflight",
-		"version": "node scripts/sync-version.cjs && git add server.json mcpb/manifest.json gemini-extension.json Dockerfile"
+		"version": "node scripts/sync-version.cjs && node scripts/promote-changelog.cjs && git add server.json mcpb/manifest.json gemini-extension.json Dockerfile CHANGELOG.md"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/constants.cjs
+++ b/scripts/constants.cjs
@@ -15,5 +15,6 @@ module.exports = {
 	MANIFEST_JSON_PATH: path.join( ROOT_DIR, 'mcpb', MANIFEST_FILE ),
 	GEMINI_EXTENSION_JSON_PATH: path.join( ROOT_DIR, 'gemini-extension.json' ),
 	DOCKERFILE_PATH: path.join( ROOT_DIR, 'Dockerfile' ),
+	CHANGELOG_PATH: path.join( ROOT_DIR, 'CHANGELOG.md' ),
 	MCPB_BUNDLE_PATH: path.join( ROOT_DIR, MCPB_FILE )
 };

--- a/scripts/extract-changelog-section.cjs
+++ b/scripts/extract-changelog-section.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require( 'fs' );
+const { CHANGELOG_PATH } = require( './constants.cjs' );
+
+const version = process.argv[ 2 ];
+if ( !version ) {
+	console.error( 'Usage: extract-changelog-section.cjs <version>' );
+	process.exit( 1 );
+}
+
+const changelog = fs.readFileSync( CHANGELOG_PATH, 'utf8' );
+
+const startMarker = `## [${ version }]`;
+const startIdx = changelog.indexOf( startMarker );
+if ( startIdx === -1 ) {
+	console.error( `No section found for version ${ version } in CHANGELOG.md` );
+	process.exit( 1 );
+}
+
+const afterHeadingIdx = changelog.indexOf( '\n', startIdx ) + 1;
+
+const candidates = [
+	changelog.indexOf( '\n## [', afterHeadingIdx ),
+	changelog.indexOf( '\n[Unreleased]:', afterHeadingIdx )
+].filter( ( i ) => i !== -1 );
+const endIdx = candidates.length > 0 ? Math.min( ...candidates ) : changelog.length;
+
+process.stdout.write( changelog.slice( afterHeadingIdx, endIdx ).trim() + '\n' );

--- a/scripts/promote-changelog.cjs
+++ b/scripts/promote-changelog.cjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require( 'fs' );
+const { PACKAGE_JSON_PATH, CHANGELOG_PATH } = require( './constants.cjs' );
+
+const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
+const version = packageJson.version;
+const today = new Date().toISOString().slice( 0, 10 );
+
+const changelog = fs.readFileSync( CHANGELOG_PATH, 'utf8' );
+
+const versionHeading = `## [${ version }]`;
+if ( changelog.includes( versionHeading ) ) {
+	throw new Error( `CHANGELOG.md already contains a ${ versionHeading } section.` );
+}
+
+const unreleasedHeading = '## [Unreleased]';
+if ( !changelog.includes( unreleasedHeading ) ) {
+	throw new Error( `CHANGELOG.md is missing the ${ unreleasedHeading } section.` );
+}
+
+const unreleasedLink = /^\[Unreleased\]:.*$/m;
+if ( !unreleasedLink.test( changelog ) ) {
+	throw new Error( 'CHANGELOG.md is missing the [Unreleased] link reference at the bottom.' );
+}
+
+let promoted = changelog.replace(
+	unreleasedHeading,
+	`${ unreleasedHeading }\n\n${ versionHeading } - ${ today }`
+);
+
+const repoCompareBase = 'https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/compare';
+const previousTagMatch = promoted.match( /\[Unreleased\]:.*compare\/(v[^.]+\.[^.]+\.[^.]+)\.\.\.HEAD/ );
+if ( !previousTagMatch ) {
+	throw new Error( 'Could not parse previous tag from [Unreleased] link reference.' );
+}
+const previousTag = previousTagMatch[ 1 ];
+const newTag = `v${ version }`;
+
+promoted = promoted.replace(
+	unreleasedLink,
+	`[Unreleased]: ${ repoCompareBase }/${ newTag }...HEAD\n[${ version }]: ${ repoCompareBase }/${ previousTag }...${ newTag }`
+);
+
+fs.writeFileSync( CHANGELOG_PATH, promoted );
+console.log( `✓ Promoted CHANGELOG.md Unreleased section to ${ version } (${ today })` );


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` (Keep-a-Changelog format) with the 0.7.0 entry staged under `## [Unreleased]`.
- Add `scripts/promote-changelog.cjs` so `npm version` renames `## [Unreleased]` to `## [<version>] - <date>` and refreshes the link references inside the existing version commit.
- Add `scripts/extract-changelog-section.cjs` and switch `release.yml` from `generate_release_notes: true` to `body_path: release-notes.md`, so the GitHub Release body is the curated CHANGELOG section for that tag.
- Update `docs/releasing.md` to describe the new flow.

The previous auto-generated release notes were a raw dump of PR titles (mostly dependabot bumps) with no breaking-changes story. The new flow distributes the writing across PRs (each contributor adds bullets under Unreleased) and consolidates at tag time without manual copy-paste.

If the section for the tag is missing or empty, the workflow fails before creating the GitHub Release.

## Test plan

- [x] Inspect `CHANGELOG.md` for accuracy against `git log v0.6.5..HEAD`
- [x] Locally bump `package.json` to a stub version, run `node scripts/promote-changelog.cjs`, confirm CHANGELOG.md is updated and revert
- [x] Run `node scripts/extract-changelog-section.cjs 0.7.0` against a promoted CHANGELOG and confirm the expected body
- [x] CI lint + tests pass on this branch
- [ ] After merge, cut 0.7.0 with `npm version 0.7.0` and verify the resulting GitHub Release uses the CHANGELOG section as its body

🤖 Generated with [Claude Code](https://claude.com/claude-code)