### PR TITLE
Add optional Prometheus /metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, latency histograms, upstream status totals, active sessions, and ready-probe failures. Off by default.
+
 ## [0.8.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, latency histograms, upstream status totals, active sessions, and ready-probe failures. Off by default.
+- Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and ready-probe failures. Off by default.
 
 ## [0.8.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and ready-probe failures. Off by default.
+- Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
 
 ## [0.8.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
+| `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. Off by default. | `unset` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
-| `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. Off by default. | `unset` |
+| `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,22 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 - `MCP_ALLOWED_HOSTS` — comma-separated Host-header allowlist (e.g. `MCP_ALLOWED_HOSTS=wiki.example.org`). Set it on any non-localhost bind — without it, the SDK disables its DNS-rebinding check and logs a startup warning. Not needed on localhost binds, where the SDK auto-allows `localhost`, `127.0.0.1`, and `[::1]`. A bare hostname in `MCP_BIND` counts as non-localhost: the auto-allowlist only matches those three literals.
 - `MCP_ALLOWED_ORIGINS` — comma-separated `Origin`-header allowlist (e.g. `MCP_ALLOWED_ORIGINS=https://wiki.example.org`). Requests whose `Origin` is present but not listed get a 403. On a localhost bind, defaults to the three loopback origins on the bound port (`http://localhost:<port>`, `http://127.0.0.1:<port>`, `http://[::1]:<port>`) so local browser clients keep working. On a non-localhost bind, leaving it unset disables Origin validation and logs a startup warning. The allowlist is an exact string match — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements) for the gotchas that silently cause every browser request to fail.
 
+## Metrics
+
+Set `MCP_METRICS=true` to expose `GET /metrics` on the HTTP transport in Prometheus text format. Off by default.
+
+Exposed series:
+
+- `mcp_tool_calls_total{tool,wiki,outcome}` — counter of tool invocations.
+- `mcp_tool_call_duration_seconds{tool,wiki}` — histogram of tool-call durations.
+- `mcp_upstream_status_total{tool,wiki,status}` — counter of upstream MediaWiki HTTP status codes.
+- `mcp_active_sessions` — gauge of active StreamableHTTP MCP sessions.
+- `mcp_ready_failures_total` — counter of `/ready` probes that returned non-200.
+
+The endpoint is **unauthenticated**. Bind reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
+
+Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments (≤ 50 tools, ≤ 5 wikis, ~10 outcomes) stay well within prom-client's practical limits.
+
 ## Shape 1 — Single-wiki, read-only, anonymous
 
 ```json

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -150,6 +150,19 @@ Tokens, usernames, and passwords never appear.
 
 Set `MCP_METRICS=true` to expose `GET /metrics` on the HTTP transport in Prometheus text format. Off by default.
 
+Sample scrape:
+
+```
+# HELP mcp_tool_calls_total Total number of MCP tool invocations, labelled by tool, wiki, and outcome.
+# TYPE mcp_tool_calls_total counter
+mcp_tool_calls_total{tool="get-page",wiki="example.org",outcome="success"} 142
+mcp_tool_calls_total{tool="get-page",wiki="example.org",outcome="not_found"} 4
+
+# HELP mcp_active_sessions Number of active StreamableHTTP MCP sessions.
+# TYPE mcp_active_sessions gauge
+mcp_active_sessions 3
+```
+
 Exposed series:
 
 - `mcp_tool_calls_total{tool,wiki,outcome}` — counter of tool invocations.
@@ -158,9 +171,9 @@ Exposed series:
 - `mcp_active_sessions` — gauge of active StreamableHTTP MCP sessions.
 - `mcp_ready_failures_total` — counter of `/ready` probes that returned non-200.
 
-The endpoint is **unauthenticated**. Bind reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
+The endpoint is **unauthenticated**. Restrict reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
 
-Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments stay in the low thousands of series, well within typical Prometheus ingest budgets. If you enable `allowWikiManagement`, treat the `wiki` label set as monotonically growing — `add-wiki` / `remove-wiki` cycles never shrink the cardinality of historical series.
+Cardinality for `mcp_tool_calls_total` scales as `tools × wikis × outcomes` — low thousands of series in a typical deployment, comfortably within Prometheus ingest budgets. With `allowWikiManagement` enabled, treat the `wiki` label set as monotonically growing: `remove-wiki` does not retract values already exported in past samples.
 
 ### Tailing logs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,22 +17,6 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 - `MCP_ALLOWED_HOSTS` — comma-separated Host-header allowlist (e.g. `MCP_ALLOWED_HOSTS=wiki.example.org`). Set it on any non-localhost bind — without it, the SDK disables its DNS-rebinding check and logs a startup warning. Not needed on localhost binds, where the SDK auto-allows `localhost`, `127.0.0.1`, and `[::1]`. A bare hostname in `MCP_BIND` counts as non-localhost: the auto-allowlist only matches those three literals.
 - `MCP_ALLOWED_ORIGINS` — comma-separated `Origin`-header allowlist (e.g. `MCP_ALLOWED_ORIGINS=https://wiki.example.org`). Requests whose `Origin` is present but not listed get a 403. On a localhost bind, defaults to the three loopback origins on the bound port (`http://localhost:<port>`, `http://127.0.0.1:<port>`, `http://[::1]:<port>`) so local browser clients keep working. On a non-localhost bind, leaving it unset disables Origin validation and logs a startup warning. The allowlist is an exact string match — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements) for the gotchas that silently cause every browser request to fail.
 
