### PR TITLE
Sync env-var metadata in server.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,15 @@ A PR that adds, removes, or renames a tool — or that materially changes a tool
 
 Pure-internal refactors that don't change tool surface or behaviour don't need either.
 
+## Adding or changing environment variables
+
+A PR that adds, removes, or renames an env var read by the server — or that changes its default or accepted values — must also update:
+
+- **`README.md`** — the environment-variable table.
+- **`server.json`** — the `environmentVariables` array in **both** the `mcpb` and `npm` package blocks.
+- **`CHANGELOG.md`** — an entry under `## [Unreleased]` if the change is user-visible.
+- **`Dockerfile`** — only if the var needs a default baked into the docker image.
+
 ## Testing
 
 Tool tests build a `ToolContext` via `fakeContext()` from `tests/helpers/fakeContext.ts` and dispatch through `dispatch( descriptor, ctx )`. Provide an `mwn` factory (typically `createMockMwn()` from `tests/helpers/mock-mwn.ts`) and override only the slices the test exercises. See [docs/testing.md](docs/testing.md) for the full pattern, MCP Inspector CLI examples, and the bot-password setup required to exercise authenticated tools against a local wiki.

--- a/server.json
+++ b/server.json
@@ -24,6 +24,16 @@
           "format": "filepath"
         },
         {
+          "name": "MCP_ALLOW_STATIC_FALLBACK",
+          "description": "Set to 'true' to allow HTTP startup when config.json has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests."
+        },
+        {
+          "name": "MCP_CONTENT_MAX_BYTES",
+          "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
+          "format": "number",
+          "default": "50000"
+        },
+        {
           "name": "MCP_TRANSPORT",
           "description": "Type of MCP server transport",
           "choices": [
@@ -44,6 +54,7 @@
       "registryType": "npm",
       "identifier": "@professional-wiki/mediawiki-mcp-server",
       "version": "0.7.0",
+      "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       },
@@ -53,6 +64,16 @@
           "description": "Path to your configuration file",
           "default": "config.json",
           "format": "filepath"
+        },
+        {
+          "name": "MCP_ALLOW_STATIC_FALLBACK",
+          "description": "Set to 'true' to allow HTTP startup when config.json has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests."
+        },
+        {
+          "name": "MCP_CONTENT_MAX_BYTES",
+          "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
+          "format": "number",
+          "default": "50000"
         },
         {
           "name": "MCP_TRANSPORT",


### PR DESCRIPTION
## Summary

- Adds `MCP_ALLOW_STATIC_FALLBACK` and `MCP_CONTENT_MAX_BYTES` to the `environmentVariables` array of **both** the `mcpb` and `npm` package blocks in `server.json`, so the registry-visible metadata matches the README env-var table. Both vars were already documented in the README but never propagated to `server.json`.
- Sets `"runtimeHint": "npx"` on the npm package, signalling the canonical launcher used by Claude Desktop and Inspector configs.
- Adds an `## Adding or changing environment variables` section to `AGENTS.md` listing the surfaces (README, `server.json`, CHANGELOG, Dockerfile) that need to stay in sync — this drift slipped past us twice.

No CHANGELOG entry: `MCP_ALLOW_STATIC_FALLBACK` is already noted under `[Unreleased] → Security`, and this PR is registry-metadata catch-up rather than a behaviour change.

## Test plan

- [x] `npm run validate:server-json` passes.
- [x] Reviewer spot-check: env-var rows in `server.json` match the README table (CONFIG, MCP_ALLOW_STATIC_FALLBACK, MCP_CONTENT_MAX_BYTES, MCP_TRANSPORT, PORT) and appear in both package blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)