### PR TITLE
Copy server.json into the Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `set-wiki` and `remove-wiki` are hidden from `tools/list` when fewer than two wikis are configured: `set-wiki` has nothing to switch to, and `remove-wiki` would orphan the server.
 - Logger output is now one JSON object per stderr line, replacing the previous `<level>: <message> {<json>}` text shape. Operators with stderr parsers must update them or pipe through `jq -R 'fromjson? // empty'` (or `humanlog`) for live reading.
 
+### Fixed
+
+- Docker image now includes `server.json`, so containers start instead of crashing with `Cannot find module '../server.json'`.
+
 ### Security
 
 - HTTP transport refuses to start with static credentials in `config.json` unless `MCP_ALLOW_STATIC_FALLBACK=true` opts into a shared-identity deployment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ COPY --from=builder /app/dist ./dist
 # Copy package.json and lockfile for production install
 COPY package.json package-lock.json ./
 
+# Copy server.json (loaded at runtime for server name, title, and version)
+COPY server.json ./
+
 # Install only production dependencies
 RUN npm install --production --ignore-scripts
 


### PR DESCRIPTION
## Summary
- The production Docker image was missing `server.json`, so containers built from `Dockerfile` crashed on start with `Cannot find module '../server.json'` (raised from `dist/server.js`, `dist/runtime/constants.js`, and `dist/runtime/banner.js`, which all `createRequire(...)` it relative to `dist/`).
- Added `COPY server.json ./` to the production stage and a `### Fixed` entry in `CHANGELOG.md`.

Fixes #317.

## Test plan
- [x] Reproduced the crash by replicating the production-stage filesystem locally (`dist/` + `package.json` + `package-lock.json`, no `server.json`) and running `node dist/index.js` — got the exact `MODULE_NOT_FOUND` from the issue.
- [x] Re-ran with `server.json` copied in alongside `package.json` — server boots cleanly and emits the structured `event: "startup"` log.
- [x] `npm test` (651 tests, 0 failures) on a clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)