### PR TITLE
Polish Dockerfile and inclusion lists ahead of GHCR publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Production build context — keep in sync with .mcpbignore and "files" in package.json.
+# This is an allow-list: anything not !-prefixed is excluded from the build context.
+/*
+!/src
+!/package.json
+!/package-lock.json
+!/tsconfig.json
+!/server.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# Production build context — keep in sync with .mcpbignore and "files" in package.json.
+# Production build context — when adding or removing a production-relevant path, review .mcpbignore and "files" in package.json.
 # This is an allow-list: anything not !-prefixed is excluded from the build context.
 /*
 !/src

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,4 +1,5 @@
-# Whitelist: only ship runtime, metadata, README, LICENSE.
+# Production artifact contents — keep in sync with .dockerignore and "files" in package.json.
+# Allow-list: only ship runtime, metadata, README, LICENSE.
 # Mirrors the npm tarball contents (`files` in package.json plus npm's
 # auto-included README and LICENSE).
 /*

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,4 +1,4 @@
-# Production artifact contents — keep in sync with .dockerignore and "files" in package.json.
+# Production artifact contents — when adding or removing a production-relevant path, review .dockerignore and "files" in package.json.
 # Allow-list: only ship runtime, metadata, README, LICENSE.
 # Mirrors the npm tarball contents (`files` in package.json plus npm's
 # auto-included README and LICENSE).

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-README.md
-LICENSE
-!dist/**/*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
 - `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits. Oversize requests return a JSON-RPC 413; the resolved value appears in the startup banner.
 
+### Changed
+
+- Added `.dockerignore`. The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository.
+- Reworked Docker image labels to follow OCI image-spec: dropped the deprecated `maintainer` label and the hand-maintained `image.version`; added `image.title`, `image.url`, `image.source`, `image.licenses`, and a per-build `image.revision` populated from a `GIT_SHA` build arg.
+- The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.
+- `npm version` no longer touches `Dockerfile`. The `image.version` label it used to keep in sync has been removed; `scripts/sync-version.cjs` continues to update `server.json`, `mcpb/manifest.json`, and `gemini-extension.json`.
+
+### Removed
+
+- `.npmignore`. The `files` field in `package.json` already controls npm tarball contents.
+
 ## [0.8.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
-- Added `.dockerignore`. The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository.
+- The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository, configured via a new `.dockerignore`.
 - Reworked Docker image labels to follow OCI image-spec: dropped the deprecated `maintainer` label and the hand-maintained `image.version`; added `image.title`, `image.url`, `image.source`, `image.licenses`, and a per-build `image.revision` populated from a `GIT_SHA` build arg.
 - The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.
 - `npm version` no longer touches `Dockerfile`. The `image.version` label it used to keep in sync has been removed; `scripts/sync-version.cjs` continues to update `server.json`, `mcpb/manifest.json`, and `gemini-extension.json`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@ RUN npm ci && npm run build
 # ----- Production Stage -----
 FROM node:lts-alpine
 
-LABEL maintainer="Professional Wiki"
-LABEL org.opencontainers.image.description="Model Context Protocol (MCP) server for MediaWiki"
-LABEL org.opencontainers.image.version="0.8.0"
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.title="MediaWiki MCP Server" \
+      org.opencontainers.image.description="Model Context Protocol (MCP) server for MediaWiki" \
+      org.opencontainers.image.authors="Professional Wiki" \
+      org.opencontainers.image.url="https://professional.wiki/en/mediawiki-mcp-server" \
+      org.opencontainers.image.source="https://github.com/ProfessionalWiki/MediaWiki-MCP-Server" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${GIT_SHA}"
 
 WORKDIR /app
 
@@ -30,7 +35,7 @@ COPY package.json package-lock.json ./
 COPY server.json ./
 
 # Install only production dependencies
-RUN npm install --production --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts
 
 # Use a non-root user for security
 RUN addgroup -S nodejs \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,9 +79,11 @@ Hosted-use notes:
 Build and run the image locally:
 
 ```bash
-docker build -t mediawiki-mcp-server .
+docker build --build-arg GIT_SHA=$(git rev-parse HEAD) -t mediawiki-mcp-server .
 docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" mediawiki-mcp-server
 ```
+
+The `GIT_SHA` build arg populates the `org.opencontainers.image.revision` label so `docker inspect` reports which commit the image was built from. Omit it for ad-hoc builds; the label defaults to `unknown`.
 
 For public deployments, set both the Host-header and Origin allowlists:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,7 +25,7 @@ npm version 0.2.0
 This command automatically:
 
 - Updates `package.json` and `package-lock.json`
-- Syncs the version in `server.json`, `mcpb/manifest.json`, `gemini-extension.json`, and `Dockerfile` (via the `version` script)
+- Syncs the version in `server.json`, `mcpb/manifest.json`, and `gemini-extension.json` (via the `version` script)
 - Promotes `## [Unreleased]` in `CHANGELOG.md` to `## [<version>] - <today>` and refreshes the link references
 - Creates a git commit
 - Creates a git tag (e.g. `v0.2.0`)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"bundle": "npm run build && node scripts/bundle.cjs",
 		"preversion": "npm run preflight",
