### PR TITLE
Add MCP_MAX_REQUEST_BODY env var for HTTP body size cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
+- `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size on the StreamableHTTP transport. Replaces body-parser's silent 100 kB default that was rejecting long-form wikitext edits. The resolved value appears in the startup banner; oversize requests return a JSON-RPC 413 instead of an HTML error page.
 
 ## [0.8.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
-- `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size on the StreamableHTTP transport. Replaces body-parser's silent 100 kB default that was rejecting long-form wikitext edits. The resolved value appears in the startup banner; oversize requests return a JSON-RPC 413 instead of an HTML error page.
+- `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits. Oversize requests return a JSON-RPC 413; the resolved value appears in the startup banner.
 
 ## [0.8.0] - 2026-04-28
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
+| `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings (`512kb`, `1mb`, `2mb`). Requests over the cap return a JSON-RPC 413. | `1mb` |
 | `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
 | `MCP_SHUTDOWN_GRACE_MS` | Maximum time in ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT` before exiting. Capped at 600000 (10 min); invalid values fall back to the default with a warning. | `10000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
-| `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings (`512kb`, `1mb`, `2mb`). Requests over the cap return a JSON-RPC 413. | `1mb` |
+| `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings like `512kb` or `1mb`. Oversize requests get a JSON-RPC 413. | `1mb` |
 | `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
 | `MCP_SHUTDOWN_GRACE_MS` | Maximum time in ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT` before exiting. Capped at 600000 (10 min); invalid values fall back to the default with a warning. | `10000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,7 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 - `MCP_SHUTDOWN_GRACE_MS` — milliseconds to wait for in-flight `/mcp` requests to drain on `SIGTERM` or `SIGINT` (default `10000`, max `600000`). On expiry the server exits 1 with `grace_exceeded: true`. See [Graceful shutdown](#graceful-shutdown).
 - `MCP_ALLOWED_HOSTS` — comma-separated Host-header allowlist (e.g. `MCP_ALLOWED_HOSTS=wiki.example.org`). Set it on any non-localhost bind — without it, the SDK disables its DNS-rebinding check and logs a startup warning. Not needed on localhost binds, where the SDK auto-allows `localhost`, `127.0.0.1`, and `[::1]`. A bare hostname in `MCP_BIND` counts as non-localhost: the auto-allowlist only matches those three literals.
 - `MCP_ALLOWED_ORIGINS` — comma-separated `Origin`-header allowlist (e.g. `MCP_ALLOWED_ORIGINS=https://wiki.example.org`). Requests whose `Origin` is present but not listed get a 403. On a localhost bind, defaults to the three loopback origins on the bound port (`http://localhost:<port>`, `http://127.0.0.1:<port>`, `http://[::1]:<port>`) so local browser clients keep working. On a non-localhost bind, leaving it unset disables Origin validation and logs a startup warning. The allowlist is an exact string match — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements) for the gotchas that silently cause every browser request to fail.
