### PR TITLE
Drain SIGTERM/SIGINT cleanly on HTTP and stdio transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 
 - Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
+- `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
 
 ## [0.8.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
 | `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
+| `MCP_SHUTDOWN_GRACE_MS` | Maximum time in ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT` before exiting. Capped at 600000 (10 min); invalid values fall back to the default with a warning. | `10000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,7 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 - `MCP_TRANSPORT=http` — switch to the StreamableHTTP transport (the Dockerfile sets this by default).
 - `PORT` — listen port (default `3000` locally, `8080` in Docker).
 - `MCP_BIND` — listen interface (default `127.0.0.1`; the Dockerfile overrides to `0.0.0.0` so container port forwarding reaches the listener). Set to `0.0.0.0` outside Docker only when you need remote access.
+- `MCP_SHUTDOWN_GRACE_MS` — milliseconds to wait for in-flight `/mcp` requests to drain on `SIGTERM` or `SIGINT` (default `10000`, max `600000`). On expiry the server exits 1 with `grace_exceeded: true`. See [Graceful shutdown](#graceful-shutdown).
 - `MCP_ALLOWED_HOSTS` — comma-separated Host-header allowlist (e.g. `MCP_ALLOWED_HOSTS=wiki.example.org`). Set it on any non-localhost bind — without it, the SDK disables its DNS-rebinding check and logs a startup warning. Not needed on localhost binds, where the SDK auto-allows `localhost`, `127.0.0.1`, and `[::1]`. A bare hostname in `MCP_BIND` counts as non-localhost: the auto-allowlist only matches those three literals.
 - `MCP_ALLOWED_ORIGINS` — comma-separated `Origin`-header allowlist (e.g. `MCP_ALLOWED_ORIGINS=https://wiki.example.org`). Requests whose `Origin` is present but not listed get a 403. On a localhost bind, defaults to the three loopback origins on the bound port (`http://localhost:<port>`, `http://127.0.0.1:<port>`, `http://[::1]:<port>`) so local browser clients keep working. On a non-localhost bind, leaving it unset disables Origin validation and logs a startup warning. The allowlist is an exact string match — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements) for the gotchas that silently cause every browser request to fail.
 