-		"version": "node scripts/sync-version.cjs && node scripts/promote-changelog.cjs && git add server.json mcpb/manifest.json gemini-extension.json Dockerfile CHANGELOG.md"
+		"version": "node scripts/sync-version.cjs && node scripts/promote-changelog.cjs && git add server.json mcpb/manifest.json gemini-extension.json CHANGELOG.md"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/constants.cjs
+++ b/scripts/constants.cjs
@@ -14,7 +14,6 @@ module.exports = {
 	SERVER_JSON_PATH: path.join( ROOT_DIR, 'server.json' ),
 	MANIFEST_JSON_PATH: path.join( ROOT_DIR, 'mcpb', MANIFEST_FILE ),
 	GEMINI_EXTENSION_JSON_PATH: path.join( ROOT_DIR, 'gemini-extension.json' ),
-	DOCKERFILE_PATH: path.join( ROOT_DIR, 'Dockerfile' ),
 	CHANGELOG_PATH: path.join( ROOT_DIR, 'CHANGELOG.md' ),
 	MCPB_BUNDLE_PATH: path.join( ROOT_DIR, MCPB_FILE )
 };

--- a/scripts/sync-version.cjs
+++ b/scripts/sync-version.cjs
@@ -6,15 +6,13 @@ const {
 	PACKAGE_JSON_PATH,
 	SERVER_JSON_PATH,
 	MANIFEST_JSON_PATH,
-	GEMINI_EXTENSION_JSON_PATH,
-	DOCKERFILE_PATH
+	GEMINI_EXTENSION_JSON_PATH
 } = require( './constants.cjs' );
 
 const packageJson = JSON.parse( fs.readFileSync( PACKAGE_JSON_PATH, 'utf8' ) );
 const serverJson = JSON.parse( fs.readFileSync( SERVER_JSON_PATH, 'utf8' ) );
 const manifestJson = JSON.parse( fs.readFileSync( MANIFEST_JSON_PATH, 'utf8' ) );
 const geminiExtensionJson = JSON.parse( fs.readFileSync( GEMINI_EXTENSION_JSON_PATH, 'utf8' ) );
-let dockerfile = fs.readFileSync( DOCKERFILE_PATH, 'utf8' );
 
 const version = packageJson.version;
 
@@ -27,14 +25,9 @@ manifestJson.version = version;
 // Update gemini-extension.json
 geminiExtensionJson.version = version;
 
-// Update Dockerfile
-const versionRegex = /(org\.opencontainers\.image\.version=")[^"]*(")/;
-dockerfile = dockerfile.replace( versionRegex, `$1${ version }$2` );
-
 fs.writeFileSync( SERVER_JSON_PATH, JSON.stringify( serverJson, null, 2 ) + '\n' );
 fs.writeFileSync( MANIFEST_JSON_PATH, JSON.stringify( manifestJson, null, 2 ) + '\n' );
 fs.writeFileSync( GEMINI_EXTENSION_JSON_PATH, JSON.stringify( geminiExtensionJson, null, 2 ) + '\n' );
-fs.writeFileSync( DOCKERFILE_PATH, dockerfile );
 
 // Post-write verification: re-read gemini-extension.json and assert the version round-tripped.
 // Protects against silent sync drift (e.g., a future edit that breaks JSON or forgets the field).
@@ -48,4 +41,3 @@ if ( geminiVerify.version !== version ) {
 console.log( `✓ Updated server.json to version ${ version }` );
 console.log( `✓ Updated manifest.json to version ${ version }` );
 console.log( `✓ Updated gemini-extension.json to version ${ version }` );
-console.log( `✓ Updated Dockerfile to version ${ version }` );


### PR DESCRIPTION
Groundwork for #323. Lands the file-shape work so the GHCR publishing PR can focus on CI, signing, attestations, and tag conventions.

## Summary

- Add `.dockerignore` allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`); cross-reference with `.mcpbignore` so future maintainers find both files from either side.
- Rework Dockerfile labels to OCI image-spec: drop deprecated `maintainer` and hand-maintained `image.version`; add `image.title`, `image.url`, `image.source`, `image.licenses`, plus a per-build `image.revision` populated from a `GIT_SHA` build arg (defaults to `unknown`).
- Switch production install from `npm install --production` to `npm ci --omit=dev` so builds fail fast when `package-lock.json` and `package.json` disagree.
- Stop `npm version` from rewriting `Dockerfile`. The `image.version` label `scripts/sync-version.cjs` used to keep in sync is gone, so the script, `scripts/constants.cjs`, the `version` script's `git add` list, and `docs/releasing.md` all drop the Dockerfile reference.
- Delete `.npmignore`. It has been a no-op since `package.json:files` was added 2025-06-03.

## Notes for #323

- The publish workflow should pass `--build-arg GIT_SHA=$GITHUB_SHA` so the published image's `image.revision` is honest. Without it the label falls back to `unknown`.
- `image.version` is intentionally absent from the Dockerfile — the workflow sets it via `--label org.opencontainers.image.version=$VERSION` at publish time, avoiding the drift hazard the hand-maintained label had.
- Base-image digest pinning, multi-arch builds, SBOM, provenance, and cosign signing are all explicitly out of scope here — they belong to #323.

## Test plan

- [x] `docker build --build-arg GIT_SHA=$(git rev-parse HEAD) .` succeeds
- [x] `docker inspect` shows all 7 OCI labels populated; `image.revision` matches `HEAD`; `maintainer` and `image.version` are absent
- [x] Container starts and `/health` returns 200
- [x] Build with no `GIT_SHA` falls back to `revision=unknown`
- [x] `npm version --no-git-tag-version 0.0.0-test` does NOT modify `Dockerfile`
- [x] `npm pack --dry-run` produces the same file list before and after `.npmignore` deletion (empirical proof the file was inert)
- [x] `npm run lint && npm run validate:server-json && npm test && npm run build` clean (715/715 tests pass)
- [x] `git grep -l DOCKERFILE_PATH` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)