### PR TITLE
Bump ipaddr.js to 2.3.0 and simplify SSRF guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"express": "^5.1.0",
-				"ipaddr.js": "1.9.1",
+				"ipaddr.js": "2.3.0",
 				"mwn": "^3.0.1",
 				"node-fetch": "^3.3.2",
 				"types-mediawiki-api": "^2.0.0"
@@ -4510,12 +4510,12 @@
 			}
 		},
 		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+			"integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/is-arrayish": {
@@ -5734,6 +5734,15 @@
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
 			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/proxy-addr/node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"express": "^5.1.0",
-		"ipaddr.js": "1.9.1",
+		"ipaddr.js": "2.3.0",
 		"mwn": "^3.0.1",
 		"node-fetch": "^3.3.2",
 		"types-mediawiki-api": "^2.0.0"

--- a/src/common/ssrfGuard.ts
+++ b/src/common/ssrfGuard.ts
@@ -12,11 +12,8 @@ export class SsrfValidationError extends Error {
 	}
 }
 
-// ipaddr.js .range() classifies most reserved space correctly, but leaves
-// these as 'unicast' in v1.9.1. We treat them as non-public explicitly.
-const EXTRA_BLOCKED_V4: Record<string, [ipaddr.IPv4, number]> = {
-	benchmarking: [ ipaddr.IPv4.parse( '198.18.0.0' ), 15 ]
-};
+// ipaddr.js .range() classifies most reserved space correctly, but still
+// returns 'unicast' for these deprecated IPv6 blocks. Treat them as non-public.
 const EXTRA_BLOCKED_V6: Record<string, [ipaddr.IPv6, number]> = {
 	deprecatedSiteLocal: [ ipaddr.IPv6.parse( 'fec0::' ), 10 ],
 	deprecated6bone: [ ipaddr.IPv6.parse( '3ffe::' ), 16 ]
@@ -107,12 +104,12 @@ function assertAddressIsUnicast( address: string, urlString: string ): void {
 		);
 	}
 
-	const extraMatch = parsed.kind() === 'ipv4' ?
-		ipaddr.subnetMatch( parsed as ipaddr.IPv4, EXTRA_BLOCKED_V4, 'unicast' ) :
-		ipaddr.subnetMatch( parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast' );
-	if ( extraMatch !== 'unicast' ) {
-		throw new SsrfValidationError(
-			`Refusing to fetch URL resolving to non-public address ${ address } (${ extraMatch }): ${ urlString }`
-		);
+	if ( parsed.kind() === 'ipv6' ) {
+		const extraMatch = ipaddr.subnetMatch( parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast' );
+		if ( extraMatch !== 'unicast' ) {
+			throw new SsrfValidationError(
+				`Refusing to fetch URL resolving to non-public address ${ address } (${ extraMatch }): ${ urlString }`
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Takes the dependabot bump of `ipaddr.js` from 1.9.1 to 2.3.0 (merged onto this branch).
- Drops the now-redundant `EXTRA_BLOCKED_V4` workaround in `ssrfGuard` — `ipaddr.js` 2.x classifies `198.18.0.0/15` (RFC 2544 benchmarking) as a non-unicast range via `range()`, so the supplemental list is no longer load-bearing.
- Keeps `EXTRA_BLOCKED_V6` — verified empirically that `fec0::/10` (deprecated site-local) and `3ffe::/16` (6bone) still return `'unicast'` from `range()` in 2.3.0, so those explicit checks remain necessary.
- The 2.0.0 release was an internal CoffeeScript-to-JS rewrite; all APIs we call (`parse`, `IPv4.parse`, `IPv6.parse`, `subnetMatch`, `kind()`, `range()`, `isIPv4MappedAddress`, `toIPv4Address`) have identical signatures in 2.3.0.

## Why pin 1.9.1 originally

The original pin in #286 was a dedupe-with-Express convenience (Express transitively carries `ipaddr.js` via `proxy-addr`), not a behavioural requirement. The dep is declared directly because `src/common/ssrfGuard.ts` uses it in security-critical code; relying on the transitive would risk a silent breakage on any Express refactor.

## Test plan

- [x] `npm test` — 508/508 pass (including the three RFC-block regression tests at `tests/common/ssrfGuard.test.ts:110-135`)
- [x] `npm run lint` — clean on changed code (4 pre-existing warnings in `config.ts` / `uploadGuard.ts` unrelated to this PR)
- [x] `npm run build` — clean
- [x] Verified empirically against `ipaddr.js@2.3.0`: `198.18.0.1` → `'reserved'`, `fec0::1` → `'unicast'`, `3ffe::1` → `'unicast'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)