### PR TITLE
Add update-file and update-file-from-url tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- `update-file` tool for uploading a new revision of an existing file from local disk. (#304)
+- `update-file-from-url` tool for uploading a new revision of an existing file from a URL. (#304)
+
 ## [0.7.0] - 2026-04-25
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `search-page-by-prefix` | Search page titles by prefix. | - |
 | `set-wiki` | Set the active wiki for the current session. | - |
 | `undelete-page` 🔐 | Undelete a wiki page. | `Delete pages, revisions, and log entries` |
+| `update-file` 🔐 | Upload a new revision of an existing file from local disk. | `Upload, replace, and move files` |
+| `update-file-from-url` 🔐 | Upload a new revision of an existing file from a URL. | `Upload, replace, and move files` |
 | `update-page` 🔐 | Update an existing wiki page. | `Edit existing pages` |
 | `upload-file` 🔐 | Upload a file to the wiki from local disk. | `Upload new files` |
 | `upload-file-from-url` 🔐 | Upload a file to the wiki from a URL. | `Upload, replace, and move files` |

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -231,3 +231,5 @@ When writing or updating a tool in these pairs, each side's description should e
 - **`search-page` vs `search-page-by-prefix`** — full-text content search vs. title-prefix search.
 - **`get-revision` vs `get-page` with `metadata=true`** — fetch a specific historical revision vs. fetch the latest revision with metadata attached.
 - **`compare-pages` vs. client-side diff** — `compare-pages` computes the diff server-side and returns a compact text diff; prefer it over fetching both sources and diffing locally.
+- **`upload-file` vs `update-file`** — create a new file (rejects if the title already exists) vs. upload a new revision of an existing file (rejects if the title does not exist).
+- **`upload-file-from-url` vs `update-file-from-url`** — same pairing for URL-source uploads.

--- a/src/common/fileExistence.ts
+++ b/src/common/fileExistence.ts
@@ -1,0 +1,29 @@
+import type { ApiPage } from 'mwn';
+import { getMwn } from './mwn.js';
+
+export class FileNotFoundError extends Error {
+	public constructor( public readonly title: string ) {
+		super( `File "${ title }" does not exist.` );
+		this.name = 'FileNotFoundError';
+	}
+}
+
+export async function assertFileExists( title: string ): Promise<void> {
+	const fileTitle = title.startsWith( 'File:' ) ? title : `File:${ title }`;
+	const mwn = await getMwn();
+
+	const response = await mwn.request( {
+		action: 'query',
+		titles: fileTitle,
+		prop: 'imageinfo',
+		iiprop: 'timestamp',
+		formatversion: '2'
+	} );
+
+	const page = ( response as { query?: { pages?: ApiPage[] } } )
+		.query?.pages?.[ 0 ];
+
+	if ( !page || page.missing || !page.imageinfo || page.imageinfo.length === 0 ) {
+		throw new FileNotFoundError( title );
+	}
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { createPageTool } from './create-page.js';
 import { uploadFileTool } from './upload-file.js';
 import { uploadFileFromUrlTool } from './upload-file-from-url.js';
 import { updateFileTool } from './update-file.js';
+import { updateFileFromUrlTool } from './update-file-from-url.js';
 import { deletePageTool } from './delete-page.js';
 import { getRevisionTool } from './get-revision.js';
 import { undeletePageTool } from './undelete-page.js';
@@ -45,6 +46,7 @@ const toolRegistrars: [ string, ToolRegistrar ][] = [
 	[ 'upload-file', uploadFileTool ],
 	[ 'upload-file-from-url', uploadFileFromUrlTool ],
 	[ 'update-file', updateFileTool ],
+	[ 'update-file-from-url', updateFileFromUrlTool ],
 	[ 'delete-page', deletePageTool ],
 	[ 'get-revision', getRevisionTool ],
 	[ 'undelete-page', undeletePageTool ],

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import { getFileTool } from './get-file.js';
 import { createPageTool } from './create-page.js';
 import { uploadFileTool } from './upload-file.js';
 import { uploadFileFromUrlTool } from './upload-file-from-url.js';
+import { updateFileTool } from './update-file.js';
 import { deletePageTool } from './delete-page.js';
 import { getRevisionTool } from './get-revision.js';
 import { undeletePageTool } from './undelete-page.js';
@@ -43,6 +44,7 @@ const toolRegistrars: [ string, ToolRegistrar ][] = [
 	[ 'create-page', createPageTool ],
 	[ 'upload-file', uploadFileTool ],
 	[ 'upload-file-from-url', uploadFileFromUrlTool ],
+	[ 'update-file', updateFileTool ],
 	[ 'delete-page', deletePageTool ],
 	[ 'get-revision', getRevisionTool ],
 	[ 'undelete-page', undeletePageTool ],

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -16,7 +16,7 @@ export function updateFileFromUrlTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'update-file-from-url',
 		{
-			description: 'Fetches a file from a remote web URL and uploads it as a new revision of an existing file, preserving prior revisions in the file history, and returns the file title and URL. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use update-file instead. Fails if no file exists at the target title; for the initial upload, use upload-file-from-url.',
+			description: 'Fetches a file from a remote web URL and uploads it as a new revision of an existing file, preserving prior revisions in the file history, and returns the file title and URL. The upload appears in the wiki\'s upload log. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use update-file instead. Fails if no file exists at the target title; for the initial upload, use upload-file-from-url.',
 			inputSchema: {
 				url: z.string().url().describe( 'URL of the file to upload' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiUploadParams } from 'types-mediawiki-api';
+/* eslint-enable n/no-missing-import */
+import type { ApiUploadResponse } from 'mwn';
+import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
+import { assertFileExists, FileNotFoundError } from '../common/fileExistence.js';
+import { formatEditComment, getPageUrl } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
+import { structuredResult } from '../common/structuredResult.js';
+
+export function updateFileFromUrlTool( server: McpServer ): RegisteredTool {
+	return server.registerTool(
+		'update-file-from-url',
+		{
+			description: 'Fetches a file from a remote web URL and uploads it as a new revision of an existing file, preserving prior revisions in the file history, and returns the file title and URL. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use update-file instead. Fails if no file exists at the target title; for the initial upload, use upload-file-from-url.',
+			inputSchema: {
+				url: z.string().url().describe( 'URL of the file to upload' ),
+				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),
+				comment: z.string().optional().describe( 'Reason for uploading the new revision' )
+			},
+			annotations: {
+				title: 'Update file from URL',
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true
+			} as ToolAnnotations
+		},
+		async (
+			{ url, title, comment }
+		) => handleUpdateFileFromUrlTool( url, title, comment )
+	);
+}
+
+export async function handleUpdateFileFromUrlTool(
+	url: string, title: string, comment?: string
+): Promise< CallToolResult > {
+
+	try {
+		await assertFileExists( title );
+	} catch ( error ) {
+		if ( error instanceof FileNotFoundError ) {
+			return errorResult(
+				'not_found',
+				`File "${ error.title }" does not exist. To create a new file, use upload-file-from-url.`
+			);
+		}
+		const { category, code } = classifyError( error );
+		return errorResult( category, `Failed to update file: ${ ( error as Error ).message }`, code );
+	}
+
+	let data: ApiUploadResponse;
+	try {
+		const mwn = await getMwn();
+		data = await mwn.uploadFromUrl( url, title, '', getApiUploadParams( comment ) );
+	} catch ( error ) {
+		const errorMessage = ( error as Error ).message;
+
+		// Mirror upload-file-from-url: redirect the model away from retrying via URL when
+		// the wiki has copyuploads disabled. Routing hint points at the update-file (local)
+		// sibling for this tool's update intent.
+		if ( errorMessage.includes( 'copyuploaddisabled' ) ) {
+			return errorResult(
+				'invalid_input',
+				'Upload by URL is disabled on this wiki. Download the file locally, then use update-file with the local file path.',
+				'copyuploaddisabled'
+			);
+		}
+
+		const { category, code } = classifyError( error );
+		return errorResult( category, `Failed to update file: ${ errorMessage }`, code );
+	}
+
+	const imageinfo = ( data as ApiUploadResponse & {
+		imageinfo?: { descriptionurl?: string; url?: string };
+	} ).imageinfo;
+	const filename = data.filename ?? title.replace( /^File:/, '' );
+	return structuredResult( {
+		filename,
+		pageUrl: imageinfo?.descriptionurl ?? getPageUrl( `File:${ filename }` ),
+		...( imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {} )
+	} );
+}
+
+function getApiUploadParams( comment?: string ): ApiUploadParams {
+	const params: ApiUploadParams = {
+		comment: formatEditComment( 'update-file-from-url', comment ),
+		ignorewarnings: true
+	};
+	const { config } = wikiService.getCurrent();
+	if ( config.tags !== null && config.tags !== undefined ) {
+		params.tags = config.tags;
+	}
+	return params;
+}

--- a/src/tools/update-file.ts
+++ b/src/tools/update-file.ts
@@ -17,7 +17,7 @@ export function updateFileTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'update-file',
 		{
-			description: 'Uploads a new revision of an existing file from the local disk, preserving prior revisions in the file history, and returns the file title and URL. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if no file exists at the target title; for the initial upload, use upload-file. To upload a new revision from a remote web address instead of a local path, use update-file-from-url.',
+			description: 'Uploads a new revision of an existing file from the local disk, preserving prior revisions in the file history, and returns the file title and URL. The upload appears in the wiki\'s upload log. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if no file exists at the target title; for the initial upload, use upload-file. To upload a new revision from a remote web address instead of a local path, use update-file-from-url.',
 			inputSchema: {
 				filepath: z.string().describe( 'File path on the local disk' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/update-file.ts
+++ b/src/tools/update-file.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+/* eslint-disable n/no-missing-import */
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { ApiUploadParams } from 'types-mediawiki-api';
+/* eslint-enable n/no-missing-import */
+import type { ApiUploadResponse } from 'mwn';
+import { getMwn } from '../common/mwn.js';
+import { wikiService } from '../common/wikiService.js';
+import { assertAllowedPath, UploadValidationError } from '../common/uploadGuard.js';
+import { assertFileExists, FileNotFoundError } from '../common/fileExistence.js';
+import { formatEditComment, getPageUrl } from '../common/utils.js';
+import { classifyError, errorResult } from '../common/errorMapping.js';
+import { structuredResult } from '../common/structuredResult.js';
+
+export function updateFileTool( server: McpServer ): RegisteredTool {
+	return server.registerTool(
+		'update-file',
+		{
+			description: 'Uploads a new revision of an existing file from the local disk, preserving prior revisions in the file history, and returns the file title and URL. Replaces the file content (bytes) only; for editing the wikitext on a file\'s description page, use update-page. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if no file exists at the target title; for the initial upload, use upload-file. To upload a new revision from a remote web address instead of a local path, use update-file-from-url.',
+			inputSchema: {
+				filepath: z.string().describe( 'File path on the local disk' ),
+				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),
+				comment: z.string().optional().describe( 'Reason for uploading the new revision' )
+			},
+			annotations: {
+				title: 'Update file',
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true
+			} as ToolAnnotations
+		},
+		async (
+			{ filepath, title, comment }
+		) => handleUpdateFileTool( filepath, title, comment )
+	);
+}
+
+export async function handleUpdateFileTool(
+	filepath: string, title: string, comment?: string
+): Promise< CallToolResult > {
+
+	let resolvedPath: string;
+	try {
+		resolvedPath = await assertAllowedPath( filepath, wikiService.getUploadDirs() );
+	} catch ( error ) {
+		if ( error instanceof UploadValidationError ) {
+			return errorResult( 'invalid_input', `Failed to update file: ${ error.message }` );
+		}
+		const { category, code } = classifyError( error );
+		return errorResult( category, `Failed to update file: ${ ( error as Error ).message }`, code );
+	}
+
+	try {
+		await assertFileExists( title );
+	} catch ( error ) {
+		if ( error instanceof FileNotFoundError ) {
+			return errorResult(
+				'not_found',
+				`File "${ error.title }" does not exist. To create a new file, use upload-file.`
+			);
+		}
+		const { category, code } = classifyError( error );
+		return errorResult( category, `Failed to update file: ${ ( error as Error ).message }`, code );
+	}
+
+	let data: ApiUploadResponse;
+	try {
+		const mwn = await getMwn();
+		data = await mwn.upload( resolvedPath, title, '', getApiUploadParams( comment ) );
+	} catch ( error ) {
+		const { category, code } = classifyError( error );
+		return errorResult( category, `Failed to update file: ${ ( error as Error ).message }`, code );
+	}
+
+	const imageinfo = ( data as ApiUploadResponse & {
+		imageinfo?: { descriptionurl?: string; url?: string };
+	} ).imageinfo;
+	const filename = data.filename ?? title.replace( /^File:/, '' );
+	return structuredResult( {
+		filename,
+		pageUrl: imageinfo?.descriptionurl ?? getPageUrl( `File:${ filename }` ),
+		...( imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {} )
+	} );
+}
+
+function getApiUploadParams( comment?: string ): ApiUploadParams {
+	const params: ApiUploadParams = {
+		comment: formatEditComment( 'update-file', comment ),
+		ignorewarnings: true
+	};
+	const { config } = wikiService.getCurrent();
+	if ( config.tags !== null && config.tags !== undefined ) {
+		params.tags = config.tags;
+	}
+	return params;
+}

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -15,7 +15,7 @@ export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'upload-file-from-url',
 		{
-			description: 'Fetches a file from a remote web URL and uploads it into the wiki\'s File namespace, returning the resulting file title and URL. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists.',
+			description: 'Fetches a file from a remote web URL and uploads it into the wiki\'s File namespace, returning the resulting file title and URL. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists. To replace an existing file with a new revision, use update-file-from-url.',
 			inputSchema: {
 				url: z.string().url().describe( 'URL of the file to upload' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -15,7 +15,7 @@ export function uploadFileFromUrlTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'upload-file-from-url',
 		{
-			description: 'Fetches a file from a remote web URL and uploads it into the wiki\'s File namespace, returning the resulting file title and URL. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists. To replace an existing file with a new revision, use update-file-from-url.',
+			description: 'Fetches a file from a remote web URL and uploads it into the wiki\'s File namespace, returning the resulting file title and URL. The upload appears in the wiki\'s upload log. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists. To replace an existing file with a new revision, use update-file-from-url.',
 			inputSchema: {
 				url: z.string().url().describe( 'URL of the file to upload' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -16,7 +16,7 @@ export function uploadFileTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'upload-file',
 		{
-			description: 'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url. To replace an existing file with a new revision, use update-file.',
+			description: 'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. The upload appears in the wiki\'s upload log. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url. To replace an existing file with a new revision, use update-file.',
 			inputSchema: {
 				filepath: z.string().describe( 'File path on the local disk' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -16,7 +16,7 @@ export function uploadFileTool( server: McpServer ): RegisteredTool {
 	return server.registerTool(
 		'upload-file',
 		{
-			description: 'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url.',
+			description: 'Uploads a file from the local disk into the wiki\'s File namespace and returns the resulting file title and URL. The operator restricts which directories are readable; filepath must be an absolute path inside a configured upload directory, or the call fails before contacting the wiki. Fails if a file with the target title already exists (the wiki does not silently overwrite existing files). To upload directly from a remote web address instead of a local path, use upload-file-from-url. To replace an existing file with a new revision, use update-file.',
 			inputSchema: {
 				filepath: z.string().describe( 'File path on the local disk' ),
 				title: z.string().describe( 'File title (with or without the "File:" prefix)' ),

--- a/tests/common/fileExistence.test.ts
+++ b/tests/common/fileExistence.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+import { getMwn } from '../../src/common/mwn.js';
+
+describe( 'assertFileExists', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'resolves when the file exists with at least one imageinfo entry', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ {
+					title: 'File:Cat.jpg',
+					imageinfo: [ { timestamp: '2026-01-01T00:00:00Z' } ]
+				} ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists } = await import( '../../src/common/fileExistence.js' );
+		await expect( assertFileExists( 'Cat.jpg' ) ).resolves.toBeUndefined();
+	} );
+
+	it( 'prefixes File: when the title lacks it', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ {
+					title: 'File:Cat.jpg',
+					imageinfo: [ { timestamp: '2026-01-01T00:00:00Z' } ]
+				} ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists } = await import( '../../src/common/fileExistence.js' );
+		await assertFileExists( 'Cat.jpg' );
+
+		expect( mock.request ).toHaveBeenCalledWith( {
+			action: 'query',
+			titles: 'File:Cat.jpg',
+			prop: 'imageinfo',
+			iiprop: 'timestamp',
+			formatversion: '2'
+		} );
+	} );
+
+	it( 'preserves the File: prefix when already present', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ {
+					title: 'File:Cat.jpg',
+					imageinfo: [ { timestamp: '2026-01-01T00:00:00Z' } ]
+				} ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists } = await import( '../../src/common/fileExistence.js' );
+		await assertFileExists( 'File:Cat.jpg' );
+
+		expect( ( mock.request.mock.calls[ 0 ][ 0 ] as { titles: string } ).titles ).toBe(
+			'File:Cat.jpg'
+		);
+	} );
+
+	it( 'throws FileNotFoundError when the page is missing', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { title: 'File:Missing.jpg', missing: true } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists, FileNotFoundError } = await import(
+			'../../src/common/fileExistence.js'
+		);
+		await expect( assertFileExists( 'Missing.jpg' ) ).rejects.toThrow( FileNotFoundError );
+		await expect( assertFileExists( 'Missing.jpg' ) ).rejects.toThrow( /Missing\.jpg/ );
+	} );
+
+	it( 'throws FileNotFoundError when the page exists but has no imageinfo', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockResolvedValue( {
+				query: { pages: [ { title: 'File:Empty.jpg' } ] }
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists, FileNotFoundError } = await import(
+			'../../src/common/fileExistence.js'
+		);
+		await expect( assertFileExists( 'Empty.jpg' ) ).rejects.toThrow( FileNotFoundError );
+	} );
+
+	it( 're-throws non-missing errors from mwn.request', async () => {
+		const mock = createMockMwn( {
+			request: vi.fn().mockRejectedValue( new Error( 'Connection refused' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { assertFileExists } = await import( '../../src/common/fileExistence.js' );
+		await expect( assertFileExists( 'Cat.jpg' ) ).rejects.toThrow( 'Connection refused' );
+	} );
+} );

--- a/tests/tools/update-file-from-url.test.ts
+++ b/tests/tools/update-file-from-url.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} )
+	}
+} ) );
+
+vi.mock( '../../src/common/fileExistence.js', async () => {
+	const actual = await vi.importActual<typeof import( '../../src/common/fileExistence.js' )>(
+		'../../src/common/fileExistence.js'
+	);
+	return {
+		...actual,
+		assertFileExists: vi.fn()
+	};
+} );
+
+import { getMwn } from '../../src/common/mwn.js';
+import { assertFileExists, FileNotFoundError } from '../../src/common/fileExistence.js';
+import { formatPayload } from '../../src/common/formatPayload.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess
+} from '../helpers/structuredResult.js';
+
+describe( 'update-file-from-url', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns not_found with routing hint when the file does not exist', async () => {
+		vi.mocked( assertFileExists ).mockRejectedValue( new FileNotFoundError( 'Cat.jpg' ) );
+		const mock = createMockMwn( { uploadFromUrl: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		const result = await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'Cat.jpg'
+		);
+
+		const envelope = assertStructuredError( result, 'not_found' );
+		expect( envelope.message ).toMatch( /Cat\.jpg/ );
+		expect( envelope.message ).toMatch( /upload-file-from-url\b/ );
+		expect( mock.uploadFromUrl ).not.toHaveBeenCalled();
+	} );
+
+	it( 'calls mwn.uploadFromUrl with ignorewarnings: true and the formatted comment', async () => {
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			uploadFromUrl: vi.fn().mockResolvedValue( {
+				result: 'Success',
+				filename: 'Cat.jpg',
+				imageinfo: {
+					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+					url: 'https://test.wiki/images/Cat.jpg'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg',
+			'Higher resolution'
+		);
+
+		expect( mock.uploadFromUrl ).toHaveBeenCalledWith(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg',
+			'',
+			expect.objectContaining( {
+				ignorewarnings: true,
+				comment: expect.stringMatching( /^Higher resolution.*update-file-from-url/ )
+			} )
+		);
+	} );
+
+	it( 'returns the same structured payload as upload-file-from-url on success', async () => {
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			uploadFromUrl: vi.fn().mockResolvedValue( {
+				result: 'Success',
+				filename: 'Cat.jpg',
+				imageinfo: {
+					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+					url: 'https://test.wiki/images/Cat.jpg'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		const result = await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		const text = assertStructuredSuccess( result );
+		expect( text ).toBe( formatPayload( {
+			filename: 'Cat.jpg',
+			pageUrl: 'https://test.wiki/wiki/File:Cat.jpg',
+			fileUrl: 'https://test.wiki/images/Cat.jpg'
+		} ) );
+	} );
+
+	it( 'maps copyuploaddisabled errors to invalid_input with the routing hint', async () => {
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			uploadFromUrl: vi.fn().mockRejectedValue(
+				new Error( 'copyuploaddisabled: Upload by URL is disabled on this wiki.' )
+			)
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		const result = await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		const envelope = assertStructuredError( result, 'invalid_input' );
+		expect( envelope.code ).toBe( 'copyuploaddisabled' );
+		expect( envelope.message ).toMatch( /Download the file locally.*update-file\b/ );
+	} );
+
+	it( 'maps generic upload errors to upstream_failure', async () => {
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			uploadFromUrl: vi.fn().mockRejectedValue( new Error( 'Boom' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		const result = await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		const envelope = assertStructuredError( result, 'upstream_failure' );
+		expect( envelope.message ).toMatch( /Failed to update file: Boom/ );
+	} );
+
+	it( 'maps permissiondenied-coded errors to permission_denied', async () => {
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const err = Object.assign( new Error( 'You cannot reupload' ), { code: 'permissiondenied' } );
+		const mock = createMockMwn( {
+			uploadFromUrl: vi.fn().mockRejectedValue( err )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileFromUrlTool } = await import(
+			'../../src/tools/update-file-from-url.js'
+		);
+		const result = await handleUpdateFileFromUrlTool(
+			'https://example.com/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		assertStructuredError( result, 'permission_denied' );
+	} );
+} );

--- a/tests/tools/update-file.test.ts
+++ b/tests/tools/update-file.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+
+vi.mock( '../../src/common/mwn.js', () => ( {
+	getMwn: vi.fn()
+} ) );
+
+vi.mock( '../../src/common/wikiService.js', () => ( {
+	wikiService: {
+		getCurrent: vi.fn().mockReturnValue( {
+			key: 'test-wiki',
+			config: { server: 'https://test.wiki', articlepath: '/wiki', scriptpath: '/w' }
+		} ),
+		getUploadDirs: vi.fn().mockReturnValue( [ '/home/user/uploads' ] )
+	}
+} ) );
+
+vi.mock( '../../src/common/uploadGuard.js', async () => {
+	const actual = await vi.importActual<typeof import( '../../src/common/uploadGuard.js' )>(
+		'../../src/common/uploadGuard.js'
+	);
+	return {
+		...actual,
+		assertAllowedPath: vi.fn()
+	};
+} );
+
+vi.mock( '../../src/common/fileExistence.js', async () => {
+	const actual = await vi.importActual<typeof import( '../../src/common/fileExistence.js' )>(
+		'../../src/common/fileExistence.js'
+	);
+	return {
+		...actual,
+		assertFileExists: vi.fn()
+	};
+} );
+
+import { getMwn } from '../../src/common/mwn.js';
+import { assertAllowedPath, UploadValidationError } from '../../src/common/uploadGuard.js';
+import { assertFileExists, FileNotFoundError } from '../../src/common/fileExistence.js';
+import { formatPayload } from '../../src/common/formatPayload.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess
+} from '../helpers/structuredResult.js';
+
+describe( 'update-file', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'returns invalid_input for UploadValidationError, skips pre-flight and upload', async () => {
+		vi.mocked( assertAllowedPath ).mockRejectedValue(
+			new UploadValidationError( '"/etc/passwd" is not allowed' )
+		);
+		const mock = createMockMwn( { upload: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool( '/etc/passwd', 'File:Shadow' );
+
+		const envelope = assertStructuredError( result, 'invalid_input' );
+		expect( envelope.message ).toMatch( /Failed to update file:.*not allowed/ );
+		expect( assertFileExists ).not.toHaveBeenCalled();
+		expect( mock.upload ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns upstream_failure for unexpected guard errors, skips upload', async () => {
+		vi.mocked( assertAllowedPath ).mockRejectedValue( new Error( 'Connection refused' ) );
+		const mock = createMockMwn( { upload: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool( '/home/user/uploads/x.jpg', 'File:X' );
+
+		assertStructuredError( result, 'upstream_failure' );
+		expect( mock.upload ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns not_found with routing hint when the file does not exist', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		vi.mocked( assertFileExists ).mockRejectedValue( new FileNotFoundError( 'Cat.jpg' ) );
+		const mock = createMockMwn( { upload: vi.fn() } );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool( '/home/user/uploads/cat.jpg', 'Cat.jpg' );
+
+		const envelope = assertStructuredError( result, 'not_found' );
+		expect( envelope.message ).toMatch( /Cat\.jpg/ );
+		expect( envelope.message ).toMatch( /upload-file\b/ );
+		expect( mock.upload ).not.toHaveBeenCalled();
+	} );
+
+	it( 'calls mwn.upload with ignorewarnings: true and the formatted comment', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockResolvedValue( {
+				result: 'Success',
+				filename: 'Cat.jpg',
+				imageinfo: {
+					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+					url: 'https://test.wiki/images/Cat.jpg'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		await handleUpdateFileTool( '/home/user/uploads/cat.jpg', 'File:Cat.jpg', 'New colour pass' );
+
+		expect( mock.upload ).toHaveBeenCalledWith(
+			'/var/lib/uploads/cat.jpg',
+			'File:Cat.jpg',
+			'',
+			expect.objectContaining( {
+				ignorewarnings: true,
+				comment: expect.stringMatching( /^New colour pass.*update-file/ )
+			} )
+		);
+	} );
+
+	it( 'returns the same structured payload as upload-file on success', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockResolvedValue( {
+				result: 'Success',
+				filename: 'Cat.jpg',
+				imageinfo: {
+					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+					url: 'https://test.wiki/images/Cat.jpg'
+				}
+			} )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool(
+			'/home/user/uploads/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		const text = assertStructuredSuccess( result );
+		expect( text ).toBe( formatPayload( {
+			filename: 'Cat.jpg',
+			pageUrl: 'https://test.wiki/wiki/File:Cat.jpg',
+			fileUrl: 'https://test.wiki/images/Cat.jpg'
+		} ) );
+	} );
+
+	it( 'maps generic mwn.upload errors to upstream_failure', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockRejectedValue( new Error( 'Boom' ) )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool(
+			'/home/user/uploads/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		const envelope = assertStructuredError( result, 'upstream_failure' );
+		expect( envelope.message ).toMatch( /Failed to update file: Boom/ );
+	} );
+
+	it( 'maps permissiondenied-coded errors to permission_denied', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/var/lib/uploads/cat.jpg' );
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const err = Object.assign( new Error( 'You cannot reupload' ), { code: 'permissiondenied' } );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockRejectedValue( err )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		const result = await handleUpdateFileTool(
+			'/home/user/uploads/cat.jpg',
+			'File:Cat.jpg'
+		);
+
+		assertStructuredError( result, 'permission_denied' );
+	} );
+
+	it( 'forwards the configured uploadDirs allowlist to the path guard', async () => {
+		vi.mocked( assertAllowedPath ).mockResolvedValue( '/home/user/uploads/x.jpg' );
+		vi.mocked( assertFileExists ).mockResolvedValue( undefined );
+		const mock = createMockMwn( {
+			upload: vi.fn().mockResolvedValue( { result: 'Success' } )
+		} );
+		vi.mocked( getMwn ).mockResolvedValue( mock as any );
+
+		const { handleUpdateFileTool } = await import( '../../src/tools/update-file.js' );
+		await handleUpdateFileTool( '/home/user/uploads/x.jpg', 'File:X' );
+
+		expect( assertAllowedPath ).toHaveBeenCalledWith(
+			'/home/user/uploads/x.jpg',
+			[ '/home/user/uploads' ]
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

Adds two new MCP tools — `update-file` and `update-file-from-url` — that upload a new revision of an existing wiki file from local disk or a remote URL. Mirrors the existing `upload-file` / `upload-file-from-url` pair, following the codebase's `create-page` / `update-page` precedent.

- New shared helper `assertFileExists` (in `src/common/fileExistence.ts`) performs a single `prop=imageinfo` query as a strict pre-flight; both new tools refuse the upload (with a `not_found` routing hint to the create sibling) when the target title doesn't exist.
- Both new tools pass `ignorewarnings: true` and an empty `text` to mwn's upload — so the `fileexists` warning no longer aborts, and the description page is preserved (callers chain `update-page` separately to edit it).
- `destructiveHint: true`, `idempotentHint: false` on the new tools (per the conventions doc's decision guide for "delete, overwrite, or remove").
- `update-file-from-url` mirrors `upload-file-from-url`'s `copyuploaddisabled` special case, but its routing hint redirects to `update-file` (preserving the caller's update intent) rather than `upload-file`.
- `upload-file` and `upload-file-from-url` descriptions now include a back-reference to the new tools.
- `docs/tool-conventions.md` "Sibling overlap pairs" list extended with the two new pairs.
- All four upload-family descriptions now mention the upload-log side effect (per the new "Name observable side effects" convention added in b31c2b7).

## Test Plan

- [x] `npm run lint` — clean (4 pre-existing warnings unrelated to this branch)
- [x] `npm run validate:server-json` — OK
- [x] `npm test` — 508/508 (was 488 before this branch; 20 new tests across `tests/common/fileExistence.test.ts`, `tests/tools/update-file.test.ts`, `tests/tools/update-file-from-url.test.ts`)
- [x] `npm run build` — clean
- [x] `npx mcpb pack` + `npx mcpb clean` — OK
- [x] Manual smoke test against `test.pro.wiki`: `update-file` rejects missing title with `not_found`; `update-file-from-url` rejects missing title with `not_found`; both succeed against a known-existing file and produce a new revision visible in the file's history.