@@ -183,3 +184,18 @@ Pipe stderr through `jq` or `humanlog` for live reading:
 docker logs -f mediawiki-mcp-server | jq -R 'fromjson? // empty'
 docker logs -f mediawiki-mcp-server | humanlog
 ```
+
+## Graceful shutdown
+
+The server registers `SIGTERM` and `SIGINT` handlers in both the HTTP and stdio transports. On signal:
+
+1. The HTTP listener stops accepting new connections (`server.close()`), and active StreamableHTTP sessions are closed. `/health` and `/ready` keep responding until the listener finishes closing.
+2. In-flight `/mcp` requests are given up to `MCP_SHUTDOWN_GRACE_MS` (default `10000`) to finish.
+3. The server emits two structured stderr events:
+   - `event: "shutdown"` with `signal`, `transport`, `grace_ms`, `in_flight_at_signal`, `sessions_at_signal`.
+   - `event: "shutdown_complete"` with `in_flight_drained`, `sessions_closed`, `grace_exceeded`, `duration_ms`.
+4. The process exits with code `0` if the drain finished within grace, `1` if `grace_exceeded` is true.
+
+A second `SIGTERM` or `SIGINT` during drain forces an immediate exit with code `1`, so an operator can escape a hung shutdown with a second Ctrl-C or follow-up signal.
+
+This makes `docker stop`, Kubernetes pod termination, and `systemctl stop` behave correctly: the orchestrator's default `SIGTERM` triggers a drain rather than a hard kill, and the orchestrator's escalation to `SIGKILL` after its own timeout still works as the backstop.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,4 +198,6 @@ The server registers `SIGTERM` and `SIGINT` handlers in both the HTTP and stdio 
 
 A second `SIGTERM` or `SIGINT` during drain forces an immediate exit with code `1`, so an operator can escape a hung shutdown with a second Ctrl-C or follow-up signal.
 
-This makes `docker stop`, Kubernetes pod termination, and `systemctl stop` behave correctly: the orchestrator's default `SIGTERM` triggers a drain rather than a hard kill, and the orchestrator's escalation to `SIGKILL` after its own timeout still works as the backstop.
+The stdio transport closes its single transport on the same signals; `MCP_SHUTDOWN_GRACE_MS` is logged as `0` since stdio has no per-call queue to drain.
+
+This makes `docker stop`, Kubernetes pod termination, and `systemctl stop` behave correctly: the orchestrator's default `SIGTERM` triggers a drain rather than a hard kill, and the orchestrator's escalation to `SIGKILL` after its own timeout still works as the backstop. Keep `MCP_SHUTDOWN_GRACE_MS` ≤ the orchestrator's own grace (Docker's default is 10s, Kubernetes' `terminationGracePeriodSeconds` defaults to 30s) — otherwise the drain never finishes before the orchestrator escalates to `SIGKILL`.

--- a/server.json
+++ b/server.json
@@ -38,6 +38,12 @@
           "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Has no effect on the stdio transport."
         },
         {
+          "name": "MCP_SHUTDOWN_GRACE_MS",
+          "description": "Maximum milliseconds to wait for in-flight /mcp calls to drain on SIGTERM/SIGINT before exiting. Capped at 600000.",
+          "format": "number",
+          "default": "10000"
+        },
+        {
           "name": "MCP_TRANSPORT",
           "description": "Type of MCP server transport",
           "choices": [
@@ -82,6 +88,12 @@
         {
           "name": "MCP_METRICS",
           "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Has no effect on the stdio transport."
+        },
+        {
+          "name": "MCP_SHUTDOWN_GRACE_MS",
+          "description": "Maximum milliseconds to wait for in-flight /mcp calls to drain on SIGTERM/SIGINT before exiting. Capped at 600000.",
+          "format": "number",
+          "default": "10000"
         },
         {
           "name": "MCP_TRANSPORT",

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -93,6 +93,9 @@ async function runDrain(
 			// Stop accepting new connections. The close callback isn't awaited
 			// because drain is gated on inFlight.count(), not on socket lifetime.
 			deps.httpServer.close();
+			// Node 18.2+ exposes closeIdleConnections, which lets keep-alive
+			// idle sockets close so the listener can finish closing during the
+			// grace window. Feature-detected so older runtimes still build.
 			const idleCloser = (
 				deps.httpServer as unknown as { closeIdleConnections?: () => void }
 			).closeIdleConnections;
@@ -101,7 +104,11 @@ async function runDrain(
 			}
 		}
 		if ( deps.sessions ) {
-			for ( const id of Object.keys( deps.sessions ) ) {
+			// Snapshot the ids before iterating: transport.onclose deletes its
+			// own entry from the registry, which would skip the next entry if
+			// we iterated the live object directly.
+			const sessionIds = Object.keys( deps.sessions );
+			for ( const id of sessionIds ) {
 				try {
 					await deps.sessions[ id ].transport.close();
 					sessionsClosed++;
@@ -150,6 +157,10 @@ async function waitForDrain(
 	if ( !inFlight ) {
 		return false;
 	}
+	// "0" means no /mcp request has reached the in-flight middleware yet —
+	// not "no socket activity at all". A request mid-Express-routing isn't
+	// counted, but it's a sub-millisecond window that closeIdleConnections
+	// handles.
 	if ( inFlight.count() === 0 ) {
 		return false;
 	}

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -1,3 +1,7 @@
+import type { Server as HttpServer } from 'node:http';
+/* eslint-disable n/no-missing-import */
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+/* eslint-enable n/no-missing-import */
 import { logger } from './logger.js';
 
 const DEFAULT_GRACE_MS = 10_000;
@@ -17,4 +21,144 @@ export function resolveShutdownGrace( env: NodeJS.ProcessEnv ): number {
 		return DEFAULT_GRACE_MS;
 	}
 	return n;
+}
+
+export interface InFlightCounterReader {
+	readonly count: () => number;
+}
+
+export type ShutdownSessionRegistry = Record<string, {
+	readonly transport: Pick<StreamableHTTPServerTransport, 'close'>;
+}>;
+
+export type StdioCloseable = { close(): Promise<void> | void };
+
+export interface ShutdownDeps {
+	readonly transport: 'http' | 'stdio';
+	readonly graceMs: number;
+	readonly httpServer?: HttpServer;
+	readonly sessions?: ShutdownSessionRegistry;
+	readonly inFlight?: InFlightCounterReader;
+	readonly stdioTransport?: StdioCloseable;
+	readonly process?: NodeJS.Process;
+	readonly pollIntervalMs?: number;
+}
+
+const DEFAULT_POLL_MS = 50;
+
+export function registerShutdownHandlers( deps: ShutdownDeps ): void {
+	const proc = deps.process ?? process;
+	let draining = false;
+
+	const handler = ( signal: 'SIGTERM' | 'SIGINT' ): void => {
+		if ( draining ) {
+			proc.exit( 1 );
+			return;
+		}
+		draining = true;
+		runDrain( signal, deps, proc ).catch( () => {
+			// runDrain swallows its own errors; this catch is a belt-and-braces
+			// guard so the unhandled rejection never reaches Node's default handler.
+		} );
+	};
+
+	proc.on( 'SIGTERM', () => handler( 'SIGTERM' ) );
+	proc.on( 'SIGINT', () => handler( 'SIGINT' ) );
+}
+
+async function runDrain(
+	signal: 'SIGTERM' | 'SIGINT',
+	deps: ShutdownDeps,
+	proc: NodeJS.Process
+): Promise<void> {
+	const start = Date.now();
+	const inFlightAtSignal = deps.inFlight?.count() ?? 0;
+	const sessionsAtSignal = deps.sessions ? Object.keys( deps.sessions ).length : 0;
+
+	logger.info( '', {
+		event: 'shutdown',
+		signal,
+		transport: deps.transport,
+		// eslint-disable-next-line camelcase
+		grace_ms: deps.graceMs,
+		// eslint-disable-next-line camelcase
+		in_flight_at_signal: inFlightAtSignal,
+		// eslint-disable-next-line camelcase
+		sessions_at_signal: sessionsAtSignal
+	} );
+
+	let sessionsClosed = 0;
+	if ( deps.transport === 'http' ) {
+		if ( deps.httpServer ) {
+			deps.httpServer.close();
+			const idleCloser = (
+				deps.httpServer as unknown as { closeIdleConnections?: () => void }
+			).closeIdleConnections;
+			if ( typeof idleCloser === 'function' ) {
+				idleCloser.call( deps.httpServer );
+			}
+		}
+		if ( deps.sessions ) {
+			for ( const id of Object.keys( deps.sessions ) ) {
+				try {
+					await deps.sessions[ id ].transport.close();
+					sessionsClosed++;
+				} catch {
+					// Ignore: a session that fails to close cleanly should not block drain.
+				}
+			}
+		}
+	} else if ( deps.stdioTransport ) {
+		try {
+			await deps.stdioTransport.close();
+		} catch {
+			// Same rationale.
+		}
+	}
+
+	const graceExceeded = await waitForDrain(
+		deps.inFlight,
+		deps.graceMs,
+		deps.pollIntervalMs ?? DEFAULT_POLL_MS
+	);
+
+	const drained = inFlightAtSignal - ( deps.inFlight?.count() ?? 0 );
+	logger.info( '', {
+		event: 'shutdown_complete',
+		signal,
+		transport: deps.transport,
+		// eslint-disable-next-line camelcase
+		in_flight_drained: drained,
+		// eslint-disable-next-line camelcase
+		sessions_closed: sessionsClosed,
+		// eslint-disable-next-line camelcase
+		grace_exceeded: graceExceeded,
+		// eslint-disable-next-line camelcase
+		duration_ms: Date.now() - start
+	} );
+
+	proc.exit( graceExceeded ? 1 : 0 );
+}
+
+async function waitForDrain(
+	inFlight: InFlightCounterReader | undefined,
+	graceMs: number,
+	pollMs: number
+): Promise<boolean> {
+	if ( !inFlight ) {
+		return false;
+	}
+	if ( inFlight.count() === 0 ) {
+		return false;
+	}
+	const deadline = Date.now() + graceMs;
+	while ( Date.now() < deadline ) {
+		await new Promise( ( r ) => {
+			setTimeout( r, pollMs );
+		} );
+		if ( inFlight.count() === 0 ) {
+			return false;
+		}
+	}
+	return inFlight.count() > 0;
 }

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -90,6 +90,8 @@ async function runDrain(
 	let sessionsClosed = 0;
 	if ( deps.transport === 'http' ) {
 		if ( deps.httpServer ) {
+			// Stop accepting new connections. The close callback isn't awaited
+			// because drain is gated on inFlight.count(), not on socket lifetime.
 			deps.httpServer.close();
 			const idleCloser = (
 				deps.httpServer as unknown as { closeIdleConnections?: () => void }

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -1,0 +1,20 @@
+import { logger } from './logger.js';
+
+const DEFAULT_GRACE_MS = 10_000;
+const MAX_GRACE_MS = 600_000;
+
+export function resolveShutdownGrace( env: NodeJS.ProcessEnv ): number {
+	const raw = env.MCP_SHUTDOWN_GRACE_MS;
+	if ( raw === undefined ) {
+		return DEFAULT_GRACE_MS;
+	}
+	const n = Number( raw );
+	if ( raw === '' || !Number.isInteger( n ) || n < 0 || n > MAX_GRACE_MS ) {
+		logger.warning(
+			`Ignoring invalid MCP_SHUTDOWN_GRACE_MS=${ JSON.stringify( raw ) }; ` +
+			`expected an integer between 0 and ${ MAX_GRACE_MS }. Using default ${ DEFAULT_GRACE_MS }ms.`
+		);
+		return DEFAULT_GRACE_MS;
+	}
+	return n;
+}

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -2,7 +2,7 @@ import type { Server as HttpServer } from 'node:http';
 /* eslint-disable n/no-missing-import */
 import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 /* eslint-enable n/no-missing-import */
-import { logger } from './logger.js';
+import { emitTelemetryEvent, logger } from './logger.js';
 
 const DEFAULT_GRACE_MS = 10_000;
 const MAX_GRACE_MS = 600_000;
@@ -75,7 +75,7 @@ async function runDrain(
 	const inFlightAtSignal = deps.inFlight?.count() ?? 0;
 	const sessionsAtSignal = deps.sessions ? Object.keys( deps.sessions ).length : 0;
 
-	logger.info( '', {
+	emitTelemetryEvent( 'info', {
 		event: 'shutdown',
 		signal,
 		transport: deps.transport,
@@ -125,7 +125,7 @@ async function runDrain(
 	);
 
 	const drained = inFlightAtSignal - ( deps.inFlight?.count() ?? 0 );
-	logger.info( '', {
+	emitTelemetryEvent( 'info', {
 		event: 'shutdown_complete',
 		signal,
 		transport: deps.transport,

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -7,6 +7,7 @@ import { logger } from '../runtime/logger.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
 import { createToolContext } from '../runtime/createContext.js';
+import { registerShutdownHandlers, resolveShutdownGrace } from '../runtime/shutdown.js';
 
 async function main(): Promise<void> {
 	emitStartupBanner( { transport: 'stdio' } );
@@ -15,6 +16,11 @@ async function main(): Promise<void> {
 	const server = createServer( ctx );
 
 	await server.connect( transport );
+	registerShutdownHandlers( {
+		transport: 'stdio',
+		graceMs: resolveShutdownGrace( process.env ),
+		stdioTransport: transport
+	} );
 }
 
 main().catch( ( error ) => {

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -7,7 +7,7 @@ import { logger } from '../runtime/logger.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
 import { createToolContext } from '../runtime/createContext.js';
-import { registerShutdownHandlers, resolveShutdownGrace } from '../runtime/shutdown.js';
+import { registerShutdownHandlers } from '../runtime/shutdown.js';
 
 async function main(): Promise<void> {
 	emitStartupBanner( { transport: 'stdio' } );
@@ -16,9 +16,11 @@ async function main(): Promise<void> {
 	const server = createServer( ctx );
 
 	await server.connect( transport );
+	// Stdio has no in-flight queue, so grace doesn't apply — log graceMs: 0
+	// to make that explicit in the shutdown event.
 	registerShutdownHandlers( {
 		transport: 'stdio',
-		graceMs: resolveShutdownGrace( process.env ),
+		graceMs: 0,
 		stdioTransport: transport
 	} );
 }

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -98,6 +98,23 @@ export type SessionEntry = {
 
 export type SessionRegistry = { [ sessionId: string ]: SessionEntry };
 
+export interface InFlightCounter {
+	readonly middleware: RequestHandler;
+	readonly count: () => number;
+}
+
+export function createInFlightCounter(): InFlightCounter {
+	let n = 0;
+	const middleware: RequestHandler = ( _req, res, next ) => {
+		n++;
+		res.on( 'close', () => {
+			n--;
+		} );
+		next();
+	};
+	return { middleware, count: () => n };
+}
+
 function sendSessionBearerMismatch( res: Response ): void {
 	res.status( 401 ).json( {
 		jsonrpc: '2.0',

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -25,6 +25,7 @@ import { wikiRegistry, wikiSelection, mwnProvider } from '../wikis/state.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
 import { createToolContext } from '../runtime/createContext.js';
+import { registerShutdownHandlers, resolveShutdownGrace } from '../runtime/shutdown.js';
 
 export async function withRequestContext<T>(
 	runtimeToken: string | undefined,
@@ -348,6 +349,9 @@ const sessions: SessionRegistry = {};
 const sessionRequestHandler = createSessionRequestHandler( sessions );
 const ctx = createToolContext( { logger } );
 
+const inFlight = createInFlightCounter();
+app.use( '/mcp', inFlight.middleware );
+
 app.post( '/mcp', createMcpPostHandler(
 	sessions,
 	() => createServer( ctx ),
@@ -365,6 +369,14 @@ mountReadyEndpoint( app );
 mountMetricsEndpoint( app );
 setSessionsProvider( () => Object.keys( sessions ).length );
 
-app.listen( port, host, () => {
+const httpServer = app.listen( port, host, () => {
 	logger.info( `MCP Streamable HTTP Server listening on ${ host }:${ port }` );
+} );
+
+registerShutdownHandlers( {
+	transport: 'http',
+	graceMs: resolveShutdownGrace( process.env ),
+	httpServer,
+	sessions,
+	inFlight
 } );

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveShutdownGrace } from '../../src/runtime/shutdown.js';
+
+describe( 'resolveShutdownGrace', () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach( () => {
+		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		stderrSpy.mockRestore();
+	} );
+
+	function warningLines(): string[] {
+		return stderrSpy.mock.calls
+			.map( ( c ) => String( c[ 0 ] ) )
+			.filter( ( s ) => s.includes( '"level":"warning"' ) );
+	}
+
+	it( 'defaults to 10000 when unset', () => {
+		expect( resolveShutdownGrace( {} ) ).toBe( 10_000 );
+		expect( warningLines() ).toHaveLength( 0 );
+	} );
+
+	it( 'parses a valid integer string', () => {
+		expect( resolveShutdownGrace( { MCP_SHUTDOWN_GRACE_MS: '5000' } ) ).toBe( 5_000 );
+		expect( warningLines() ).toHaveLength( 0 );
+	} );
+
+	it( 'accepts zero (immediate exit, no drain wait)', () => {
+		expect( resolveShutdownGrace( { MCP_SHUTDOWN_GRACE_MS: '0' } ) ).toBe( 0 );
+	} );
+
+	it.each( [
+		[ 'not-a-number' ],
+		[ '-1' ],
+		[ '1.5' ],
+		[ '600001' ],
+		[ '' ]
+	] )( 'falls back with a warning for %s', ( v ) => {
+		expect( resolveShutdownGrace( { MCP_SHUTDOWN_GRACE_MS: v } ) ).toBe( 10_000 );
+		const lines = warningLines();
+		expect( lines ).toHaveLength( 1 );
+		expect( lines[ 0 ] ).toContain( v );
+	} );
+} );

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -211,7 +211,7 @@ describe( 'registerShutdownHandlers (stdio)', () => {
 		let closed = false;
 		registerShutdownHandlers( {
 			transport: 'stdio',
-			graceMs: 10_000,
+			graceMs: 0,
 			stdioTransport: { close: async () => { closed = true; } },
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			process: proc as any
@@ -224,7 +224,11 @@ describe( 'registerShutdownHandlers (stdio)', () => {
 		expect( proc.exitCalls ).toEqual( [ 0 ] );
 		const events = captureEvents( stderrSpy, 'shutdown' );
 		const done = captureEvents( stderrSpy, 'shutdown_complete' );
-		expect( events[ 0 ] ).toMatchObject( { transport: 'stdio', signal: 'SIGTERM' } );
+		expect( events[ 0 ] ).toMatchObject( {
+			transport: 'stdio',
+			signal: 'SIGTERM',
+			grace_ms: 0
+		} );
 		expect( done[ 0 ] ).toMatchObject( { transport: 'stdio', grace_exceeded: false } );
 	} );
 } );

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -194,3 +194,37 @@ describe( 'registerShutdownHandlers (http)', () => {
 		expect( proc.exitCalls[ proc.exitCalls.length - 1 ] ).toBe( 1 );
 	} );
 } );
+
+describe( 'registerShutdownHandlers (stdio)', () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach( () => {
+		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		stderrSpy.mockRestore();
+	} );
+
+	it( 'closes the stdio transport and exits 0', async () => {
+		const proc = fakeProcess();
+		let closed = false;
+		registerShutdownHandlers( {
+			transport: 'stdio',
+			graceMs: 10_000,
+			stdioTransport: { close: async () => { closed = true; } },
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			process: proc as any
+		} );
+
+		proc.signals.get( 'SIGTERM' )!();
+		await new Promise( ( r ) => setImmediate( r ) );
+
+		expect( closed ).toBe( true );
+		expect( proc.exitCalls ).toEqual( [ 0 ] );
+		const events = captureEvents( stderrSpy, 'shutdown' );
+		const done = captureEvents( stderrSpy, 'shutdown_complete' );
+		expect( events[ 0 ] ).toMatchObject( { transport: 'stdio', signal: 'SIGTERM' } );
+		expect( done[ 0 ] ).toMatchObject( { transport: 'stdio', grace_exceeded: false } );
+	} );
+} );

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -30,6 +30,7 @@ describe( 'resolveShutdownGrace', () => {
 
 	it( 'accepts zero (immediate exit, no drain wait)', () => {
 		expect( resolveShutdownGrace( { MCP_SHUTDOWN_GRACE_MS: '0' } ) ).toBe( 0 );
+		expect( warningLines() ).toHaveLength( 0 );
 	} );
 
 	it.each( [
@@ -42,6 +43,9 @@ describe( 'resolveShutdownGrace', () => {
 		expect( resolveShutdownGrace( { MCP_SHUTDOWN_GRACE_MS: v } ) ).toBe( 10_000 );
 		const lines = warningLines();
 		expect( lines ).toHaveLength( 1 );
-		expect( lines[ 0 ] ).toContain( v );
+		// For non-empty values the raw string is preserved in the log line.
+		// For the empty-string case, we verify the variable name appears instead,
+		// because toContain('') is always true and provides no signal.
+		expect( lines[ 0 ] ).toContain( v !== '' ? v : 'MCP_SHUTDOWN_GRACE_MS' );
 	} );
 } );

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveShutdownGrace } from '../../src/runtime/shutdown.js';
+import { resolveShutdownGrace, registerShutdownHandlers } from '../../src/runtime/shutdown.js';
 
 describe( 'resolveShutdownGrace', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -47,5 +47,150 @@ describe( 'resolveShutdownGrace', () => {
 		// For the empty-string case, we verify the variable name appears instead,
 		// because toContain('') is always true and provides no signal.
 		expect( lines[ 0 ] ).toContain( v !== '' ? v : 'MCP_SHUTDOWN_GRACE_MS' );
+	} );
+} );
+
+interface FakeProcess {
+	on: ( signal: 'SIGTERM' | 'SIGINT', cb: () => void ) => void;
+	exit: ( code: number ) => void;
+	signals: Map<string, () => void>;
+	exitCalls: number[];
+}
+
+function fakeProcess(): FakeProcess {
+	const signals = new Map<string, () => void>();
+	const exitCalls: number[] = [];
+	return {
+		signals,
+		exitCalls,
+		on: ( s, cb ) => {
+			signals.set( s, cb );
+		},
+		exit: ( code ) => {
+			exitCalls.push( code );
+		}
+	};
+}
+
+function captureEvents( spy: ReturnType<typeof vi.spyOn>, name: string ): Record<string, unknown>[] {
+	return spy.mock.calls
+		.map( ( c ) => String( c[ 0 ] ) )
+		.filter( ( s ) => s.startsWith( '{' ) )
+		.map( ( s ) => JSON.parse( s.replace( /\n$/, '' ) ) as Record<string, unknown> )
+		.filter( ( e ) => e.event === name );
+}
+
+describe( 'registerShutdownHandlers (http)', () => {
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach( () => {
+		stderrSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		stderrSpy.mockRestore();
+	} );
+
+	function setup( opts: { inFlight: number; sessions: number; graceMs?: number } ) {
+		const proc = fakeProcess();
+		const closedSessions: string[] = [];
+		const sessions: Record<string, { transport: { close: () => Promise<void> } }> = {};
+		for ( let i = 0; i < opts.sessions; i++ ) {
+			const id = `s-${ i }`;
+			sessions[ id ] = {
+				transport: {
+					close: async () => {
+						closedSessions.push( id );
+					}
+				}
+			};
+		}
+
+		let httpClosed = false;
+		const httpServer = {
+			close: ( cb?: () => void ) => {
+				httpClosed = true;
+				if ( cb ) {
+					cb();
+				}
+			},
+			closeIdleConnections: () => {}
+		};
+
+		let count = opts.inFlight;
+		const inFlight = { count: () => count, drain: () => {
+			count = 0;
+		} };
+
+		registerShutdownHandlers( {
+			transport: 'http',
+			graceMs: opts.graceMs ?? 10_000,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			httpServer: httpServer as any,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			sessions: sessions as any,
+			inFlight,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			process: proc as any,
+			pollIntervalMs: 5
+		} );
+
+		return { proc, sessions, closedSessions, httpServer: { closed: () => httpClosed }, inFlight };
+	}
+
+	it( 'registers SIGTERM and SIGINT', () => {
+		const { proc } = setup( { inFlight: 0, sessions: 0 } );
+		expect( proc.signals.has( 'SIGTERM' ) ).toBe( true );
+		expect( proc.signals.has( 'SIGINT' ) ).toBe( true );
+	} );
+
+	it( 'drains cleanly when in-flight reaches zero', async () => {
+		const { proc, httpServer, closedSessions, inFlight } = setup( { inFlight: 2, sessions: 1 } );
+		proc.signals.get( 'SIGTERM' )!();
+		await new Promise( ( r ) => setImmediate( r ) );
+		inFlight.drain();
+		await new Promise( ( r ) => setTimeout( r, 20 ) );
+
+		expect( httpServer.closed() ).toBe( true );
+		expect( closedSessions ).toEqual( [ 's-0' ] );
+		expect( proc.exitCalls ).toEqual( [ 0 ] );
+
+		const start = captureEvents( stderrSpy, 'shutdown' );
+		const done = captureEvents( stderrSpy, 'shutdown_complete' );
+		expect( start ).toHaveLength( 1 );
+		expect( start[ 0 ] ).toMatchObject( {
+			signal: 'SIGTERM',
+			transport: 'http',
+			grace_ms: 10_000,
+			in_flight_at_signal: 2,
+			sessions_at_signal: 1
+		} );
+		expect( done ).toHaveLength( 1 );
+		expect( done[ 0 ] ).toMatchObject( {
+			in_flight_drained: 2,
+			sessions_closed: 1,
+			grace_exceeded: false
+		} );
+		expect( typeof done[ 0 ].duration_ms ).toBe( 'number' );
+	} );
+
+	it( 'exits 1 with grace_exceeded: true when in-flight is stuck', async () => {
+		const { proc } = setup( { inFlight: 3, sessions: 0, graceMs: 30 } );
+		proc.signals.get( 'SIGINT' )!();
+		await new Promise( ( r ) => setTimeout( r, 60 ) );
+		expect( proc.exitCalls ).toEqual( [ 1 ] );
+		const done = captureEvents( stderrSpy, 'shutdown_complete' );
+		expect( done[ 0 ] ).toMatchObject( {
+			grace_exceeded: true,
+			in_flight_drained: 0
+		} );
+	} );
+
+	it( 'forces immediate exit on a second signal', async () => {
+		const { proc } = setup( { inFlight: 5, sessions: 0, graceMs: 10_000 } );
+		proc.signals.get( 'SIGTERM' )!();
+		await new Promise( ( r ) => setImmediate( r ) );
+		proc.signals.get( 'SIGTERM' )!();
+		expect( proc.exitCalls[ proc.exitCalls.length - 1 ] ).toBe( 1 );
 	} );
 } );

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -39,6 +39,7 @@ import request from 'supertest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 /* eslint-enable n/no-missing-import */
 import {
+	createInFlightCounter,
 	createMcpPostHandler,
 	createSessionRequestHandler,
 	extractBearerToken,
@@ -402,5 +403,46 @@ describe( 'withRequestContext', () => {
 			expect( getRuntimeToken() ).toBeUndefined();
 			expect( getSessionId() ).toBe( 'sess-only' );
 		} );
+	} );
+} );
+
+describe( 'createInFlightCounter', () => {
+	function buildApp(): Express {
+		const app = express();
+		const inFlight = createInFlightCounter();
+		app.use( '/mcp', inFlight.middleware );
+		app.post( '/mcp', ( _req, res ) => {
+			res.json( { count: inFlight.count() } );
+		} );
+		app.get( '/count', ( _req, res ) => res.json( { count: inFlight.count() } ) );
+		return app;
+	}
+
+	it( 'is 1 during the request and 0 after', async () => {
+		const app = buildApp();
+		const mid = await request( app ).post( '/mcp' ).send( {} );
+		expect( mid.body.count ).toBe( 1 );
+
+		const after = await request( app ).get( '/count' );
+		expect( after.body.count ).toBe( 0 );
+	} );
+
+	it( 'decrements when the client aborts (res close without finish)', async () => {
+		const app = express();
+		const inFlight = createInFlightCounter();
+		app.use( '/mcp', inFlight.middleware );
+		app.post( '/mcp', ( _req, res ) => {
+			res.destroy();
+		} );
+
+		await request( app ).post( '/mcp' ).send( {} ).catch( () => undefined );
+		await new Promise( ( r ) => setImmediate( r ) );
+		expect( inFlight.count() ).toBe( 0 );
+	} );
+
+	it( 'each factory call has its own counter', () => {
+		const a = createInFlightCounter();
+		const b = createInFlightCounter();
+		expect( a.count ).not.toBe( b.count );
 	} );
 } );


### PR DESCRIPTION
## Summary

- Registers `SIGTERM` and `SIGINT` handlers for both transports. On signal the HTTP listener stops accepting new connections, active StreamableHTTP sessions are closed, in-flight `/mcp` requests are given up to `MCP_SHUTDOWN_GRACE_MS` (default `10000`, max `600000`) to finish, and the process exits `0` on a clean drain or `1` when grace expires. Stdio closes its single transport. A second signal during drain forces immediate exit.
- New structured stderr telemetry events: `event: "shutdown"` (`signal`, `transport`, `grace_ms`, `in_flight_at_signal`, `sessions_at_signal`) and `event: "shutdown_complete"` (`in_flight_drained`, `sessions_closed`, `grace_exceeded`, `duration_ms`). Routed through `emitTelemetryEvent` so they don't broadcast to connected MCP clients via `sendLoggingMessage`.
- New `/mcp`-scoped in-flight middleware via `createInFlightCounter()`. Mounted on `/mcp` only so `/health` and `/ready` keep responding during drain.
- New `MCP_SHUTDOWN_GRACE_MS` env var, propagated to README, `server.json` (both `mcpb` and `npm` package blocks), `CHANGELOG.md` `[Unreleased] → Added`, and a new `## Graceful shutdown` section in `docs/deployment.md`.