-## Metrics
-
-Set `MCP_METRICS=true` to expose `GET /metrics` on the HTTP transport in Prometheus text format. Off by default.
-
-Exposed series:
-
-- `mcp_tool_calls_total{tool,wiki,outcome}` — counter of tool invocations.
-- `mcp_tool_call_duration_seconds{tool,wiki}` — histogram of tool-call durations.
-- `mcp_upstream_status_total{tool,wiki,status}` — counter of upstream MediaWiki HTTP status codes.
-- `mcp_active_sessions` — gauge of active StreamableHTTP MCP sessions.
-- `mcp_ready_failures_total` — counter of `/ready` probes that returned non-200.
-
-The endpoint is **unauthenticated**. Bind reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
-
-Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments (≤ 50 tools, ≤ 5 wikis, ~10 outcomes) stay well within prom-client's practical limits.
-
 ## Shape 1 — Single-wiki, read-only, anonymous
 
 ```json
@@ -161,6 +145,22 @@ Tokens, usernames, and passwords never appear.
 ```json
 { "status": "not_ready", "wiki": "example.org", "reason": "...", "checked_at": "..." }
 ```
+
+### Metrics
+
+Set `MCP_METRICS=true` to expose `GET /metrics` on the HTTP transport in Prometheus text format. Off by default.
+
+Exposed series:
+
+- `mcp_tool_calls_total{tool,wiki,outcome}` — counter of tool invocations.
+- `mcp_tool_call_duration_seconds{tool,wiki}` — histogram of tool-call durations.
+- `mcp_upstream_status_total{tool,wiki,status}` — counter of upstream MediaWiki HTTP status codes.
+- `mcp_active_sessions` — gauge of active StreamableHTTP MCP sessions.
+- `mcp_ready_failures_total` — counter of `/ready` probes that returned non-200.
+
+The endpoint is **unauthenticated**. Bind reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
+
+Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments stay in the low thousands of series, well within typical Prometheus ingest budgets.
 
 ### Tailing logs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -160,7 +160,7 @@ Exposed series:
 
 The endpoint is **unauthenticated**. Bind reverse-proxy access to your scrape network only — most Kubernetes-style deployments expose `/metrics` on a separate port or path that isn't routable from the public ingress.
 
-Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments stay in the low thousands of series, well within typical Prometheus ingest budgets.
+Cardinality scales as `tools × wikis × outcomes` for `mcp_tool_calls_total`. Typical deployments stay in the low thousands of series, well within typical Prometheus ingest budgets. If you enable `allowWikiManagement`, treat the `wiki` label set as monotonically growing — `add-wiki` / `remove-wiki` cycles never shrink the cardinality of historical series.
 
 ### Tailing logs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"ipaddr.js": "2.3.0",
 				"mwn": "^3.0.1",
 				"node-fetch": "^3.3.2",
+				"prom-client": "^15.1.3",
 				"types-mediawiki-api": "^2.0.0"
 			},
 			"bin": {
@@ -727,6 +728,15 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -1928,6 +1938,12 @@
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.js"
 			}
+		},
+		"node_modules/bintrees": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+			"integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+			"license": "MIT"
 		},
 		"node_modules/body-parser": {
 			"version": "2.2.1",
@@ -5725,6 +5741,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/prom-client": {
+			"version": "15.1.3",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+			"integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.4.0",
+				"tdigest": "^0.1.1"
+			},
+			"engines": {
+				"node": "^16 || ^18 || >=20"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6639,6 +6668,15 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/tdigest": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+			"integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+			"license": "MIT",
+			"dependencies": {
+				"bintrees": "1.0.2"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"ipaddr.js": "2.3.0",
 		"mwn": "^3.0.1",
 		"node-fetch": "^3.3.2",
+		"prom-client": "^15.1.3",
 		"types-mediawiki-api": "^2.0.0"
 	},
 	"devDependencies": {

--- a/server.json
+++ b/server.json
@@ -35,7 +35,7 @@
         },
         {
           "name": "MCP_METRICS",
-          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Off by default. No effect on the stdio transport."
+          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Has no effect on the stdio transport."
         },
         {
           "name": "MCP_TRANSPORT",
@@ -81,7 +81,7 @@
         },
         {
           "name": "MCP_METRICS",
-          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Off by default. No effect on the stdio transport."
+          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Has no effect on the stdio transport."
         },
         {
           "name": "MCP_TRANSPORT",

--- a/server.json
+++ b/server.json
@@ -34,6 +34,10 @@
           "default": "50000"
         },
         {
+          "name": "MCP_METRICS",
+          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Off by default. No effect on the stdio transport."
+        },
+        {
           "name": "MCP_TRANSPORT",
           "description": "Type of MCP server transport",
           "choices": [
@@ -74,6 +78,10 @@
           "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
           "format": "number",
           "default": "50000"
+        },
+        {
+          "name": "MCP_METRICS",
+          "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Off by default. No effect on the stdio transport."
         },
         {
           "name": "MCP_TRANSPORT",

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -105,6 +105,7 @@ export function emitToolCall<TArgs>( opts: EmitToolCallOptions<TArgs> ): void {
 	const level = levelFor( opts.outcome );
 	const targetValue = safeTarget( opts.target, opts.args );
 	const truncated = opts.outcome === 'success' ? detectTruncation( opts.result ) : false;
+	const durationMs = Math.round( performance.now() - opts.started );
 	// Snake-case keys are required by the structured log schema.
 	const data: Record<string, unknown> = {
 		event: 'tool_call',
@@ -112,7 +113,7 @@ export function emitToolCall<TArgs>( opts: EmitToolCallOptions<TArgs> ): void {
 		wiki: opts.wikiKey,
 		outcome: opts.outcome,
 		// eslint-disable-next-line camelcase
-		duration_ms: Math.round( performance.now() - opts.started ),
+		duration_ms: durationMs,
 		caller: hashCaller( opts.runtimeToken ),
 		truncated
 	};
@@ -136,7 +137,7 @@ export function emitToolCall<TArgs>( opts: EmitToolCallOptions<TArgs> ): void {
 		tool: opts.toolName,
 		wiki: opts.wikiKey,
 		outcome: opts.outcome,
-		durationMs: Math.round( performance.now() - opts.started ),
+		durationMs,
 		upstreamStatus: opts.upstreamStatus
 	} );
 }

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
 import { emitTelemetryEvent } from './logger.js';
+import { recordToolCall } from './metrics.js';
 import type { ErrorCategory } from '../errors/classifyError.js';
 
 export type ToolOutcome = 'success' | ErrorCategory;
@@ -131,4 +132,11 @@ export function emitToolCall<TArgs>( opts: EmitToolCallOptions<TArgs> ): void {
 		data.error_message = opts.errorMessage;
 	}
 	emitTelemetryEvent( level, data );
+	recordToolCall( {
+		tool: opts.toolName,
+		wiki: opts.wikiKey,
+		outcome: opts.outcome,
+		durationMs: Math.round( performance.now() - opts.started ),
+		upstreamStatus: opts.upstreamStatus
+	} );
 }

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -133,11 +133,19 @@ export function emitToolCall<TArgs>( opts: EmitToolCallOptions<TArgs> ): void {
 		data.error_message = opts.errorMessage;
 	}
 	emitTelemetryEvent( level, data );
-	recordToolCall( {
-		tool: opts.toolName,
-		wiki: opts.wikiKey,
-		outcome: opts.outcome,
-		durationMs,
-		upstreamStatus: opts.upstreamStatus
-	} );
+	// Telemetry must never break tool calls — the dispatcher does not wrap
+	// emitToolCall in its own try/catch, so an unexpected throw from the
+	// metrics path would propagate up and fail the call. The stderr line
+	// above has already flushed, so we still have an operator-visible record.
+	try {
+		recordToolCall( {
+			tool: opts.toolName,
+			wiki: opts.wikiKey,
+			outcome: opts.outcome,
+			durationMs,
+			upstreamStatus: opts.upstreamStatus
+		} );
+	} catch {
+		// swallow
+	}
 }

--- a/src/runtime/metrics.ts
+++ b/src/runtime/metrics.ts
@@ -1,0 +1,147 @@
+import type { RequestHandler } from 'express';
+import { Counter, Gauge, Histogram, Registry } from 'prom-client';
+import type { ToolOutcome } from './instrument.js';
+
+export interface RecordToolCallInput {
+	readonly tool: string;
+	readonly wiki: string;
+	readonly outcome: ToolOutcome;
+	readonly durationMs: number;
+	readonly upstreamStatus: number | undefined;
+}
+
+interface Recorder {
+	recordToolCall( input: RecordToolCallInput ): void;
+	recordReadyFailure(): void;
+	setSessionsProvider( fn: () => number ): void;
+	getMetricsHandler(): RequestHandler | undefined;
+}
+
+const DURATION_BUCKETS_SECONDS: readonly number[] = [
+	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+];
+
+function makeDisabledRecorder(): Recorder {
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		recordToolCall: () => {},
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		recordReadyFailure: () => {},
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		setSessionsProvider: () => {},
+		getMetricsHandler: () => undefined
+	};
+}
+
+function makeLiveRecorder(): Recorder {
+	const registry = new Registry();
+	let sessionsProvider: ( () => number ) | undefined;
+
+	const toolCalls = new Counter( {
+		name: 'mcp_tool_calls_total',
+		help: 'Total number of MCP tool invocations, labelled by tool, wiki, and outcome.',
+		labelNames: [ 'tool', 'wiki', 'outcome' ] as const,
+		registers: [ registry ]
+	} );
+
+	const toolCallDuration = new Histogram( {
+		name: 'mcp_tool_call_duration_seconds',
+		help: 'Tool-call duration in seconds, labelled by tool and wiki.',
+		labelNames: [ 'tool', 'wiki' ] as const,
+		buckets: [ ...DURATION_BUCKETS_SECONDS ],
+		registers: [ registry ]
+	} );
+
+	const upstreamStatus = new Counter( {
+		name: 'mcp_upstream_status_total',
+		help: 'Upstream MediaWiki HTTP status codes observed, labelled by tool, wiki, and status.',
+		labelNames: [ 'tool', 'wiki', 'status' ] as const,
+		registers: [ registry ]
+	} );
+
+	const readyFailures = new Counter( {
+		name: 'mcp_ready_failures_total',
+		help: 'Total number of /ready probes that returned a non-200 status.',
+		registers: [ registry ]
+	} );
+
+	// eslint-disable-next-line no-new
+	new Gauge( {
+		name: 'mcp_active_sessions',
+		help: 'Number of active StreamableHTTP MCP sessions.',
+		registers: [ registry ],
+		collect() {
+			this.set( sessionsProvider ? sessionsProvider() : 0 );
+		}
+	} );
+
+	const handler: RequestHandler = async ( _req, res ) => {
+		res.set( 'Content-Type', registry.contentType );
+		res.status( 200 ).send( await registry.metrics() );
+	};
+
+	return {
+		recordToolCall( input ) {
+			toolCalls.inc( { tool: input.tool, wiki: input.wiki, outcome: input.outcome } );
+			toolCallDuration.observe(
+				{ tool: input.tool, wiki: input.wiki },
+				input.durationMs / 1000
+			);
+			if ( input.upstreamStatus !== undefined ) {
+				upstreamStatus.inc( {
+					tool: input.tool,
+					wiki: input.wiki,
+					status: String( input.upstreamStatus )
+				} );
+			}
+		},
+		recordReadyFailure() {
+			readyFailures.inc();
+		},
+		setSessionsProvider( fn ) {
+			sessionsProvider = fn;
+		},
+		getMetricsHandler() {
+			return handler;
+		}
+	};
+}
+
+let recorder: Recorder = makeDisabledRecorder();
+let initialized = false;
+
+export function isMetricsEnabled(): boolean {
+	return process.env.MCP_METRICS === 'true';
+}
+
+export function initMetrics(): void {
+	if ( initialized ) {
+		return;
+	}
+	initialized = true;
+	recorder = makeLiveRecorder();
+}
+
+export function recordToolCall( input: RecordToolCallInput ): void {
+	recorder.recordToolCall( input );
+}
+
+export function recordReadyFailure(): void {
+	recorder.recordReadyFailure();
+}
+
+export function setSessionsProvider( fn: () => number ): void {
+	recorder.setSessionsProvider( fn );
+}
+
+export function getMetricsHandler(): RequestHandler | undefined {
+	return recorder.getMetricsHandler();
+}
+
+// Test-only seam: returns the module to its disabled state so tests can re-init
+// without prom-client throwing on duplicate metric registration.
+// eslint-disable-next-line no-underscore-dangle
+export function __resetMetricsForTesting(): void {
+	initialized = false;
+	recorder = makeDisabledRecorder();
+}

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -13,6 +13,13 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { evaluateBearerGuard } from './bearerGuard.js';
 import { LOCALHOST_HOSTS, resolveHttpConfig } from './httpConfig.js';
 import { logger } from '../runtime/logger.js';
+import {
+	getMetricsHandler,
+	initMetrics,
+	isMetricsEnabled,
+	recordReadyFailure,
+	setSessionsProvider
+} from '../runtime/metrics.js';
 import { runtimeTokenStore } from './requestContext.js';
 import { wikiRegistry, wikiSelection, mwnProvider } from '../wikis/state.js';
 import { createServer } from '../server.js';
@@ -252,10 +259,24 @@ async function probeDefaultWiki(): Promise<ReadyCacheEntry> {
 // eslint-disable-next-line no-underscore-dangle
 export const __probeDefaultWikiForTesting = probeDefaultWiki;
 
+export function mountMetricsEndpoint( app: express.Express ): void {
+	if ( !isMetricsEnabled() ) {
+		return;
+	}
+	initMetrics();
+	const handler = getMetricsHandler();
+	if ( handler ) {
+		app.get( '/metrics', handler );
+	}
+}
+
 export function mountReadyEndpoint( app: express.Express ): void {
 	app.get( '/ready', async ( _req, res ) => {
 		if ( !readyCache || Date.now() >= readyCache.expiresAt ) {
 			readyCache = await probeDefaultWiki();
+		}
+		if ( readyCache.httpStatus !== 200 ) {
+			recordReadyFailure();
 		}
 		res.status( readyCache.httpStatus ).json( readyCache.payload );
 	} );
@@ -321,6 +342,8 @@ app.get( '/health', ( _req: Request, res: Response ) => {
 } );
 
 mountReadyEndpoint( app );
+mountMetricsEndpoint( app );
+setSessionsProvider( () => Object.keys( sessions ).length );
 
 app.listen( port, host, () => {
 	logger.info( `MCP Streamable HTTP Server listening on ${ host }:${ port }` );

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -274,9 +274,12 @@ export function mountReadyEndpoint( app: express.Express ): void {
 	app.get( '/ready', async ( _req, res ) => {
 		if ( !readyCache || Date.now() >= readyCache.expiresAt ) {
 			readyCache = await probeDefaultWiki();
-		}
-		if ( readyCache.httpStatus !== 200 ) {
-			recordReadyFailure();
+			// Count distinct probe failures, not cached replays — K8s readiness
+			// probes that fire every second would otherwise inflate the counter
+			// 5x against a 5s cache for the same underlying outage.
+			if ( readyCache.httpStatus !== 200 ) {
+				recordReadyFailure();
+			}
 		}
 		res.status( readyCache.httpStatus ).json( readyCache.payload );
 	} );

--- a/tests/runtime/instrument.test.ts
+++ b/tests/runtime/instrument.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock( '../../src/runtime/metrics.js', () => ( {
+	recordToolCall: vi.fn()
+} ) );
+
 /* eslint-disable n/no-missing-import */
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 /* eslint-enable n/no-missing-import */
@@ -15,6 +20,7 @@ import {
 	registerServer,
 	clearRegisteredServers
 } from '../../src/runtime/logger.js';
+import { recordToolCall } from '../../src/runtime/metrics.js';
 
 function captureToolCallLine( spy: ReturnType<typeof vi.spyOn> ): Record<string, unknown> {
 	const events = spy.mock.calls
@@ -433,5 +439,57 @@ describe( 'emitToolCall', () => {
 		} );
 
 		expect( fakeServer.sendLoggingMessage ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'emitToolCall — metrics integration', () => {
+	beforeEach( () => {
+		( recordToolCall as ReturnType<typeof vi.fn> ).mockClear();
+	} );
+
+	it( 'forwards the call to recordToolCall with raw duration and labels', () => {
+		const stderrSpy = vi.spyOn( process.stderr, 'write' ).mockReturnValue( true );
+		emitToolCall( {
+			toolName: 'get-page',
+			args: { title: 'X' },
+			started: performance.now() - 25,
+			result: okResult(),
+			outcome: 'success',
+			upstreamStatus: 200,
+			errorMessage: undefined,
+			runtimeToken: undefined,
+			sessionId: undefined,
+			wikiKey: 'example.org'
+		} );
+		stderrSpy.mockRestore();
+		expect( recordToolCall ).toHaveBeenCalledTimes( 1 );
+		const call = ( recordToolCall as ReturnType<typeof vi.fn> ).mock.calls[ 0 ][ 0 ];
+		expect( call ).toMatchObject( {
+			tool: 'get-page',
+			wiki: 'example.org',
+			outcome: 'success',
+			upstreamStatus: 200
+		} );
+		expect( typeof call.durationMs ).toBe( 'number' );
+		expect( call.durationMs ).toBeGreaterThanOrEqual( 0 );
+	} );
+
+	it( 'passes upstreamStatus undefined through unchanged', () => {
+		const stderrSpy = vi.spyOn( process.stderr, 'write' ).mockReturnValue( true );
+		emitToolCall( {
+			toolName: 'set-wiki',
+			args: {},
+			started: performance.now(),
+			result: okResult(),
+			outcome: 'success',
+			upstreamStatus: undefined,
+			errorMessage: undefined,
+			runtimeToken: undefined,
+			sessionId: undefined,
+			wikiKey: 'example.org'
+		} );
+		stderrSpy.mockRestore();
+		const call = ( recordToolCall as ReturnType<typeof vi.fn> ).mock.calls[ 0 ][ 0 ];
+		expect( call.upstreamStatus ).toBeUndefined();
 	} );
 } );

--- a/tests/runtime/metrics.test.ts
+++ b/tests/runtime/metrics.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import {
+	initMetrics,
+	isMetricsEnabled,
+	recordToolCall,
+	recordReadyFailure,
+	setSessionsProvider,
+	getMetricsHandler,
+	__resetMetricsForTesting
+} from '../../src/runtime/metrics.js';
+
+describe( 'metrics module — disabled state', () => {
+	beforeEach( () => {
+		__resetMetricsForTesting();
+	} );
+
+	it( 'recorders are no-ops before initMetrics', () => {
+		expect( () =>
+			recordToolCall( { tool: 't', wiki: 'w', outcome: 'success', durationMs: 1, upstreamStatus: undefined } )
+		).not.toThrow();
+		expect( () => recordReadyFailure() ).not.toThrow();
+		expect( () => setSessionsProvider( () => 0 ) ).not.toThrow();
+	} );
+
+	it( 'getMetricsHandler returns undefined before init', () => {
+		expect( getMetricsHandler() ).toBeUndefined();
+	} );
+
+	it( 'isMetricsEnabled reflects MCP_METRICS env', () => {
+		const old = process.env.MCP_METRICS;
+		process.env.MCP_METRICS = 'true';
+		expect( isMetricsEnabled() ).toBe( true );
+		process.env.MCP_METRICS = 'false';
+		expect( isMetricsEnabled() ).toBe( false );
+		delete process.env.MCP_METRICS;
+		expect( isMetricsEnabled() ).toBe( false );
+		if ( old !== undefined ) {
+			process.env.MCP_METRICS = old;
+		}
+	} );
+} );
+
+describe( 'metrics module — enabled state', () => {
+	beforeEach( () => {
+		__resetMetricsForTesting();
+		initMetrics();
+	} );
+
+	async function scrape(): Promise<string> {
+		const handler = getMetricsHandler();
+		expect( handler ).toBeDefined();
+		const app = express();
+		app.get( '/metrics', handler! );
+		const res = await request( app ).get( '/metrics' );
+		expect( res.status ).toBe( 200 );
+		expect( res.headers[ 'content-type' ] ).toContain( 'text/plain' );
+		return res.text;
+	}
+
+	it( 'increments mcp_tool_calls_total with tool/wiki/outcome labels', async () => {
+		recordToolCall( { tool: 'get-page', wiki: 'example.org', outcome: 'success', durationMs: 12, upstreamStatus: undefined } );
+		recordToolCall( { tool: 'get-page', wiki: 'example.org', outcome: 'success', durationMs: 7, upstreamStatus: undefined } );
+		const body = await scrape();
+		expect( body ).toMatch( /mcp_tool_calls_total\{tool="get-page",wiki="example\.org",outcome="success"\} 2/ );
+	} );
+
+	it( 'observes mcp_tool_call_duration_seconds', async () => {
+		recordToolCall( { tool: 'get-page', wiki: 'example.org', outcome: 'success', durationMs: 25, upstreamStatus: undefined } );
+		const body = await scrape();
+		expect( body ).toContain( 'mcp_tool_call_duration_seconds_count{tool="get-page",wiki="example.org"} 1' );
+		expect( body ).toContain( 'mcp_tool_call_duration_seconds_sum{tool="get-page",wiki="example.org"} 0.025' );
+	} );
+
+	it( 'increments mcp_upstream_status_total only when upstreamStatus is set', async () => {
+		recordToolCall( { tool: 'get-page', wiki: 'example.org', outcome: 'upstream_failure', durationMs: 5, upstreamStatus: 503 } );
+		recordToolCall( { tool: 'get-page', wiki: 'example.org', outcome: 'success', durationMs: 5, upstreamStatus: undefined } );
+		const body = await scrape();
+		expect( body ).toMatch( /mcp_upstream_status_total\{tool="get-page",wiki="example\.org",status="503"\} 1/ );
+		expect( body ).not.toMatch( /mcp_upstream_status_total\{[^}]*status="undefined"/ );
+	} );
+
+	it( 'increments mcp_ready_failures_total', async () => {
+		recordReadyFailure();
+		recordReadyFailure();
+		const body = await scrape();
+		expect( body ).toMatch( /mcp_ready_failures_total 2/ );
+	} );
+
+	it( 'mcp_active_sessions reads provider lazily at scrape', async () => {
+		let count = 3;
+		setSessionsProvider( () => count );
+		let body = await scrape();
+		expect( body ).toMatch( /mcp_active_sessions 3/ );
+		count = 7;
+		body = await scrape();
+		expect( body ).toMatch( /mcp_active_sessions 7/ );
+	} );
+
+	it( 'mcp_active_sessions reports 0 when no provider set', async () => {
+		const body = await scrape();
+		expect( body ).toMatch( /mcp_active_sessions 0/ );
+	} );
+
+	it( 'initMetrics is idempotent', async () => {
+		expect( () => initMetrics() ).not.toThrow();
+		expect( () => initMetrics() ).not.toThrow();
+		recordReadyFailure();
+		const body = await scrape();
+		expect( body ).toMatch( /mcp_ready_failures_total 1/ );
+	} );
+
+	it( 'histogram exposes the documented bucket boundaries', async () => {
+		recordToolCall( { tool: 't', wiki: 'w', outcome: 'success', durationMs: 100, upstreamStatus: undefined } );
+		const body = await scrape();
+		for ( const le of [ '0.005', '0.01', '0.025', '0.05', '0.1', '0.25', '0.5', '1', '2.5', '5', '10' ] ) {
+			expect( body ).toContain( `le="${ le }"` );
+		}
+	} );
+} );

--- a/tests/runtime/metrics.test.ts
+++ b/tests/runtime/metrics.test.ts
@@ -17,8 +17,7 @@ describe( 'metrics module — disabled state', () => {
 	} );
 
 	it( 'recorders are no-ops before initMetrics', () => {
-		expect( () =>
-			recordToolCall( { tool: 't', wiki: 'w', outcome: 'success', durationMs: 1, upstreamStatus: undefined } )
+		expect( () => recordToolCall( { tool: 't', wiki: 'w', outcome: 'success', durationMs: 1, upstreamStatus: undefined } )
 		).not.toThrow();
 		expect( () => recordReadyFailure() ).not.toThrow();
 		expect( () => setSessionsProvider( () => 0 ) ).not.toThrow();

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -92,6 +92,20 @@ describe( 'GET /metrics — enabled', () => {
 		expect( metrics.text ).toMatch( /mcp_ready_failures_total 1/ );
 	} );
 
+	it( 'mcp_ready_failures_total does not double-count cached 503 replays', async () => {
+		mockRequest.mockRejectedValue( new Error( 'upstream down' ) );
+		const app = makeApp();
+		// Two consecutive probes within the cache TTL — second hits the cache
+		// and must not re-increment the counter.
+		const first = await request( app ).get( '/ready' );
+		const second = await request( app ).get( '/ready' );
+		expect( first.status ).toBe( 503 );
+		expect( second.status ).toBe( 503 );
+		expect( mockRequest ).toHaveBeenCalledTimes( 1 );
+		const metrics = await request( app ).get( '/metrics' );
+		expect( metrics.text ).toMatch( /mcp_ready_failures_total 1/ );
+	} );
+
 	it( 'mcp_active_sessions reads the configured provider', async () => {
 		const app = makeApp();
 		setSessionsProvider( () => 4 );

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mockRequest = vi.fn();
+
+vi.mock( '../../src/wikis/state.js', () => ( {
+	wikiRegistry: {
+		getAll: () => ( {} ),
+		get: () => undefined,
+		add: () => {},
+		remove: () => {},
+		isManagementAllowed: () => false
+	},
+	wikiSelection: {
+		getCurrent: () => ( { key: 'example.org', config: {} } ),
+		setCurrent: () => {},
+		reset: () => {}
+	},
+	uploadDirs: { list: () => [] },
+	mwnProvider: {
+		get: async () => ( { request: mockRequest } ),
+		invalidate: () => {}
+	},
+	licenseCache: {
+		get: () => undefined,
+		set: () => {},
+		delete: () => {}
+	}
+} ) );
+
+import express from 'express';
+import request from 'supertest';
+import {
+	mountMetricsEndpoint,
+	mountReadyEndpoint,
+	__resetReadyCacheForTesting
+} from '../../src/transport/streamableHttp.js';
+import {
+	__resetMetricsForTesting,
+	setSessionsProvider
+} from '../../src/runtime/metrics.js';
+
+function makeApp(): express.Express {
+	const app = express();
+	mountMetricsEndpoint( app );
+	mountReadyEndpoint( app );
+	return app;
+}
+
+describe( 'GET /metrics — disabled', () => {
+	beforeEach( () => {
+		delete process.env.MCP_METRICS;
+		__resetMetricsForTesting();
+		__resetReadyCacheForTesting();
+		mockRequest.mockReset();
+	} );
+
+	it( 'returns 404 when MCP_METRICS is unset', async () => {
+		const res = await request( makeApp() ).get( '/metrics' );
+		expect( res.status ).toBe( 404 );
+	} );
+} );
+
+describe( 'GET /metrics — enabled', () => {
+	beforeEach( () => {
+		process.env.MCP_METRICS = 'true';
+		__resetMetricsForTesting();
+		__resetReadyCacheForTesting();
+		mockRequest.mockReset();
+	} );
+
+	afterEach( () => {
+		delete process.env.MCP_METRICS;
+		__resetMetricsForTesting();
+	} );
+
+	it( 'returns 200 with prom-client content type and HELP lines', async () => {
+		const res = await request( makeApp() ).get( '/metrics' );
+		expect( res.status ).toBe( 200 );
+		expect( res.headers[ 'content-type' ] ).toContain( 'text/plain' );
+		expect( res.text ).toContain( '# HELP mcp_tool_calls_total' );
+		expect( res.text ).toContain( '# HELP mcp_tool_call_duration_seconds' );
+		expect( res.text ).toContain( '# HELP mcp_active_sessions' );
+		expect( res.text ).toContain( '# HELP mcp_ready_failures_total' );
+	} );
+
+	it( 'mcp_ready_failures_total increments when /ready returns 503', async () => {
+		mockRequest.mockRejectedValue( new Error( 'upstream down' ) );
+		const app = makeApp();
+		const ready = await request( app ).get( '/ready' );
+		expect( ready.status ).toBe( 503 );
+		const metrics = await request( app ).get( '/metrics' );
+		expect( metrics.text ).toMatch( /mcp_ready_failures_total 1/ );
+	} );
+
+	it( 'mcp_active_sessions reads the configured provider', async () => {
+		const app = makeApp();
+		setSessionsProvider( () => 4 );
+		const res = await request( app ).get( '/metrics' );
+		expect( res.text ).toMatch( /mcp_active_sessions 4/ );
+	} );
+} );


### PR DESCRIPTION
## Summary

- New `MCP_METRICS=true` env var enables `GET /metrics` on the HTTP transport in Prometheus text format. Off by default, unauthenticated (operators scope via reverse proxy).
- Publishes `mcp_tool_calls_total{tool,wiki,outcome}`, `mcp_tool_call_duration_seconds{tool,wiki}` (histogram), `mcp_upstream_status_total{tool,wiki,status}`, `mcp_active_sessions`, and `mcp_ready_failures_total`.
- Stdio transport never initializes the metrics infrastructure. When `MCP_METRICS` is unset, every recorder is a no-op stub and `/metrics` 404s.

## Architecture

`src/runtime/metrics.ts` owns a `prom-client` `Registry` and a typed recorder API. `initMetrics()` swaps from no-op stubs to the live implementation; only the HTTP transport's `mountMetricsEndpoint(app)` calls it. `emitToolCall` in `src/runtime/instrument.ts` forwards each tool-call telemetry event to `recordToolCall(...)` so logs and metrics share the same emission point. `mountReadyEndpoint` increments `mcp_ready_failures_total` on non-200; the bootstrap installs a sessions-count provider for the `mcp_active_sessions` gauge.

Closes #321.

## Test plan

- [x] `npm test` — 668 / 668 passing (11 new metrics module tests, 2 new instrument integration tests, 4 new transport tests).
- [x] `npm run lint` clean on `src/`.
- [x] `npm run validate:server-json` passes.
- [x] Manual smoke: `MCP_METRICS=true MCP_TRANSPORT=http node dist/index.js` → `GET /metrics` returns 200 + `text/plain; version=0.0.4` + all five HELP lines.
- [x] Manual smoke: same without `MCP_METRICS` → `GET /metrics` returns 404, `/health` and `/ready` unchanged.