-- `MCP_MAX_REQUEST_BODY` — maximum HTTP request body size (default `1mb`). Long-form wikitext can run 100–300 kB and the JSON-RPC envelope adds escape overhead; the default mirrors typical reverse-proxy caps (e.g. nginx's `client_max_body_size 1m`). Raise this when `update-page` calls return 413 on legitimately large edits, or when your wiki has raised `$wgMaxArticleSize` (default 2 MB) and routinely edits near the ceiling. Lower it for a tighter DoS guard. Accepts body-parser size strings (`b`, `kb`, `mb`, `gb`).
+- `MCP_MAX_REQUEST_BODY` — maximum HTTP request body size (default `1mb`, matching nginx's `client_max_body_size 1m`). Raise it if `update-page` calls return 413 on legitimately large edits, or if your wiki has raised `$wgMaxArticleSize` (MediaWiki default 2 MB) and routinely edits near the ceiling. Lower it for a tighter DoS guard. Accepts body-parser size strings (`b`, `kb`, `mb`, `gb`).
 
 ## Shape 1 — Single-wiki, read-only, anonymous
 
@@ -128,7 +128,7 @@ One line on server boot — a snapshot of the effective configuration that's saf
 - **`auth_shape`** — `anonymous`, `static-credential`, or `bearer-passthrough`.
 - **`host`, `port`, `allowed_hosts`, `allowed_origins`** — HTTP transport only. The two allowlists are also omitted when not configured.
 - **`upload_dirs_configured`** — `true` when `uploadDirs` (config) or `MCP_UPLOAD_DIRS` (env) is set. The actual paths are not logged.
-- **`max_request_body`** — HTTP transport only. The resolved `MCP_MAX_REQUEST_BODY` value (default `1mb`).
+- **`max_request_body`** — HTTP transport only. The resolved `MCP_MAX_REQUEST_BODY` value.
 
 Tokens, usernames, and passwords never appear.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,7 @@ The server can run as a remote HTTP endpoint for clients that only accept URLs (
 - `MCP_SHUTDOWN_GRACE_MS` — milliseconds to wait for in-flight `/mcp` requests to drain on `SIGTERM` or `SIGINT` (default `10000`, max `600000`). On expiry the server exits 1 with `grace_exceeded: true`. See [Graceful shutdown](#graceful-shutdown).
 - `MCP_ALLOWED_HOSTS` — comma-separated Host-header allowlist (e.g. `MCP_ALLOWED_HOSTS=wiki.example.org`). Set it on any non-localhost bind — without it, the SDK disables its DNS-rebinding check and logs a startup warning. Not needed on localhost binds, where the SDK auto-allows `localhost`, `127.0.0.1`, and `[::1]`. A bare hostname in `MCP_BIND` counts as non-localhost: the auto-allowlist only matches those three literals.
 - `MCP_ALLOWED_ORIGINS` — comma-separated `Origin`-header allowlist (e.g. `MCP_ALLOWED_ORIGINS=https://wiki.example.org`). Requests whose `Origin` is present but not listed get a 403. On a localhost bind, defaults to the three loopback origins on the bound port (`http://localhost:<port>`, `http://127.0.0.1:<port>`, `http://[::1]:<port>`) so local browser clients keep working. On a non-localhost bind, leaving it unset disables Origin validation and logs a startup warning. The allowlist is an exact string match — see [configuration.md — reverse proxy requirements](configuration.md#reverse-proxy-requirements) for the gotchas that silently cause every browser request to fail.
+- `MCP_MAX_REQUEST_BODY` — maximum HTTP request body size (default `1mb`). Long-form wikitext can run 100–300 kB and the JSON-RPC envelope adds escape overhead; the default mirrors typical reverse-proxy caps (e.g. nginx's `client_max_body_size 1m`). Raise this when `update-page` calls return 413 on legitimately large edits, or when your wiki has raised `$wgMaxArticleSize` (default 2 MB) and routinely edits near the ceiling. Lower it for a tighter DoS guard. Accepts body-parser size strings (`b`, `kb`, `mb`, `gb`).
 
 ## Shape 1 — Single-wiki, read-only, anonymous
 
@@ -121,12 +122,13 @@ Fields you'll filter on:
 One line on server boot — a snapshot of the effective configuration that's safe to paste into a support ticket:
 
 ```json
-{"ts":"...","level":"info","event":"startup","version":"0.7.0","transport":"http","host":"0.0.0.0","port":8080,"auth_shape":"bearer-passthrough","default_wiki":"example.org","wikis":["example.org"],"allow_wiki_management":false,"allowed_hosts":["wiki.example.org"],"allowed_origins":["https://wiki.example.org"],"upload_dirs_configured":false}
+{"ts":"...","level":"info","event":"startup","version":"0.8.0","transport":"http","host":"0.0.0.0","port":8080,"auth_shape":"bearer-passthrough","default_wiki":"example.org","wikis":["example.org"],"allow_wiki_management":false,"allowed_hosts":["wiki.example.org"],"allowed_origins":["https://wiki.example.org"],"max_request_body":"1mb","upload_dirs_configured":false}
 ```
 
 - **`auth_shape`** — `anonymous`, `static-credential`, or `bearer-passthrough`.
 - **`host`, `port`, `allowed_hosts`, `allowed_origins`** — HTTP transport only. The two allowlists are also omitted when not configured.
 - **`upload_dirs_configured`** — `true` when `uploadDirs` (config) or `MCP_UPLOAD_DIRS` (env) is set. The actual paths are not logged.
+- **`max_request_body`** — HTTP transport only. The resolved `MCP_MAX_REQUEST_BODY` value (default `1mb`).
 
 Tokens, usernames, and passwords never appear.
 

--- a/server.json
+++ b/server.json
@@ -34,6 +34,11 @@
           "default": "50000"
         },
         {
+          "name": "MCP_MAX_REQUEST_BODY",
+          "description": "Maximum HTTP request body size for the StreamableHTTP transport. Accepts body-parser size strings (e.g. 1mb, 512kb).",
+          "default": "1mb"
+        },
+        {
           "name": "MCP_METRICS",
           "description": "Set to 'true' to expose Prometheus metrics at GET /metrics on the HTTP transport. Has no effect on the stdio transport."
         },
@@ -84,6 +89,11 @@
           "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
           "format": "number",
           "default": "50000"
+        },
+        {
+          "name": "MCP_MAX_REQUEST_BODY",
+          "description": "Maximum HTTP request body size for the StreamableHTTP transport. Accepts body-parser size strings (e.g. 1mb, 512kb).",
+          "default": "1mb"
         },
         {
           "name": "MCP_METRICS",

--- a/server.json
+++ b/server.json
@@ -35,7 +35,7 @@
         },
         {
           "name": "MCP_MAX_REQUEST_BODY",
-          "description": "Maximum HTTP request body size for the StreamableHTTP transport. Accepts body-parser size strings (e.g. 1mb, 512kb).",
+          "description": "Maximum HTTP request body size on the StreamableHTTP transport. Accepts size strings like 1mb or 512kb.",
           "default": "1mb"
         },
         {
@@ -92,7 +92,7 @@
         },
         {
           "name": "MCP_MAX_REQUEST_BODY",
-          "description": "Maximum HTTP request body size for the StreamableHTTP transport. Accepts body-parser size strings (e.g. 1mb, 512kb).",
+          "description": "Maximum HTTP request body size on the StreamableHTTP transport. Accepts size strings like 1mb or 512kb.",
           "default": "1mb"
         },
         {

--- a/src/runtime/banner.ts
+++ b/src/runtime/banner.ts
@@ -19,6 +19,7 @@ export type CreateServerOptions =
 			port: number;
 			allowedHosts?: readonly string[];
 			allowedOrigins?: readonly string[];
+			maxRequestBody: string;
 		};
 	};
 
@@ -49,6 +50,8 @@ export function emitStartupBanner( opts: CreateServerOptions ): void {
 			// eslint-disable-next-line camelcase
 			data.allowed_origins = opts.http.allowedOrigins;
 		}
+		// eslint-disable-next-line camelcase
+		data.max_request_body = opts.http.maxRequestBody;
 	}
 	logger.info( '', data );
 }

--- a/src/transport/httpConfig.ts
+++ b/src/transport/httpConfig.ts
@@ -3,6 +3,8 @@ export interface HttpConfig {
 	port: number;
 	allowedHosts: string[] | undefined;
 	allowedOrigins: string[] | undefined;
+	maxRequestBody: string;
+	warnings: string[];
 }
 
 export const LOCALHOST_HOSTS: readonly string[] = [ '127.0.0.1', 'localhost', '::1' ];
@@ -10,6 +12,12 @@ export const LOCALHOST_HOSTS: readonly string[] = [ '127.0.0.1', 'localhost', ':
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 3000;
 const MAX_PORT = 65535;
+export const DEFAULT_MAX_REQUEST_BODY = '1mb';
+
+// Mirrors body-parser's size grammar: optional decimal number followed by an
+// optional unit (bytes if omitted). Validating at startup prevents body-parser
+// from silently treating a malformed value as "no limit".
+const SIZE_PATTERN = /^\s*\d+(?:\.\d+)?\s*(?:b|kb|mb|gb|tb|pb)?\s*$/i;
 
 function resolveHost(): string {
 	const raw = process.env.MCP_BIND;
@@ -71,13 +79,44 @@ function resolveAllowedOrigins( host: string, port: number ): string[] | undefin
 	return undefined;
 }
 
+function resolveMaxRequestBody(): { value: string; warning?: string } {
+	const raw = process.env.MCP_MAX_REQUEST_BODY;
+	if ( raw === undefined ) {
+		return { value: DEFAULT_MAX_REQUEST_BODY };
+	}
+	const trimmed = raw.trim();
+	if ( trimmed === '' ) {
+		return { value: DEFAULT_MAX_REQUEST_BODY };
+	}
+	if ( !SIZE_PATTERN.test( trimmed ) ) {
+		return {
+			value: DEFAULT_MAX_REQUEST_BODY,
+			warning: `MCP_MAX_REQUEST_BODY=${ raw } is not a recognised size; using default ${ DEFAULT_MAX_REQUEST_BODY }`
+		};
+	}
+	if ( parseFloat( trimmed ) === 0 ) {
+		return {
+			value: DEFAULT_MAX_REQUEST_BODY,
+			warning: `MCP_MAX_REQUEST_BODY=${ raw } would reject all requests; using default ${ DEFAULT_MAX_REQUEST_BODY }`
+		};
+	}
+	return { value: trimmed };
+}
+
 export function resolveHttpConfig(): HttpConfig {
 	const host = resolveHost();
 	const port = resolvePort();
+	const body = resolveMaxRequestBody();
+	const warnings: string[] = [];
+	if ( body.warning ) {
+		warnings.push( body.warning );
+	}
 	return {
 		host,
 		port,
 		allowedHosts: resolveAllowedHosts(),
-		allowedOrigins: resolveAllowedOrigins( host, port )
+		allowedOrigins: resolveAllowedOrigins( host, port ),
+		maxRequestBody: body.value,
+		warnings
 	};
 }

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
-import express, { type RequestHandler, type Request, type Response } from 'express';
+import express, {
+	type ErrorRequestHandler,
+	type RequestHandler,
+	type Request,
+	type Response
+} from 'express';
 /* eslint-disable n/no-missing-import */
 import {
 	hostHeaderValidation,
@@ -211,6 +216,29 @@ export function createSessionRequestHandler( sessions: SessionRegistry ): Reques
 			sessionId,
 			() => entry.transport.handleRequest( req, res )
 		);
+	};
+}
+
+// body-parser raises a PayloadTooLargeError with `type === 'entity.too.large'`
+// when the request body exceeds the configured limit. Without this handler the
+// default Express error page returns an HTML blob, which an MCP client cannot
+// parse — so we shape it as a JSON-RPC error.
+export function payloadTooLargeHandler( limit: string ): ErrorRequestHandler {
+	return ( err, _req, res, next ) => {
+		const tooLarge = typeof err === 'object' && err !== null &&
+			( err as { type?: unknown } ).type === 'entity.too.large';
+		if ( !tooLarge ) {
+			next( err );
+			return;
+		}
+		res.status( 413 ).json( {
+			jsonrpc: '2.0',
+			error: {
+				code: -32000,
+				message: `Request body exceeds the configured maximum size of ${ limit }`
+			},
+			id: null
+		} );
 	};
 }
 

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -331,7 +331,7 @@ export function mountReadyEndpoint( app: express.Express ): void {
 	} );
 }
 
