### PR TITLE
Pin sigstore/cosign-installer to v4.1.1

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -59,7 +59,7 @@ jobs:
           provenance: mode=max
 
       - if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
 
       - if: startsWith(github.ref, 'refs/tags/v')
         run: cosign sign --yes ghcr.io/professionalwiki/mediawiki-mcp-server@${{ steps.build.outputs.digest }}


### PR DESCRIPTION
The first \`edge\` build after #329 merged failed at "Set up job" with:

\`\`\`
##[error]Unable to resolve action \`sigstore/cosign-installer@v4\`, unable to find version \`v4\`
\`\`\`

(Run: https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/actions/runs/25086403406.)

\`sigstore/cosign-installer\` publishes full-version release tags (\`v4.1.1\`, \`v4.1.0\`, ...) but only maintains moving major-version tags up to \`v3\`. So \`@v4\` doesn't resolve. The fix is a one-character change: pin to \`v4.1.1\` instead.

The other six actions in \`publish-image.yml\` (qemu/buildx/login v4, metadata v6, build-push v7, checkout v6) all correctly publish moving major tags and remain pinned to the major. Dependabot's existing \`github-actions\` ecosystem entry will keep the cosign pin current.

## Test plan
- [x] \`actionlint .github/workflows/publish-image.yml\` exits 0
- [x] Diff is one line in one file (no scope creep)
- [ ] **Post-merge:** the merge commit re-fires \`publish-image.yml\` against \`master\` and produces an \`edge\` image. Verify in the [Actions tab](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)