Closes #319.

## Why

`docker stop`, Kubernetes pod termination, and `systemctl stop` all default to `SIGTERM`. Without handlers, Node exits immediately — in-flight tool calls are dropped mid-response, persistent StreamableHTTP sessions get aborted instead of drained, and orchestrators have no way to distinguish "graceful drain" from "hard kill." This lands before publishing any \`latest\`-tagged image so the published image behaves correctly under orchestration.

## Design notes worth flagging

- **Stdio passes \`graceMs: 0\`.** Stdio has no in-flight queue at the transport layer (single connection, one request at a time), so the grace period never applies. Logging \`0\` makes that explicit instead of leaving a misleading \`10000\` in stdio events.
- **\`closeIdleConnections\` is feature-detected.** Node 18.2+ exposes it on \`http.Server\`; calling it lets keep-alive idle sockets close so the listener can finalise during the grace window. Older runtimes fall through harmlessly.
- **Operator gotcha.** \`MCP_SHUTDOWN_GRACE_MS\` should be ≤ the orchestrator's own grace (Docker default 10s, Kubernetes \`terminationGracePeriodSeconds\` default 30s) — otherwise the drain never finishes before the orchestrator escalates to \`SIGKILL\`. Documented in \`docs/deployment.md\`.
- **No Dockerfile change.** The env var has a sensible code default; operators tune it via orchestrator env injection.

## Test plan

- [x] \`npm test\` — 56 files, 667 tests, 0 failures (was 651 baseline; +16 new across \`tests/runtime/shutdown.test.ts\` and \`tests/transport/streamableHttp.test.ts\`)
- [x] \`npm run lint\` — 0 errors, 6 pre-existing warnings
- [x] \`npm run build\` — clean
- [x] \`npm run validate:server-json\` — valid (both \`mcpb\` and \`npm\` blocks)
- [x] Manual smoke, HTTP transport: \`MCP_TRANSPORT=http node dist/index.js\` then \`kill -TERM\` — stderr emits \`event: "shutdown"\` then \`event: "shutdown_complete"\` with \`grace_exceeded: false\`, exit code \`0\`.
- [x] Manual smoke, stdio transport: \`node dist/index.js\` then \`kill -TERM\` — same event pair with \`transport: "stdio"\` and \`grace_ms: 0\`, exit code \`0\`.
- [x] \`npm run preflight\` blocks on \`mcpb pack\` from inside \`.worktrees/*\` (worktree-name vs hardcoded artifact name in \`scripts/bundle.cjs\`) — pre-existing, reproduces on master, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)