### PR TITLE
Publish multi-arch image to GHCR with attestations and signing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,6 +32,12 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/professionalwiki/mediawiki-mcp-server
+          labels: |
+            org.opencontainers.image.title=MediaWiki MCP Server
+            org.opencontainers.image.description=Model Context Protocol (MCP) server for MediaWiki
+            org.opencontainers.image.authors=Professional Wiki
+            org.opencontainers.image.url=https://professional.wiki/en/mediawiki-mcp-server
+            org.opencontainers.image.licenses=MIT
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,59 @@
+name: Publish Image
+
+on:
+  push:
+    tags: ['v*']
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/professionalwiki/mediawiki-mcp-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/master' }}
+
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          sbom: true
+          provenance: mode=max
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@v3
+
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: cosign sign --yes ghcr.io/professionalwiki/mediawiki-mcp-server@${{ steps.build.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -18,18 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/professionalwiki/mediawiki-mcp-server
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=raw,value=edge,enable=${{ github.ref == 'refs/heads/master' }}
 
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -53,7 +53,7 @@ jobs:
           provenance: mode=max
 
       - if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - if: startsWith(github.ref, 'refs/tags/v')
         run: cosign sign --yes ghcr.io/professionalwiki/mediawiki-mcp-server@${{ steps.build.outputs.digest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
 - `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits. Oversize requests return a JSON-RPC 413; the resolved value appears in the startup banner.
+- Published Docker image at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Multi-arch (`linux/amd64`, `linux/arm64`); release builds carry SLSA provenance, SPDX SBOM, and a cosign keyless signature; edge builds (`master` tip) carry attestations only. Tag conventions and verification command in [`docs/deployment.md`](docs/deployment.md).
 
 ### Changed
 
@@ -23,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.
 - `npm version` no longer touches `Dockerfile`. The `image.version` label it used to keep in sync has been removed; `scripts/sync-version.cjs` continues to update `server.json`, `mcpb/manifest.json`, and `gemini-extension.json`.
 - Replaced ESLint and `eslint-config-wikimedia` with oxlint and oxfmt. Coding-style settings live in `.oxlintrc.json` and `.oxfmtrc.json`. Code reformatted to `useTabs: true`, `singleQuote: true`, otherwise oxfmt defaults (trailing commas everywhere, no spaces inside parens or brackets, default print width).
+- Pinned the Dockerfile base image to a specific `node:lts-alpine` digest. Dependabot's new `docker` ecosystem entry tracks digest updates and opens PRs when Alpine/Node publish new images, so base-image patches reach published builds via auditable git history rather than silent rebuilds.
+- The Docker builder stage now installs dependencies with `npm ci --ignore-scripts`, matching the production stage. Stops third-party postinstall scripts from running during the build that the SLSA provenance attestation vouches for.
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ----- Build Stage -----
-FROM node:lts-alpine AS builder
+FROM node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 WORKDIR /app
 
 # Copy package and configuration
@@ -9,10 +9,10 @@ COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src
 
 # Install dependencies and build
-RUN npm ci && npm run build
+RUN npm ci --ignore-scripts && npm run build
 
 # ----- Production Stage -----
-FROM node:lts-alpine
+FROM node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 ARG GIT_SHA=unknown
 LABEL org.opencontainers.image.title="MediaWiki MCP Server" \

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ See the [Gemini CLI extensions documentation](https://github.com/google-gemini/g
 
 ## Deployment
 
-Running the server as a remote HTTP endpoint for other users has its own configuration requirements — see [docs/deployment.md](docs/deployment.md).
+Running the server as a remote HTTP endpoint for other users has its own configuration requirements — see [docs/deployment.md](docs/deployment.md). A pre-built image is published at `ghcr.io/professionalwiki/mediawiki-mcp-server`.
 
 ### Logs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,7 +76,7 @@ Hosted-use notes:
 
 ## Docker
 
-The image is published at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Pull a tagged release:
+The image is published at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Pull and run it:
 
 ```bash
 docker pull ghcr.io/professionalwiki/mediawiki-mcp-server:latest
@@ -86,11 +86,13 @@ docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" \
 
 ### Tag conventions
 
+Each release publishes the following tags (examples shown for `0.8.0`; substitute the release you want):
+
 | Tag | Tracks | Use for |
 |---|---|---|
-| `0.8.0` | One specific patch release | Reproducible builds |
-| `0.8` | Latest patch in the 0.8 minor | Auto-pickup of patch releases |
-| `0` | Latest minor in the 0.x major | Auto-pickup until next major |
+| `0.8.0` | A specific patch release | Reproducible builds |
+| `0.8` | Latest patch in `0.8` | Auto-pickup of patch releases |
+| `0` | Latest release in `0.x` | Auto-pickup until the next major |
 | `latest` | Most recent stable release | Trying it out, dev environments |
 | `edge` | Tip of `master` | Tracking unreleased changes; no stability promise |
 | `@sha256:<digest>` | Immutable digest | **Recommended for production** |
@@ -107,7 +109,7 @@ cosign verify ghcr.io/professionalwiki/mediawiki-mcp-server@<digest> \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-Edge images carry SBOM and SLSA provenance attestations (verifiable with `cosign verify-attestation` or `gh attestation verify`) but are not cosign-signed.
+Edge images are not cosign-signed but still carry SBOM and SLSA provenance attestations. Verify them with `cosign verify-attestation` or `gh attestation verify`.
 
 ### Public deployments
 
@@ -121,7 +123,7 @@ docker run --rm -p 8080:8080 \
   ghcr.io/professionalwiki/mediawiki-mcp-server:latest
 ```
 
-The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` (needed for container port forwarding), runs as a non-root user, and exposes `/health` and `/ready` for orchestration probes.
+The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` — `MCP_BIND` is set so container port forwarding reaches the listener, since `127.0.0.1` (the host-default) is per-netns and unreachable from the bridge network. It runs as a non-root user and exposes `/health` and `/ready` for orchestration probes.
 
 ### Build from source
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,7 +76,56 @@ Hosted-use notes:
 
 ## Docker
 
-Build and run the image locally:
+The image is published at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Pull a tagged release:
+
+```bash
+docker pull ghcr.io/professionalwiki/mediawiki-mcp-server:latest
+docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" \
+  ghcr.io/professionalwiki/mediawiki-mcp-server:latest
+```
+
+### Tag conventions
+
+| Tag | Tracks | Use for |
+|---|---|---|
+| `0.8.0` | One specific patch release | Reproducible builds |
+| `0.8` | Latest patch in the 0.8 minor | Auto-pickup of patch releases |
+| `0` | Latest minor in the 0.x major | Auto-pickup until next major |
+| `latest` | Most recent stable release | Trying it out, dev environments |
+| `edge` | Tip of `master` | Tracking unreleased changes; no stability promise |
+| `@sha256:<digest>` | Immutable digest | **Recommended for production** |
+
+Production deployments should pin to a digest rather than a tag — tags are mutable and a `latest` reference can change underneath you.
+
+### Verify image signature
+
+Release builds (anything with a semver tag) are signed via [cosign](https://github.com/sigstore/cosign) keyless signing using GitHub's OIDC identity. Verify before deploying:
+
+```bash
+cosign verify ghcr.io/professionalwiki/mediawiki-mcp-server@<digest> \
+  --certificate-identity-regexp 'https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/.github/workflows/publish-image.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Edge images carry SBOM and SLSA provenance attestations (verifiable with `cosign verify-attestation` or `gh attestation verify`) but are not cosign-signed.
+
+### Public deployments
+
+Set both the Host-header and Origin allowlists:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e MCP_ALLOWED_HOSTS=wiki.example.org \
+  -e MCP_ALLOWED_ORIGINS=https://wiki.example.org \
+  -v "$(pwd)/config.json:/app/config.json:ro" \
+  ghcr.io/professionalwiki/mediawiki-mcp-server:latest
+```
+
+The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` (needed for container port forwarding), runs as a non-root user, and exposes `/health` and `/ready` for orchestration probes.
+
+### Build from source
+
+For local hacking or to customize the image:
 
 ```bash
 docker build --build-arg GIT_SHA=$(git rev-parse HEAD) -t mediawiki-mcp-server .
@@ -84,18 +133,6 @@ docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" mediawi
 ```
 
 The `GIT_SHA` build arg populates the `org.opencontainers.image.revision` label so `docker inspect` reports which commit the image was built from. Omit it for ad-hoc builds; the label defaults to `unknown`.
-
-For public deployments, set both the Host-header and Origin allowlists:
-
-```bash
-docker run --rm -p 8080:8080 \
-  -e MCP_ALLOWED_HOSTS=wiki.example.org \
-  -e MCP_ALLOWED_ORIGINS=https://wiki.example.org \
-  -v "$(pwd)/config.json:/app/config.json:ro" \
-  mediawiki-mcp-server
-```
-
-The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` (needed for container port forwarding), runs as a non-root user, and exposes `/health` for orchestration probes. No image is published; build from source.
 
 ## Observability
 


### PR DESCRIPTION
Closes #323. Lands the publish workflow plus the supporting Dockerfile hardening, Dependabot config, and deployment docs.

## Summary

- New `.github/workflows/publish-image.yml` builds multi-arch (`linux/amd64`, `linux/arm64`) images and pushes to `ghcr.io/professionalwiki/mediawiki-mcp-server` on `v*` tag push and `master` push, with SBOM + SLSA provenance on every build and cosign keyless signing on release builds only.
- Dockerfile base image pinned to a specific `node:lts-alpine` digest; builder stage `npm ci` gains `--ignore-scripts` (production stage already had it).
- Dependabot gains a `docker` ecosystem entry on the existing weekly cadence so base-image digest updates arrive as reviewed PRs.
- `docs/deployment.md` Docker section restructured around the published image; `README.md` Deployment paragraph points at the GHCR path.
- `metadata-action` gets explicit `labels:` so the published image's `image.url`/`image.title`/`image.description`/`image.authors`/`image.licenses` match the Dockerfile intent (otherwise metadata-action would inject GitHub-derived defaults that override the Dockerfile values).
- All workflow action versions current (qemu/buildx/login v4, metadata v6, build-push v7, cosign-installer v4).

## Notes for #323

- The publish workflow should be exercised by the merge itself: the merge commit is a `master` push, which triggers `publish-image.yml` and produces the first `edge`-tagged image. Verify in the [Actions tab](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/actions) immediately after merge.
- The first published GHCR package will be **private by default**. Visit `github.com/orgs/ProfessionalWiki/packages`, find `mediawiki-mcp-server`, and set visibility to public so external operators can pull.
- The cosign verify command in `docs/deployment.md` hard-codes the workflow filename `publish-image.yml`. If that file is ever renamed, the docs need a synchronised update.
- `image.version` is intentionally absent from the Dockerfile and gets injected by `metadata-action` at publish time from the git tag.
- This PR unblocks #145 (Docker MCP Catalog submission via the "self-provided pre-built image" path).

## Test plan

- [x] `docker build --build-arg GIT_SHA=$(git rev-parse HEAD) .` succeeds end-to-end
- [x] `docker inspect` shows the existing 7 OCI labels with `revision` matching HEAD
- [x] Container starts; `/health` returns 200
- [x] `npm run lint && npm run fmt:check && npm run validate:server-json && npm test && npm run build` clean (715/715 tests)
- [x] `actionlint .github/workflows/publish-image.yml` exits 0
- [x] `npm version --no-git-tag-version 0.0.1-test` does not modify `Dockerfile`
- [ ] **Post-merge:** the merge commit fires `publish-image.yml`, producing the first `edge` image. Set the package's visibility to public.
- [ ] **Next release:** pushing a `v*` tag triggers the full ladder (`<version>`, `<major>.<minor>`, `<major>`, `latest`) and the cosign signing step. Verify by `cosign verify` per `docs/deployment.md`.

## Known minor issues (not blockers)

- The tag-conventions table in `docs/deployment.md` uses `0.8.0`/`0.8`/`0` as concrete examples and will read as stale after the next release. Easy follow-up if reviewers prefer abstract `X.Y.Z` notation.
- `workflow_dispatch` from a branch other than `master` and a non-`v*` ref produces an empty tag set, which fails the build-push step. The dispatch trigger is intended for re-triggering failed runs (which preserve the original ref), so this is acceptable but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)