### PR TITLE
Upgrade to TypeScript 7 (tsgo) and type-aware oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,11 +5,17 @@
 		"correctness": "error",
 		"suspicious": "warn"
 	},
+	"options": {
+		"typeAware": true
+	},
 	"rules": {
 		"no-new": "off",
 		"no-shadow": "off",
 		"no-underscore-dangle": "off",
 		"preserve-caught-error": "off",
+		"typescript/no-floating-promises": "error",
+		"typescript/no-misused-promises": "error",
+		"typescript/await-thenable": "error",
 		"typescript/no-explicit-any": "warn"
 	},
 	"overrides": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Project context for AI coding agents working on this repo. For human users, star
 - `npm run lint` — oxlint.
 - `npm run fmt` / `npm run fmt:check` — oxfmt (write / dry-run).
 - `npm run preflight` — full gate (install, lint, fmt check, validate `server.json`, test, build, bundle). Run before a release.
-- Git hooks: `lefthook` auto-installs on `npm install`. Pre-commit runs `oxfmt` (auto-fix on staged files) + `oxlint`. Pre-push runs `tsc --noEmit` + the test suite. Bypass with `--no-verify`.
+- Git hooks: `lefthook` auto-installs on `npm install`. Pre-commit runs `oxfmt` (auto-fix on staged files) + `oxlint`. Pre-push runs `tsgo --noEmit` + the test suite. Bypass with `--no-verify`.
 - `npm run inspector` — watch-mode build + MCP Inspector UI for interactive debugging.
 
 ## Tool conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 
 - Build, watch, and type-check now run on `tsgo` (the Go-based TypeScript 7 compiler) via `@typescript/native-preview@beta`. The `typescript` devDependency is aliased to `@typescript/typescript6` so editors continue to load the TypeScript 6 language service. Published packages are unaffected.
+- oxlint now runs type-aware rules via `oxlint-tsgolint`. New `correctness: error` rules catch a class of latent type-aware bugs: unawaited Promises, unbound class methods passed as callbacks, and stringifying objects without a meaningful `toString`. A new `tsconfig.lint.json` extends `tsconfig.json` so lint covers both `src/` and `tests/`; the build still sees only `src/`. The pass also surfaces ~350 non-blocking warnings under `no-unsafe-type-assertion`, `no-unnecessary-type-assertion`, and a few related rules; those are tracked as a separate type-safety cleanup and do not gate CI.
 - The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository, configured via a new `.dockerignore`.
 - Reworked Docker image labels to follow OCI image-spec: dropped the deprecated `maintainer` label and the hand-maintained `image.version`; added `image.title`, `image.url`, `image.source`, `image.licenses`, and a per-build `image.revision` populated from a `GIT_SHA` build arg.
 - The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.
@@ -32,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Removed
 
 - `.npmignore`. The `files` field in `package.json` already controls npm tarball contents.
+
+### Fixed
+
+- Markdown payload formatter no longer renders unrecognised values as the bare `[object Object]` produced by `String()`. `src/results/format.ts` now serialises class instances and other non-plain objects via `JSON.stringify`, falling back to a constructor-name tag when serialisation isn't possible. Surfaced by the type-aware lint pass; previously this was reachable for any payload whose shape strayed from the JSON-only contract the formatter assumed.
+- `scripts/validate-server-json.cjs` no longer leaks an unhandled rejection if the top-level async IIFE throws synchronously. The script now defines an explicit `main()` and attaches a `.catch` that prints the error and sets `process.exitCode = 1`, matching the inner `try/catch` already in place around the schema fetch.
 
 ## [0.8.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