-const { host, port, allowedHosts, allowedOrigins } = resolveHttpConfig();
+const { host, port, allowedHosts, allowedOrigins, maxRequestBody, warnings } = resolveHttpConfig();
 const guard = evaluateBearerGuard( wikiRegistry.getAll(), process.env );
 if ( guard.kind === 'block' ) {
 	logger.error(
@@ -353,12 +353,19 @@ if ( guard.kind === 'override' ) {
 		'This deployment cannot attribute writes to individual callers.'
 	);
 }
+for ( const warning of warnings ) {
+	logger.warning( warning );
+}
 // Emit the process-level startup banner before any HTTP request
 // can spin up a per-session McpServer.
-emitStartupBanner( { transport: 'http', http: { host, port, allowedHosts, allowedOrigins } } );
+emitStartupBanner( {
+	transport: 'http',
+	http: { host, port, allowedHosts, allowedOrigins, maxRequestBody }
+} );
 
 const app = express();
-app.use( express.json() );
+app.use( express.json( { limit: maxRequestBody } ) );
+app.use( payloadTooLargeHandler( maxRequestBody ) );
 
 const hostValidation = resolveMcpHostValidation( host, allowedHosts );
 if ( hostValidation ) {

--- a/tests/runtime/startup-banner.test.ts
+++ b/tests/runtime/startup-banner.test.ts
@@ -62,6 +62,7 @@ describe( 'startup banner', () => {
 		expect( 'port' in e ).toBe( false );
 		expect( 'allowed_hosts' in e ).toBe( false );
 		expect( 'allowed_origins' in e ).toBe( false );
+		expect( 'max_request_body' in e ).toBe( false );
 	} );
 
 	it( 'includes http fields when transport is http', () => {
@@ -71,7 +72,8 @@ describe( 'startup banner', () => {
 				host: '0.0.0.0',
 				port: 8080,
 				allowedHosts: [ 'wiki.example.org' ],
-				allowedOrigins: [ 'https://wiki.example.org' ]
+				allowedOrigins: [ 'https://wiki.example.org' ],
+				maxRequestBody: '2mb'
 			}
 		} );
 
@@ -84,12 +86,13 @@ describe( 'startup banner', () => {
 		expect( e.auth_shape ).toBe( 'bearer-passthrough' );
 		expect( e.allowed_hosts ).toEqual( [ 'wiki.example.org' ] );
 		expect( e.allowed_origins ).toEqual( [ 'https://wiki.example.org' ] );
+		expect( e.max_request_body ).toBe( '2mb' );
 	} );
 
-	it( 'omits allowed_hosts/origins when not provided', () => {
+	it( 'omits allowed_hosts/origins when not provided but always emits max_request_body', () => {
 		emitStartupBanner( {
 			transport: 'http',
-			http: { host: '127.0.0.1', port: 3000 }
+			http: { host: '127.0.0.1', port: 3000, maxRequestBody: '1mb' }
 		} );
 
 		const e = captureLines( stderrSpy ).find( ( x ) => x.event === 'startup' );
@@ -97,6 +100,7 @@ describe( 'startup banner', () => {
 		expect( e!.host ).toBe( '127.0.0.1' );
 		expect( 'allowed_hosts' in e! ).toBe( false );
 		expect( 'allowed_origins' in e! ).toBe( false );
+		expect( e!.max_request_body ).toBe( '1mb' );
 	} );
 
 	it( 'classifies static-credential and never logs the token value', async () => {

--- a/tests/transport/httpConfig.test.ts
+++ b/tests/transport/httpConfig.test.ts
@@ -187,4 +187,94 @@ describe( 'resolveHttpConfig', () => {
 			expect( resolveHttpConfig().allowedOrigins ).toBeUndefined();
 		} );
 	} );
+
+	describe( 'maxRequestBody', () => {
+		it( 'defaults to 1mb when MCP_MAX_REQUEST_BODY is unset', () => {
+			expect( resolveHttpConfig().maxRequestBody ).toBe( '1mb' );
+		} );
+
+		it( 'defaults to 1mb when MCP_MAX_REQUEST_BODY is empty', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '' );
+			expect( resolveHttpConfig().maxRequestBody ).toBe( '1mb' );
+		} );
+
+		it( 'defaults to 1mb when MCP_MAX_REQUEST_BODY is whitespace', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '   ' );
+			expect( resolveHttpConfig().maxRequestBody ).toBe( '1mb' );
+		} );
+
+		it.each( [ '100b', '512kb', '1mb', '2mb', '1.5mb', '1024' ] )(
+			'accepts %s and passes it through',
+			( value ) => {
+				vi.stubEnv( 'MCP_MAX_REQUEST_BODY', value );
+				expect( resolveHttpConfig().maxRequestBody ).toBe( value );
+			}
+		);
+
+		it( 'trims surrounding whitespace from a valid value', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '  2mb  ' );
+			expect( resolveHttpConfig().maxRequestBody ).toBe( '2mb' );
+		} );
+
+		it.each( [ 'potato', '1md', '--', '5 mibibytes' ] )(
+			'falls back to 1mb when MCP_MAX_REQUEST_BODY=%s is malformed',
+			( value ) => {
+				vi.stubEnv( 'MCP_MAX_REQUEST_BODY', value );
+				expect( resolveHttpConfig().maxRequestBody ).toBe( '1mb' );
+			}
+		);
+
+		it.each( [ '0', '0mb', '0kb', '0.0mb' ] )(
+			'falls back to 1mb when MCP_MAX_REQUEST_BODY=%s would reject all requests',
+			( value ) => {
+				vi.stubEnv( 'MCP_MAX_REQUEST_BODY', value );
+				expect( resolveHttpConfig().maxRequestBody ).toBe( '1mb' );
+			}
+		);
+
+		it( 'still passes through fractional sub-1mb values like 0.5mb', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '0.5mb' );
+			expect( resolveHttpConfig().maxRequestBody ).toBe( '0.5mb' );
+		} );
+	} );
+
+	describe( 'warnings', () => {
+		it( 'is empty by default', () => {
+			expect( resolveHttpConfig().warnings ).toEqual( [] );
+		} );
+
+		it( 'is empty for valid MCP_MAX_REQUEST_BODY', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '2mb' );
+			expect( resolveHttpConfig().warnings ).toEqual( [] );
+		} );
+
+		it( 'contains a warning naming the rejected raw value when MCP_MAX_REQUEST_BODY is malformed', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '1md' );
+			const { warnings } = resolveHttpConfig();
+			expect( warnings ).toHaveLength( 1 );
+			expect( warnings[ 0 ] ).toContain( 'MCP_MAX_REQUEST_BODY' );
+			expect( warnings[ 0 ] ).toContain( '1md' );
+			expect( warnings[ 0 ] ).toContain( '1mb' );
+		} );
+
+		it( 'emits a "would reject all requests" warning when MCP_MAX_REQUEST_BODY is zero', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '0' );
+			const { warnings } = resolveHttpConfig();
+			expect( warnings ).toHaveLength( 1 );
+			expect( warnings[ 0 ] ).toContain( 'MCP_MAX_REQUEST_BODY' );
+			expect( warnings[ 0 ] ).toContain( 'would reject all requests' );
+			expect( warnings[ 0 ] ).toContain( '1mb' );
+		} );
+
+		it( 'distinguishes the zero warning from the malformed warning', () => {
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '0mb' );
+			const zeroWarnings = resolveHttpConfig().warnings;
+			vi.unstubAllEnvs();
+			vi.stubEnv( 'MCP_MAX_REQUEST_BODY', '1md' );
+			const malformedWarnings = resolveHttpConfig().warnings;
+			expect( zeroWarnings[ 0 ] ).not.toBe( malformedWarnings[ 0 ] );
+			expect( zeroWarnings[ 0 ] ).toContain( 'would reject' );
+			expect( malformedWarnings[ 0 ] ).toContain( 'not a recognised size' );
+		} );
+	} );
 } );

