### PR TITLE
Switch npm publish to trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
 
     - name: Run preflight checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Run preversion checks
@@ -32,8 +32,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_MCP_WRITE }}
 
       - name: Update server.json (npm)
         run: node scripts/update-server-json-npm.cjs


### PR DESCRIPTION
## Summary

- Replaces the long-lived `NPM_MCP_WRITE` token with OIDC-based trusted publishing. GitHub's id-token vouches for the workflow run and npm exchanges that for a short-lived publish token; no shared secret to rotate.
- Bumps Node from 22 to 24 in both `release.yml` and `ci.yml`. Node 24 is the current active LTS and ships with npm 11, which is required for trusted publishing. Aligning both workflows keeps the build environments consistent so Node-24-specific issues surface in CI rather than at release time.
- Drops `NODE_AUTH_TOKEN` from the publish step. The `id-token: write` permission is already set for provenance and MCP Registry OIDC.

The trusted publisher has been configured on npmjs.com for `@professional-wiki/mediawiki-mcp-server` against this repository and `release.yml` as the source workflow. The `NPM_MCP_WRITE` secret can be deleted from repo Settings → Secrets once a release has confirmed the new flow works.

Context: the v0.7.0 release run failed at `Publish to npm` with a 404, blocking this release ([run](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/actions/runs/24919907409)). Migrating to trusted publishing is the structural fix.

## Test plan

- [x] CI on this branch passes on Node 24
- [ ] After merge, delete and re-create the \`v0.7.0\` tag at the new master HEAD to pick up this workflow change
- [ ] Verify the workflow run succeeds end-to-end (npm publish, GitHub Release with CHANGELOG body, MCP Registry publish)
- [ ] Confirm npm shows \`0.7.0\` as latest with provenance attached
- [ ] Once verified, delete \`NPM_MCP_WRITE\` from repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)