-- Build, watch, and type-check now run on `tsgo` (the Go-based TypeScript 7 compiler) via `@typescript/native-preview@beta`. The `typescript` devDependency is aliased to `@typescript/typescript6` so editors continue to load the TypeScript 6 language service. Published packages are unaffected.
-- oxlint now runs type-aware rules via `oxlint-tsgolint`. New `correctness: error` rules catch a class of latent type-aware bugs: unawaited Promises, unbound class methods passed as callbacks, and stringifying objects without a meaningful `toString`. A new `tsconfig.lint.json` extends `tsconfig.json` so lint covers both `src/` and `tests/`; the build still sees only `src/`. The pass also surfaces ~350 non-blocking warnings under `no-unsafe-type-assertion`, `no-unnecessary-type-assertion`, and a few related rules; those are tracked as a separate type-safety cleanup and do not gate CI.
+- Build, watch, and type-check now run on the TypeScript 7 native compiler. Editors continue to use the TypeScript 6 language service. Published packages are unaffected.
+- Lint now runs type-aware checks and catches a class of bugs that syntactic lint misses: unawaited Promises, unbound class methods used as callbacks, and stringifying objects without a meaningful `toString`. Additional non-blocking warnings on type-assertion smells remain and will be tackled in a follow-up.
 - The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository, configured via a new `.dockerignore`.
 - Reworked Docker image labels to follow OCI image-spec: dropped the deprecated `maintainer` label and the hand-maintained `image.version`; added `image.title`, `image.url`, `image.source`, `image.licenses`, and a per-build `image.revision` populated from a `GIT_SHA` build arg.
 - The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.
