### PR TITLE
Publish provenance to GitHub's Attestations API

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -58,6 +58,11 @@ jobs:
           sbom: true
           provenance: mode=max
 
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/professionalwiki/mediawiki-mcp-server
+          subject-digest: ${{ steps.build.outputs.digest }}
+
       - if: startsWith(github.ref, 'refs/tags/v')
         uses: sigstore/cosign-installer@v4.1.1
 


### PR DESCRIPTION
After #329 + #331 landed, I tested the published \`edge\` image. The cosign-attestation verification path works (attestations are attached to the image manifest as buildx promised), but \`gh attestation verify\` returns HTTP 404 because \`docker/build-push-action\` doesn't push to GitHub's Attestations API on its own — it only attaches to the OCI image manifest.

\`docs/deployment.md\` claims both verification paths work for edge images. This PR makes that claim true.

## Summary
- Add \`actions/attest-build-provenance@v4\` step after the build, publishing a signed SLSA provenance attestation to the GitHub Attestations API.
- Runs on every workflow trigger (edge and release) so the verification story is consistent.
- Edge images remain unsigned at the image level — the step signs the *attestation*, not the image, so the spec's "edge images carry attestations only" is unchanged.
- The action publishes a moving \`v4\` major-tracking tag (unlike \`sigstore/cosign-installer\` from #331), so \`@v4\` resolves correctly.

## Test plan
- [x] \`actionlint .github/workflows/publish-image.yml\` exits 0
- [x] Diff is +5 lines in one file (no scope creep)
- [ ] **Post-merge:** the merge fires the workflow, producing a new \`edge\` image. Verify \`gh attestation verify oci://ghcr.io/professionalwiki/mediawiki-mcp-server:edge --owner ProfessionalWiki\` returns success (it currently returns 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)