### PR TITLE
Drop unused src/types directory

### DIFF
--- a/src/types/mwn.ts
+++ b/src/types/mwn.ts
@@ -1,5 +1,0 @@
-export type ApiPageInfo = {
-	pageid: number;
-	ns: number;
-	title: string;
-};


### PR DESCRIPTION
## Summary

`src/types/mwn.ts` declared an `ApiPageInfo` type alias that nothing in `src/` or `tests/` imports. Survived from the REST → mwn migration in #235; the post-refactor structure puts live types alongside their owning modules, so the directory has no remaining purpose.

## Test plan

- [x] `npm test` clean