@@ -36,8 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- Markdown payload formatter no longer renders unrecognised values as the bare `[object Object]` produced by `String()`. `src/results/format.ts` now serialises class instances and other non-plain objects via `JSON.stringify`, falling back to a constructor-name tag when serialisation isn't possible. Surfaced by the type-aware lint pass; previously this was reachable for any payload whose shape strayed from the JSON-only contract the formatter assumed.
-- `scripts/validate-server-json.cjs` no longer leaks an unhandled rejection if the top-level async IIFE throws synchronously. The script now defines an explicit `main()` and attaches a `.catch` that prints the error and sets `process.exitCode = 1`, matching the inner `try/catch` already in place around the schema fetch.
+- Markdown payload formatter no longer renders class instances and other non-plain objects as the bare `[object Object]`.
+- `scripts/validate-server-json.cjs` now exits with status 1 on validation failure instead of leaving an unhandled rejection.
 
 ## [0.8.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
 - `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits. Oversize requests return a JSON-RPC 413; the resolved value appears in the startup banner.
 - Published Docker image at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Multi-arch (`linux/amd64`, `linux/arm64`); release builds carry SLSA provenance, SPDX SBOM, and a cosign keyless signature; edge builds (`master` tip) carry attestations only. Tag conventions and verification command in [`docs/deployment.md`](docs/deployment.md).
-- Git hooks via lefthook. Installed automatically by `npm install`. Pre-commit auto-formats staged files with oxfmt and verifies oxlint cleanliness; pre-push runs `tsc --noEmit` and the vitest suite. Configured in `lefthook.yml`.
+- Git hooks via lefthook. Installed automatically by `npm install`. Pre-commit auto-formats staged files with oxfmt and verifies oxlint cleanliness; pre-push runs `tsgo --noEmit` and the vitest suite. Configured in `lefthook.yml`.
 
 ### Changed
 
+- Build, watch, and type-check now run on `tsgo` (the Go-based TypeScript 7 compiler) via `@typescript/native-preview@beta`. The `typescript` devDependency is aliased to `@typescript/typescript6` so editors continue to load the TypeScript 6 language service. Published packages are unaffected.
 - The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository, configured via a new `.dockerignore`.
 - Reworked Docker image labels to follow OCI image-spec: dropped the deprecated `maintainer` label and the hand-maintained `image.version`; added `image.title`, `image.url`, `image.source`, `image.licenses`, and a per-build `image.revision` populated from a `GIT_SHA` build arg.
 - The production image now installs dependencies with `npm ci --omit=dev` instead of `npm install --production`. Builds fail if `package-lock.json` and `package.json` are out of sync.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,8 +12,8 @@ pre-commit:
 pre-push:
   parallel: true
   jobs:
-    - name: tsc
-      run: npx tsc --noEmit
+    - name: tsgo
+      run: npx tsgo --noEmit
 
     - name: vitest
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
 				"ajv-formats": "^3.0.1",
 				"concurrently": "^9.1.2",
 				"lefthook": "^2.1.6",
-				"oxfmt": "0.47.0",
-				"oxlint": "1.62.0",
+				"oxfmt": "^0.47.0",
+				"oxlint": "^1.62.0",
 				"supertest": "^7.2.2",
 				"typescript": "^6.0.2",
 				"vitest": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@types/node": "^25.0.2",
 				"@types/node-fetch": "^2.6.12",
 				"@types/supertest": "^7.2.0",
+				"@typescript/native-preview": "beta",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"concurrently": "^9.1.2",
@@ -33,7 +34,7 @@
 				"oxfmt": "^0.47.0",
 				"oxlint": "^1.62.0",
 				"supertest": "^7.2.2",
-				"typescript": "^6.0.2",
+				"typescript": "npm:@typescript/typescript6@^6",
 				"vitest": "^4.1.1"
 			},
 			"engines": {
@@ -59,26 +60,6 @@
 			},
 			"bin": {
 				"mcpb": "dist/cli/cli.js"
-			}
-		},
-		"node_modules/@anthropic-ai/mcpb/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/@anthropic-ai/mcpb/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -183,9 +164,9 @@
 			}
 		},
 		"node_modules/@inquirer/core/node_modules/@types/node": {
-			"version": "22.19.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
-			"integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+			"version": "22.19.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -198,21 +179,6 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/@inquirer/editor": {
 			"version": "3.0.1",
@@ -1275,6 +1241,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1292,6 +1261,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1309,6 +1281,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1326,6 +1301,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1343,6 +1321,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1360,6 +1341,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1465,9 +1449,9 @@
 			}
 		},
 		"node_modules/@types/body-parser": {
-			"version": "1.19.5",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-			"integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1530,9 +1514,9 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-			"integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1553,13 +1537,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
 			"integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/mime": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1595,9 +1572,9 @@
 			}
 		},
 		"node_modules/@types/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1609,13 +1586,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/send": {
-			"version": "0.17.4",
-			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-			"integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/mime": "^1",
 				"@types/node": "*"
 			}
 		},
@@ -1666,6 +1642,123 @@
 			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@typescript/native-preview": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsgo": "bin/tsgo.js"
+			},
+			"optionalDependencies": {
+				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
+				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+			}
+		},
+		"node_modules/@typescript/native-preview-darwin-arm64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@typescript/native-preview-darwin-x64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@typescript/native-preview-linux-arm": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@typescript/native-preview-linux-arm64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@typescript/native-preview-linux-x64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@typescript/native-preview-win32-arm64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@typescript/native-preview-win32-x64": {
+			"version": "7.0.0-dev.20260421.2",
+			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
+			"integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.5",
@@ -1793,27 +1886,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/accepts/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1858,19 +1930,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -1942,9 +2001,9 @@
 			"license": "MIT"
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
-			"integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
@@ -1953,7 +2012,7 @@
 				"http-errors": "^2.0.0",
 				"iconv-lite": "^0.7.0",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
+				"qs": "^6.14.1",
 				"raw-body": "^3.0.1",
 				"type-is": "^2.0.1"
 			},
@@ -2029,6 +2088,18 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -2059,6 +2130,24 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/color-convert": {
@@ -2136,32 +2225,17 @@
 				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
 			}
 		},
-		"node_modules/concurrently/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
 			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/content-disposition": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-			"integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/content-type": {
@@ -2181,9 +2255,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -2206,9 +2280,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cors": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
 			"license": "MIT",
 			"dependencies": {
 				"object-assign": "^4",
@@ -2216,6 +2290,10 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -2352,9 +2430,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2433,9 +2511,9 @@
 			}
 		},
 		"node_modules/eventsource-parser": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
-			"integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
@@ -2495,9 +2573,9 @@
 			}
 		},
 		"node_modules/express-rate-limit": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-			"integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+			"integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
 			"license": "MIT",
 			"dependencies": {
 				"ip-address": "10.1.0"
@@ -2510,27 +2588,6 @@
 			},
 			"peerDependencies": {
 				"express": ">= 4.11"
-			}
-		},
-		"node_modules/express/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/express/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/external-editor": {
@@ -2639,9 +2696,9 @@
 			"license": "MIT"
 		},
 		"node_modules/finalhandler": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-			"integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.0",
@@ -2652,7 +2709,11 @@
 				"statuses": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/flora-colossus": {
@@ -2703,6 +2764,27 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/formdata-polyfill": {
@@ -2766,16 +2848,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/fs-extra/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/fsevents": {
@@ -2920,9 +2992,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -2932,9 +3004,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.14",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+			"version": "4.12.15",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+			"integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -2961,9 +3033,9 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-			"integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2974,6 +3046,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/inherits": {
@@ -3023,9 +3105,9 @@
 			"license": "ISC"
 		},
 		"node_modules/jose": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -3044,9 +3126,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3054,16 +3136,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/jsonfile/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/lefthook": {
@@ -3372,6 +3444,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3393,6 +3468,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3414,6 +3492,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3435,6 +3516,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3554,24 +3638,28 @@
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.52.0"
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/ms": {
@@ -3591,9 +3679,9 @@
 			}
 		},
 		"node_modules/mwn": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mwn/-/mwn-3.0.1.tgz",
-			"integrity": "sha512-FuANXsGtDbkRYd4c2we7veVasX6eicCIzX/bKS7mrR/3c1FlPDZKSsSSIuDhWOx008OCoTFyL8j4ayekx0rvyQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mwn/-/mwn-3.0.2.tgz",
+			"integrity": "sha512-EEwsR6L4sIp1s87t4CrLR2I+r4Cp2khBvuGhBXvzJCjYmC1NGRp24X8B05Gcu2rXmqnqgHEcjrbdi0Z3dccITQ==",
 			"license": "LGPL-3.0-or-later",
 			"dependencies": {
 				"@types/node": "^14.18.63",
@@ -3901,9 +3989,9 @@
 			}
 		},
 		"node_modules/pkce-challenge": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
@@ -4146,26 +4234,6 @@
 				"tslib": "^2.1.0"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4173,52 +4241,35 @@
 			"license": "MIT"
 		},
 		"node_modules/send": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-			"integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.5",
+				"debug": "^4.4.3",
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
 				"etag": "^1.8.1",
 				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"mime-types": "^3.0.1",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
 				"ms": "^2.1.3",
 				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
-				"statuses": "^2.0.1"
+				"statuses": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/send/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/send/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
 			},
-			"engines": {
-				"node": ">= 0.6"
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-			"integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
 			"license": "MIT",
 			"dependencies": {
 				"encodeurl": "^2.0.0",
@@ -4228,6 +4279,10 @@
 			},
 			"engines": {
 				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -4290,13 +4345,13 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4389,9 +4444,9 @@
 			}
 		},
 		"node_modules/std-env": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-			"integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4460,15 +4515,19 @@
 			}
 		},
 		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/tdigest": {
@@ -4488,9 +4547,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+			"integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4571,6 +4630,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4588,6 +4656,19 @@
 			"dev": true,
 			"license": "0BSD"
 		},
+		"node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/type-is": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -4602,31 +4683,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/type-is/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/type-is/node_modules/mime-types": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
 		"node_modules/types-mediawiki-api": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/types-mediawiki-api/-/types-mediawiki-api-2.0.0.tgz",
@@ -4634,17 +4690,17 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"name": "@typescript/typescript6",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.1.tgz",
+			"integrity": "sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+			"dependencies": {
+				"typescript": "^6"
 			},
-			"engines": {
-				"node": ">=14.17"
+			"bin": {
+				"tsc6": "bin/tsc6"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4655,12 +4711,13 @@
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/unpipe": {
@@ -4901,9 +4958,9 @@
 			}
 		},
 		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4912,10 +4969,7 @@
 				"strip-ansi": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/wrappy": {
@@ -4977,21 +5031,21 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.1.13",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-			"integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zod-to-json-schema": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
 			"license": "ISC",
 			"peerDependencies": {
-				"zod": "^3.25 || ^4"
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"lefthook": "^2.1.6",
 				"oxfmt": "^0.47.0",
 				"oxlint": "^1.62.0",
+				"oxlint-tsgolint": "^0.22.1",
 				"supertest": "^7.2.2",
 				"typescript": "npm:@typescript/typescript6@^6",
 				"vitest": "^4.1.1"
@@ -790,6 +791,90 @@
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			}
+		},
+		"node_modules/@oxlint-tsgolint/darwin-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.22.1.tgz",
+			"integrity": "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxlint-tsgolint/darwin-x64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.22.1.tgz",
+			"integrity": "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxlint-tsgolint/linux-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.22.1.tgz",
+			"integrity": "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint-tsgolint/linux-x64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.22.1.tgz",
+			"integrity": "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint-tsgolint/win32-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.22.1.tgz",
+			"integrity": "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxlint-tsgolint/win32-x64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.22.1.tgz",
+			"integrity": "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@oxlint/binding-android-arm-eabi": {
 			"version": "1.62.0",
@@ -3931,6 +4016,24 @@
 				"oxlint-tsgolint": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/oxlint-tsgolint": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.22.1.tgz",
+			"integrity": "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tsgolint": "bin/tsgolint.js"
+			},
+			"optionalDependencies": {
+				"@oxlint-tsgolint/darwin-arm64": "0.22.1",
+				"@oxlint-tsgolint/darwin-x64": "0.22.1",
+				"@oxlint-tsgolint/linux-arm64": "0.22.1",
+				"@oxlint-tsgolint/linux-x64": "0.22.1",
+				"@oxlint-tsgolint/win32-arm64": "0.22.1",
+				"@oxlint-tsgolint/win32-x64": "0.22.1"
 			}
 		},
 		"node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
 	"scripts": {
 		"start": "node dist/index.js",
 		"start:http": "MCP_TRANSPORT=http node dist/index.js",
-		"dev": "tsc --watch",
-		"build": "tsc",
+		"dev": "tsgo --watch",
+		"build": "tsgo",
 		"fmt": "oxfmt src tests scripts",
 		"fmt:check": "oxfmt --check src tests scripts",
 		"test": "vitest run",
@@ -52,9 +52,9 @@
 		"validate:server-json": "node scripts/validate-server-json.cjs",
 		"preflight": "npm ci && npm run lint && npm run fmt:check && npm run validate:server-json && npm run test && npm run build && npm run bundle -- --clean",
 		"prepare": "lefthook install",
-		"inspector": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
-		"inspector:http": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
-		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
+		"inspector": "concurrently --kill-others \"tsgo --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
+		"inspector:http": "concurrently --kill-others \"tsgo --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
+		"mcpjam": "concurrently --kill-others \"tsgo --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"bundle": "npm run build && node scripts/bundle.cjs",
 		"preversion": "npm run preflight",
 		"version": "node scripts/sync-version.cjs && node scripts/promote-changelog.cjs && git add server.json mcpb/manifest.json gemini-extension.json CHANGELOG.md"
@@ -74,6 +74,7 @@
 		"@types/node": "^25.0.2",
 		"@types/node-fetch": "^2.6.12",
 		"@types/supertest": "^7.2.0",
+		"@typescript/native-preview": "beta",
 		"ajv": "^8.17.1",
 		"ajv-formats": "^3.0.1",
 		"concurrently": "^9.1.2",
@@ -81,7 +82,7 @@
 		"oxfmt": "^0.47.0",
 		"oxlint": "^1.62.0",
 		"supertest": "^7.2.2",
-		"typescript": "^6.0.2",
+		"typescript": "npm:@typescript/typescript6@^6",
 		"vitest": "^4.1.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
 		"ajv-formats": "^3.0.1",
 		"concurrently": "^9.1.2",
 		"lefthook": "^2.1.6",
-		"oxfmt": "0.47.0",
-		"oxlint": "1.62.0",
+		"oxfmt": "^0.47.0",
+		"oxlint": "^1.62.0",
 		"supertest": "^7.2.2",
 		"typescript": "^6.0.2",
 		"vitest": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"fmt:check": "oxfmt --check src tests scripts",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"lint": "oxlint",
+		"lint": "oxlint --tsconfig=./tsconfig.lint.json",
 		"validate:server-json": "node scripts/validate-server-json.cjs",
 		"preflight": "npm ci && npm run lint && npm run fmt:check && npm run validate:server-json && npm run test && npm run build && npm run bundle -- --clean",
 		"prepare": "lefthook install",
@@ -81,6 +81,7 @@
 		"lefthook": "^2.1.6",
 		"oxfmt": "^0.47.0",
 		"oxlint": "^1.62.0",
+		"oxlint-tsgolint": "^0.22.1",
 		"supertest": "^7.2.2",
 		"typescript": "npm:@typescript/typescript6@^6",
 		"vitest": "^4.1.1"

--- a/scripts/validate-server-json.cjs
+++ b/scripts/validate-server-json.cjs
@@ -6,7 +6,7 @@ const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
 const { SERVER_JSON_PATH } = require('./constants.cjs');
 
-(async () => {
+async function main() {
 	console.log('\nValidating server.json...');
 	const serverJson = JSON.parse(fs.readFileSync(SERVER_JSON_PATH, 'utf8'));
 
@@ -42,4 +42,9 @@ const { SERVER_JSON_PATH } = require('./constants.cjs');
 		console.error(`Error validating server.json: ${e.message}`);
 		process.exitCode = 1;
 	}
-})();
+}
+
+main().catch((err) => {
+	console.error(`Unexpected error validating server.json: ${err?.message ?? err}`);
+	process.exitCode = 1;
+});

--- a/src/results/format.ts
+++ b/src/results/format.ts
@@ -75,7 +75,7 @@ function renderValue(value: unknown, indent: string): string {
 	if (isPlainObject(value)) {
 		return renderObject(value, indent);
 	}
-	return String(value);
+	return stringifyUnknown(value);
 }
 
 function renderObject(obj: Record<string, unknown>, indent: string): string {
@@ -112,7 +112,7 @@ function renderField(label: string, value: unknown, indent: string): string {
 	if (isPlainObject(value)) {
 		return `${prefix}\n${renderObject(value, indent + '  ')}`;
 	}
-	return `${prefix} ${String(value)}`;
+	return `${prefix} ${stringifyUnknown(value)}`;
 }
 
 function renderArray(arr: unknown[], indent: string): string {
@@ -146,7 +146,30 @@ function renderArray(arr: unknown[], indent: string): string {
 					: first;
 				return [`${itemIndent}${firstStripped}`, ...rest].join('\n');
 			}
-			return `${itemIndent}${String(item)}`;
+			return `${itemIndent}${stringifyUnknown(item)}`;
 		})
 		.join('\n');
+}
+
+// Last-resort renderer for values that are not null/undefined/string/number/
+// boolean/array/plain-object — typically class instances or other exotic
+// shapes that slip into a payload typed as `unknown`. JSON.stringify avoids
+// the bare `[object Object]` that `String()` would produce; if the value
+// still can't be serialised (e.g., a circular reference or a BigInt), fall
+// back to its constructor name so the output stays diagnostic rather than
+// throwing or printing nothing useful.
+function stringifyUnknown(value: unknown): string {
+	try {
+		const json = JSON.stringify(value);
+		if (json !== undefined) {
+			return json;
+		}
+	} catch {
+		// fall through to constructor-name fallback
+	}
+	const ctor =
+		typeof value === 'object' && value !== null
+			? (value.constructor?.name ?? 'Object')
+			: typeof value;
+	return `[${ctor}]`;
 }

--- a/tests/results/format.test.ts
+++ b/tests/results/format.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatPayload } from '../../src/results/format.js';
+
+describe('formatPayload unknown values', () => {
+	it('does not emit bare [object Object] for class instances', () => {
+		class Sample {
+			value = 1;
+		}
+		const result = formatPayload({ sample: new Sample() });
+		expect(result).not.toContain('[object Object]');
+	});
+});

--- a/tests/runtime/createContext.test.ts
+++ b/tests/runtime/createContext.test.ts
@@ -10,7 +10,7 @@ describe('createToolContext', () => {
 		expect(ctx.selection).toBeDefined();
 		expect(ctx.uploadDirs).toBeDefined();
 		expect(ctx.wikiCache).toBeDefined();
-		expect(ctx.wikiCache.invalidate).toBeTypeOf('function');
+		expect(typeof ctx.wikiCache.invalidate).toBe('function');
 		expect(ctx.sections).toBeDefined();
 		expect(ctx.edit).toBeDefined();
 		expect(ctx.revision).toBeDefined();

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -76,11 +76,14 @@ function setup({
 	wikis: Record<string, WikiConfig>;
 	allowManagement: boolean;
 }): void {
+	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 	vi.mocked(wikiSelection.getCurrent).mockReturnValue({
 		key: Object.keys(wikis).find((k) => wikis[k] === activeWiki) ?? 'a',
 		config: activeWiki,
 	});
+	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 	vi.mocked(wikiRegistry.getAll).mockReturnValue(wikis);
+	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 	vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(allowManagement);
 }
 

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -109,6 +109,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('lists add-wiki and remove-wiki when wiki management is allowed', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
 		const { client } = await connectClientAndServer();
 
@@ -121,6 +122,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('omits add-wiki and remove-wiki but keeps set-wiki when management is disallowed and 2+ wikis are configured', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
 		const { client } = await connectClientAndServer();
 
@@ -134,6 +136,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('hides set-wiki, add-wiki, and remove-wiki on the hosted single-wiki shape (1 wiki + management disallowed)', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
 		const originalByKey = wikiStore.byKey;
 		wikiStore.byKey = { a: wikiA };
@@ -153,6 +156,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('rejects calls to add-wiki with a disabled error when wiki management is disallowed', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
 		const { client } = await connectClientAndServer();
 
@@ -167,6 +171,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('shows set-wiki and remove-wiki when 2 wikis are configured and management is allowed', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
 		const { client } = await connectClientAndServer();
 
@@ -177,6 +182,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('hides set-wiki and remove-wiki when only 1 wiki is configured and management is allowed', async () => {
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
 		const originalByKey = wikiStore.byKey;
 		wikiStore.byKey = { a: wikiA };
@@ -196,6 +202,7 @@ describe('registerAllTools — wiki management gating', () => {
 describe('registerAllTools — per-wiki readOnly', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
 		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
 		wikiStore.current = wikiA;
 	});

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noEmit": true
+	},
+	"include": [ "src/**/*", "tests/**/*" ],
+	"exclude": [ "node_modules", "dist" ]
+}


### PR DESCRIPTION
## Summary

- Swap `tsc` to `tsgo` (the Go-based TypeScript 7 compiler) via `@typescript/native-preview@beta`. The `typescript` devDep stays installed under the `@typescript/typescript6` alias so editors keep their TypeScript 6 language service.
- Enable type-aware oxlint via `oxlint-tsgolint`. The new type-aware pass surfaced 15 errors and ~350 warnings against the existing `correctness: error` / `suspicious: warn` categories.
- Fix all 15 errors with intent-bearing changes (named `main()` + `.catch`, `stringifyUnknown()` helper, per-line disables for vitest-mocked references). The ~350 warnings (mostly `no-unsafe-type-assertion`) are out of scope and tracked as a follow-up.
- Resolves the type-aware lint deferral that landed alongside the oxc-toolchain migration in #328.

## Commits

- `6063689` — Relax oxc dev-dep version ranges
- `8d83cb7` — Swap tsc to tsgo for build, watch, and type-check
- `078b41d` — Wire type-aware oxlint via oxlint-tsgolint
- `27cd88d` — Fix type-aware lint findings surfaced by oxlint-tsgolint
- `333b32b` — Clean up CHANGELOG copy

## Benchmarks

Wall-clock (median of 3 runs) on this dev host. Captured 2026-04-29 on Node v22.16.0, Linux WSL2 x86_64.

| Step                | Before (tsc)  | After (tsgo)  | Delta            |
| ------------------- | ------------- | ------------- | ---------------- |
| `npm run build`     | 2.33s         | 0.70s         | -1.63s (~3.3x)   |
| `npm run lint`      | 0.23s         | 1.01s         | +0.78s (type-aware pass) |
| Type-check (`--noEmit`) | 2.14s     | 0.69s         | -1.45s (~3.1x)   |
| `npm test`          | 3.04s         | 3.73s         | +0.69s (vitest type-aware) |

Build and type-check are roughly 3x faster. Lint is slower but now includes the type-aware pass that previously didn't exist; net pre-push hook (`tsgo --noEmit` + vitest) is comparable to the old (`tsc --noEmit` + vitest) pair while gaining type-aware coverage.

## Findings audit

The type-aware pass surfaced:

- 1 x `no-floating-promises` (fixed in `scripts/validate-server-json.cjs`)
- 3 x `no-base-to-string` (fixed in `src/results/format.ts` via new `stringifyUnknown()`)
- 11 x `unbound-method` in test files (10 are vitest-mock false positives, suppressed inline with one-line rationales; 1 was a real method probe rewritten to `typeof`)
- ~350 warnings (`no-unsafe-type-assertion`, `no-unnecessary-type-assertion`, etc.) — out of scope for this PR

## Test plan

- [x] `npm ci && npm run lint && npm run fmt:check && npm test && npm run build` from a clean clone
- [x] `docker build .` succeeds
- [x] Pre-push hook runs `tsgo --noEmit` and exits 0
- [x] Editor (VS Code or equivalent) shows TypeScript 6 language service active against the alias