--- a/tests/transport/httpConfig.test.ts
+++ b/tests/transport/httpConfig.test.ts
@@ -216,7 +216,7 @@ describe( 'resolveHttpConfig', () => {
 			expect( resolveHttpConfig().maxRequestBody ).toBe( '2mb' );
 		} );
 
-		it.each( [ 'potato', '1md', '--', '5 mibibytes' ] )(
+		it.each( [ 'potato', '1md', '--', '5 mibibytes', '.5mb' ] )(
 			'falls back to 1mb when MCP_MAX_REQUEST_BODY=%s is malformed',
 			( value ) => {
 				vi.stubEnv( 'MCP_MAX_REQUEST_BODY', value );

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -44,6 +44,7 @@ import {
 	createSessionRequestHandler,
 	extractBearerToken,
 	hashBearer,
+	payloadTooLargeHandler,
 	resolveMcpHostValidation,
 	type SessionRegistry,
 	verifySessionBearer,
@@ -368,6 +369,61 @@ describe( 'origin validation (transport-level)', () => {
 			.set( 'Accept', 'application/json, text/event-stream' )
 			.send( initializeBody );
 		expect( res.status ).not.toBe( 403 );
+	} );
+} );
+
+describe( 'payloadTooLargeHandler', () => {
+	it( 'sends a JSON-RPC 413 when err.type is entity.too.large', () => {
+		const handler = payloadTooLargeHandler( '1mb' );
+		const next = vi.fn();
+		const tooLargeErr = Object.assign( new Error( 'too large' ), { type: 'entity.too.large' } );
+		const json = vi.fn();
+		const status = vi.fn( () => ( { json } ) );
+		const res = { status };
+		handler(
+			tooLargeErr,
+			{} as never,
+			res as never,
+			next as never
+		);
+		expect( next ).not.toHaveBeenCalled();
+		expect( status ).toHaveBeenCalledWith( 413 );
+		expect( json ).toHaveBeenCalledWith( {
+			jsonrpc: '2.0',
+			error: {
+				code: -32000,
+				message: 'Request body exceeds the configured maximum size of 1mb'
+			},
+			id: null
+		} );
+	} );
+
+	it( 'forwards non-413 errors to the next handler', () => {
+		const handler = payloadTooLargeHandler( '1mb' );
+		const next = vi.fn();
+		const otherErr = new Error( 'unrelated' );
+		const res = { status: vi.fn(), json: vi.fn() };
+		handler(
+			otherErr,
+			{} as never,
+			res as never,
+			next as never
+		);
+		expect( next ).toHaveBeenCalledWith( otherErr );
+		expect( res.status ).not.toHaveBeenCalled();
+		expect( res.json ).not.toHaveBeenCalled();
+	} );
+
+	it( 'forwards a non-error-shaped value (string) to next', () => {
+		const handler = payloadTooLargeHandler( '1mb' );
+		const next = vi.fn();
+		handler(
+			'oops' as never,
+			{} as never,
+			{} as never,
+			next as never
+		);
+		expect( next ).toHaveBeenCalledWith( 'oops' );
 	} );
 } );
 

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -372,6 +372,52 @@ describe( 'origin validation (transport-level)', () => {
 	} );
 } );
 
