### PR TITLE
Expand tool description conventions and update compare-pages

### DIFF
--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -37,15 +37,18 @@ Third-person descriptive voice avoids point-of-view inconsistencies that degrade
 Every description answers at least:
 
 1. **What** the tool does.
-2. **What it returns.**
+2. **What it returns.** Name the shape (e.g. "a compact text diff", "rendered HTML or wikitext source") when the tool name doesn't already convey it.
 
 Depth scales from there based on how much there is to disambiguate. Longer descriptions are warranted when any of the following apply:
 
 - **Sibling overlap.** Another tool in the set does something similar. State when to use this vs. the other.
+- **No implicit trigger.** Every description should convey the situation in which this tool is the right choice. The trigger can be carried by canonical domain terminology in the opening (e.g. "wiki page"), by sibling routing ("For X, use Y"), or by an explicit clause ("Use when..."). When none of those is present and the tool name alone is too generic to disambiguate against tools in other servers, add the explicit clause.
 - **Non-obvious constraints.** Input combinations that are rejected, behaviour at boundaries, capped or truncated output.
 - **Usage hints.** Soft recommendations that help the model pick this tool for the right workflow.
 
 Apply proportional depth: don't pad simple tools with filler, don't keep tautological tools short. A one-sentence description is fine when there's nothing more to say; a paragraph is fine when there is.
+
+When trimming for context-window cost, cut hedging and incidental detail first; preserve trigger conditions, parameter semantics, and return shape.
 
 #### Don't duplicate the schema
 
@@ -60,6 +63,15 @@ Do not restate this in prose. Prose is for context the schema cannot express.
 #### Avoid tautology
 
 A description that restates the tool name adds zero information. `"Deletes a wiki page"` for `delete-page` is a bad description. A better description says what "delete" means in MediaWiki (deleted pages are recoverable via `undelete-page` until purge), what the tool returns, and what errors the caller might see.
+
+#### Avoid hedging
+
+Don't soften capability statements with "may", "might", "possibly", or "could". State the behaviour, including its conditional branches.
+
+- Do: `"Returns the page source. Errors with not_found when the title does not exist."`
+- Don't: `"May return the page source, possibly erroring if the page doesn't exist."`
+
+Hedging trains the model to treat the tool as unreliable. State conditions explicitly instead.
 
 #### Sibling disambiguation with inline routing hints
 
@@ -83,6 +95,10 @@ The rule targets general imperatives aimed at the model ("You MUST...", "You sho
 
 Imperative instructions to the model ("You should...", "You MUST...") in tool descriptions reduce robustness across different LLM implementations.
 
+#### Name observable side effects
+
+Annotation hints (`destructiveHint`, `idempotentHint`, `openWorldHint`) carry the boolean classification. The description carries the *specific* effect when it isn't obvious from the verb. `delete-page` is obvious; `upload-file-from-url` is not — the description should make clear that the file is fetched server-side, whether it overwrites, and whether the upload is logged. State only effects that are observable to the caller or visible on the wiki, not implementation incidentals.
+
 ### Parameter docs
 
 #### Parameter descriptions
@@ -91,6 +107,7 @@ Every parameter has a `.describe()` call. Parameter docs complement the schema; 
 
 Parameter descriptions must:
 
+- **State the parameter's role, not only its shape.** Describe what the parameter selects, filters, or controls, in the tool's own terms. `"Integer ID of a user"` is shape; `"Filters revisions to those authored by this account"` is role. The schema already conveys shape.
 - **State format when non-obvious.** `"Revision ID"` is fine for an integer parameter; `"MCP resource URI of the wiki (e.g. mcp://wikis/en.wikipedia.org)"` is better than `"Wiki URI"`.
 - **Call out cross-parameter constraints.** E.g. `"If olderThan is set, newerThan must not be."` when such a constraint exists.
 - **Reuse canonical phrases** from Part 2 for recurring concepts (page title, revision ID, wikitext, namespace, etc.).

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -38,7 +38,7 @@ export function comparePagesTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'compare-pages',
 		{
-			description: 'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Cheaper than fetching both sources and diffing locally, because only the changes are returned. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta. Diff output is truncated at 50000 bytes with a trailing marker; a narrower revision range or includeDiff=false avoids truncation.',
+			description: 'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Only the changes are returned over the wire. For the full text of both sides, fetch with get-page instead. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta. Diff output is truncated at 50000 bytes with a trailing marker; a narrower revision range or includeDiff=false avoids truncation.',
 			inputSchema: {
 				fromRevision: z.number().int().positive().optional().describe( 'Revision ID for the "from" side' ),
 				fromTitle: z.string().optional().describe( 'Wiki page title for the "from" side (latest revision is used)' ),


### PR DESCRIPTION
## Summary

- **`docs/tool-conventions.md`** — Five guidance items added to Part 1 (Generic principles → Descriptions and Parameter docs):
  - Coverage: name the return shape when the tool name doesn't imply it.
  - Coverage: ensure each description carries a trigger condition, via canonical domain terminology, sibling routing, or an explicit `Use when…` clause. The rule fails only when none of those is present and the tool name alone is too generic to disambiguate against tools in other servers.
  - New "Avoid hedging" subsection (no `may`/`might`/`possibly`/`could` in capability statements).
  - New "Name observable side effects" subsection — prose complement to the `destructiveHint` / `openWorldHint` annotations.
  - Parameter docs: state the parameter's role, not only its shape (`"Filters revisions to those by this account"` rather than `"Integer ID of a user"`).
  - Trim-priority paragraph: when length is constrained, cut hedging and incidental detail before trigger conditions, parameter semantics, and return shape.

- **`src/tools/compare-pages.ts`** — Apply the canonical sibling-routing pattern. Replace the value claim *"Cheaper than fetching both sources and diffing locally"* with a capability statement plus an explicit route to the alternative workflow (`"For the full text of both sides, fetch with get-page instead."`). No behaviour change.

A 20-tool audit against the updated conventions surfaced no other gaps — recent description work has the codebase already tracking the standard.

## Empirical basis

The convention additions are informed by two recent studies of MCP tool description quality:

- Hasan et al., *MCP Tool Descriptions Are Smelly! Towards Improving AI Agent Efficiency with Augmented MCP Tool Descriptions* — [arXiv:2602.14878](https://arxiv.org/abs/2602.14878). Catalogues six description-quality smells across 856 tools; measures a +5.85 pp median lift in agent task success when descriptions are augmented to address them.
- Wang et al., *From Docs to Descriptions: Smell-Aware Evaluation of MCP Server Descriptions* — [arXiv:2602.18914](https://arxiv.org/abs/2602.18914). Studies 10,831 servers across four quality dimensions (accuracy, functionality, completeness, conciseness) and 18 sub-smells; standard-compliant descriptions hit 72% selection probability vs. 20% baseline.

Citations are intentionally kept out of the conventions doc body — the rules need to stand on their own to be useful as a working reference.

## Test plan

- [x] `npm run lint` — no new errors (4 pre-existing security warnings unrelated to this change).
- [x] `npm test` — 488 tests passing.
- [x] Reviewer eyeballs `compare-pages` description for tone consistency with the rest of the tool set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)