+describe( 'request body size cap', () => {
+	function buildApp( limit: string ): Express {
+		const app = express();
+		app.use( express.json( { limit } ) );
+		app.use( payloadTooLargeHandler( limit ) );
+		app.post( '/mcp', ( req, res ) => {
+			res.status( 200 ).json( { ok: true, length: JSON.stringify( req.body ).length } );
+		} );
+		return app;
+	}
+
+	function jsonRpcEnvelope( payloadBytes: number ): Record<string, unknown> {
+		return {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'update-page',
+				arguments: { wikitext: 'x'.repeat( payloadBytes ) }
+			}
+		};
+	}
+
+	it( 'accepts a body well under the configured cap', async () => {
+		const res = await request( buildApp( '200kb' ) )
+			.post( '/mcp' )
+			.set( 'Content-Type', 'application/json' )
+			.send( jsonRpcEnvelope( 50 * 1024 ) );
+		expect( res.status ).toBe( 200 );
+		expect( res.body?.ok ).toBe( true );
+	} );
+
+	it( 'returns a JSON-RPC 413 when the body exceeds the configured cap', async () => {
+		const res = await request( buildApp( '50kb' ) )
+			.post( '/mcp' )
+			.set( 'Content-Type', 'application/json' )
+			.send( jsonRpcEnvelope( 200 * 1024 ) );
+		expect( res.status ).toBe( 413 );
+		expect( res.headers[ 'content-type' ] ).toMatch( /application\/json/ );
+		expect( res.body?.jsonrpc ).toBe( '2.0' );
+		expect( res.body?.id ).toBeNull();
+		expect( typeof res.body?.error?.code ).toBe( 'number' );
+		expect( res.body?.error?.message ).toMatch( /50kb/ );
+	} );
+} );
+
 describe( 'payloadTooLargeHandler', () => {
 	it( 'sends a JSON-RPC 413 when err.type is entity.too.large', () => {
 		const handler = payloadTooLargeHandler( '1mb' );


### PR DESCRIPTION
## Summary

Closes #320.

- Adds `MCP_MAX_REQUEST_BODY` env var (default `1mb`, accepts body-parser size strings like `512kb`, `1mb`, `2mb`) and passes it as the explicit `limit` to `express.json()` on the StreamableHTTP transport, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits.
- Installs a JSON-RPC 413 error handler so oversize requests return a parseable JSON-RPC envelope (code `-32000`, `id: null`, message naming the cap) instead of Express's default HTML error page.
- Surfaces the resolved value as `max_request_body` on the `event: "startup"` banner. Emits a `logger.warning` at boot if the env var is malformed (`MCP_MAX_REQUEST_BODY=potato`) or zero-valued (`0mb`) — distinct messages so operators can tell the two failure modes apart.

## Why `1mb`?

Mirrors nginx's default `client_max_body_size 1m` so an operator running a typical reverse-proxied deployment isn't binding tighter or looser than the proxy upstream. Comfortably fits the 100–300 kB long-form wikitext cited in the issue. Operators with content approaching `$wgMaxArticleSize` (MediaWiki default 2 MB), or doing heavy JSON-RPC batching, configure higher via the env var. Picking a tight default for everyone over a generous default for the rare case keeps the per-request DoS surface bounded — raising the default later is non-breaking; lowering it would be.

## Test plan

- [x] CI green (lint + 715 vitest cases + build).
- [x] Spot-check banner field: `MCP_TRANSPORT=http node dist/index.js`, confirm `"max_request_body":"1mb"` on the `event:"startup"` line.
- [x] Spot-check malformed warning: `MCP_MAX_REQUEST_BODY=potato MCP_TRANSPORT=http node dist/index.js`, confirm a `level:"warning"` line above the banner naming the rejected value and the fallback.
- [x] Spot-check over-cap path: POST a >1 MB JSON envelope to `/mcp`, confirm a JSON-RPC 413 with `Content-Type: application/json`, `id: null`, code `-32000`, message containing `1mb`. (Verified locally with `MCP_MAX_REQUEST_BODY=10kb` and a 20 kB payload — same code path, faster turnaround.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)