### PR TITLE
Resolve type-aware lint warnings deferred from TypeScript 7 upgrade

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,6 +23,13 @@
 			"files": ["scripts/**"],
 			"rules": {
 			}
+		},
+		{
+			"files": ["tests/**"],
+			"rules": {
+				"typescript/no-unsafe-type-assertion": "off",
+				"typescript/no-unnecessary-type-assertion": "off"
+			}
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
+- Resolved the type-aware lint warnings deferred from the TypeScript 7 upgrade. Tests are no longer subject to the type-assertion rules, and source code is tightened to satisfy them. Published packages are unaffected.
 - Build, watch, and type-check now run on the TypeScript 7 native compiler. Editors continue to use the TypeScript 6 language service. Published packages are unaffected.
 - Lint now runs type-aware checks and catches a class of bugs that syntactic lint misses: unawaited Promises, unbound class methods used as callbacks, and stringifying objects without a meaningful `toString`. Additional non-blocking warnings on type-assertion smells remain and will be tackled in a follow-up.
 - The Docker build context is now an allow-list (`src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `server.json`) instead of the entire repository, configured via a new `.dockerignore`.

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
 import { logger } from '../runtime/logger.js';
+import { isErrnoException, errorMessage } from '../errors/isErrnoException.js';
 
 export interface WikiConfig {
 	/**
@@ -193,28 +194,26 @@ function runExec(raw: unknown, wikiKey: string, fieldName: SecretFieldName): str
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 	} catch (err: unknown) {
-		const e = err as NodeJS.ErrnoException & {
-			signal?: string;
-			status?: number | null;
-			stderr?: Buffer | string;
-		};
-		if (e.code === 'ENOENT') {
+		if (!isErrnoException(err)) {
+			throw err;
+		}
+		if (err.code === 'ENOENT') {
 			throw new Error(`Config error: failed to fetch ${path}: command "${command}" not found`);
 		}
-		if (e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT') {
+		if (err.signal === 'SIGTERM' || err.code === 'ETIMEDOUT') {
 			throw new Error(
 				`Config error: failed to fetch ${path}: command "${command}" timed out after 10s`,
 			);
 		}
-		if (typeof e.status === 'number' && e.status !== 0) {
-			const stderrText = e.stderr
-				? (Buffer.isBuffer(e.stderr) ? e.stderr.toString('utf-8') : e.stderr).slice(0, 200)
+		if (typeof err.status === 'number' && err.status !== 0) {
+			const stderrText = err.stderr
+				? (Buffer.isBuffer(err.stderr) ? err.stderr.toString('utf-8') : err.stderr).slice(0, 200)
 				: '';
 			throw new Error(
-				`Config error: failed to fetch ${path}: command "${command}" exited with status ${e.status}. stderr: ${stderrText}`,
+				`Config error: failed to fetch ${path}: command "${command}" exited with status ${err.status}. stderr: ${stderrText}`,
 			);
 		}
-		throw new Error(`Config error: failed to fetch ${path}: ${e.message ?? 'unknown error'}`);
+		throw new Error(`Config error: failed to fetch ${path}: ${err.message}`);
 	}
 
 	const trimmed = stdout.replace(/\r?\n+$/, '');
@@ -264,7 +263,7 @@ function resolveUploadDirs(rawFromConfig: unknown): readonly string[] {
 			canonical = fs.realpathSync(raw);
 		} catch (err) {
 			throw new Error(
-				`Config error: upload directory "${raw}" cannot be resolved (${(err as Error).message}). Ensure the directory exists before starting the server.`,
+				`Config error: upload directory "${raw}" cannot be resolved (${errorMessage(err)}). Ensure the directory exists before starting the server.`,
 			);
 		}
 		if (!canonicalised.includes(canonical)) {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -277,6 +277,7 @@ function resolveWiki(raw: unknown, wikiKey: string): WikiConfig {
 	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
 		throw new Error(`Config error: wikis.${wikiKey} must be an object`);
 	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
 	const src = raw as Record<string, unknown>;
 	const resolved: Record<string, unknown> = {};
 	for (const [fieldKey, fieldValue] of Object.entries(src)) {
@@ -289,6 +290,7 @@ function resolveWiki(raw: unknown, wikiKey: string): WikiConfig {
 	if (resolved.readOnly !== undefined && typeof resolved.readOnly !== 'boolean') {
 		throw new Error(`Config error: wikis.${wikiKey}.readOnly must be a boolean`);
 	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
 	return resolved as unknown as WikiConfig;
 }
 
@@ -296,6 +298,7 @@ function resolveConfig(parsed: unknown): Config {
 	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
 		throw new Error('Config error: config.json must be an object');
 	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
 	const p = parsed as Record<string, unknown>;
 	const defaultWiki = typeof p.defaultWiki === 'string' ? replaceEnvVars(p.defaultWiki) : '';
 	const allowWikiManagement =

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -183,7 +183,7 @@ function runExec(raw: unknown, wikiKey: string, fieldName: SecretFieldName): str
 		throw new Error(`Config error: ${path}.exec.args must be an array of strings`);
 	}
 	const command = exec.command;
-	const args = (exec.args as string[] | undefined) ?? [];
+	const args = exec.args ?? [];
 
 	let stdout: string;
 	try {

--- a/src/errors/isErrnoException.ts
+++ b/src/errors/isErrnoException.ts
@@ -1,0 +1,22 @@
+type ErrnoLike = NodeJS.ErrnoException & {
+	signal?: string;
+	status?: number | null;
+	stderr?: Buffer | string;
+};
+
+/**
+ * Type predicate that narrows an unknown caught value to ErrnoLike.
+ *
+ * Body checks `err instanceof Error` only — the optional Errno fields
+ * (`code`, `signal`, `status`, `stderr`) are NOT verified at runtime.
+ * Callers should use equality checks (e.g. `if (err.code === 'ENOENT')`)
+ * rather than truthiness, since a plain `new Error('x')` passes this
+ * predicate and `err.code` will be `undefined`.
+ */
+export function isErrnoException(err: unknown): err is ErrnoLike {
+	return err instanceof Error;
+}
+
+export function errorMessage(err: unknown, fallback = 'Unknown error'): string {
+	return err instanceof Error ? err.message : fallback;
+}

--- a/src/errors/specialCases.ts
+++ b/src/errors/specialCases.ts
@@ -1,4 +1,5 @@
 import type { ErrorCategory } from './classifyError.js';
+import { errorMessage } from './isErrnoException.js';
 
 export interface SpecialCaseResult {
 	category: ErrorCategory;
@@ -34,7 +35,7 @@ const overrides: Record<string, Override> = {
 		if (!appliesTo('nosuchsection', toolName)) {
 			return null;
 		}
-		const msg = (err as Error).message ?? '';
+		const msg = errorMessage(err, '');
 		const sectionMatch = pickFromMessage(msg, /section[^\d]*(\d+)/i);
 		const label = sectionMatch ?? 'unknown';
 		return {
@@ -47,7 +48,7 @@ const overrides: Record<string, Override> = {
 		if (!appliesTo('nosuchrevid', toolName)) {
 			return null;
 		}
-		const msg = (err as Error).message ?? '';
+		const msg = errorMessage(err, '');
 		const idMatch = pickFromMessage(msg, /\b(\d+)\b/);
 		return {
 			category: 'not_found',
@@ -59,7 +60,7 @@ const overrides: Record<string, Override> = {
 		if (!appliesTo('missingtitle', toolName)) {
 			return null;
 		}
-		const msg = (err as Error).message ?? '';
+		const msg = errorMessage(err, '');
 		const titleMatch = pickFromMessage(msg, /["'`]([^"'`]+)["'`]/);
 		return {
 			category: 'not_found',
@@ -74,7 +75,7 @@ export function applySpecialCase(
 	classified: { category: ErrorCategory; code?: string },
 	err: unknown,
 ): { category: ErrorCategory; code: string | undefined; message: string } {
-	const defaultMessage = (err as Error).message ?? 'Unknown error';
+	const defaultMessage = errorMessage(err);
 	if (classified.code && overrides[classified.code]) {
 		const result = overrides[classified.code](err, { toolName, defaultMessage });
 		if (result) {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -58,6 +58,7 @@ export function registerAllResources(server: McpServer, ctx: ToolContext): void 
 	});
 
 	server.resource('wikis', resourceTemplate, async (uri, variables) => {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- MCP ResourceTemplate variables typed as string|string[]; URI template guarantees a single string
 		const wikiKey = variables.wikiKey as string;
 		const wikiConfig = ctx.wikis.get(wikiKey);
 

--- a/src/results/response.ts
+++ b/src/results/response.ts
@@ -14,11 +14,12 @@ export interface ResponseFormatter {
 	truncationMarker(info: TruncationInfo): string;
 }
 
-export function structuredResult<T>(data: T): CallToolResult {
+export function structuredResult(data: unknown): CallToolResult {
 	return {
 		content: [{ type: 'text', text: formatPayload(data) } as TextContent],
 		// structuredContent mirrors the typed payload so the dispatcher can detect
 		// truncation via the `truncation` field without reparsing the rendered text.
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- MCP structuredContent shape; constructed from typed inputs
 		structuredContent: data as Record<string, unknown>,
 	};
 }
@@ -78,6 +79,10 @@ export class ResponseFormatterImpl implements ResponseFormatter {
 				return `More results available. Returned ${info.returnedCount} ${info.itemNoun}. To fetch the next segment, call ${info.toolName} again with ${info.continueWith.param}=${info.continueWith.value}.`;
 			case 'capped-no-continuation':
 				return `Result capped at ${info.limit} ${info.itemNoun}. Additional ${info.itemNoun} may exist — ${info.narrowHint}`;
+			default: {
+				const _exhaustive: never = info;
+				return _exhaustive;
+			}
 		}
 	}
 }

--- a/src/runtime/banner.ts
+++ b/src/runtime/banner.ts
@@ -4,6 +4,7 @@ import { classifyAuthShape } from '../transport/bearerGuard.js';
 import { wikiRegistry, wikiSelection, uploadDirs } from '../wikis/state.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- compile-time JSON import; ESM `import ... assert { type: 'json' }` migration is a separate follow-up
 const serverInfo = createRequire(import.meta.url)('../../server.json') as {
 	title: string;
 	description: string;

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 export const WIKI_RESOURCE_URI_PREFIX = 'mcp://wikis/';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- compile-time JSON import; ESM `import ... assert { type: 'json' }` migration is a separate follow-up
 const serverInfo = createRequire(import.meta.url)('../../server.json') as {
 	version: string;
 };

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -26,7 +26,11 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 		try {
 			result = await tool.handle(args, ctx);
 			if (result.isError) {
-				const text = (result.content[0] as { text?: string } | undefined)?.text;
+				const first = result.content[0];
+				const text =
+					first !== undefined && 'text' in first && typeof first.text === 'string'
+						? first.text
+						: undefined;
 				const env = parseEnvelope(text);
 				// Fall back to upstream_failure when the envelope is missing or
 				// unparseable rather than letting outcome stay 'success' — that

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from './tool.js';
 import type { ToolContext } from './context.js';
 import { applySpecialCase } from '../errors/specialCases.js';
+import { errorMessage } from '../errors/isErrnoException.js';
 import { getRuntimeToken, getSessionId } from '../transport/requestContext.js';
 import {
 	emitToolCall,
@@ -18,7 +19,7 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 	return async (args) => {
 		const started = performance.now();
 		let outcome: ToolOutcome = 'success';
-		let errorMessage: string | undefined;
+		let errorText: string | undefined;
 		let upstreamStatus: number | undefined;
 		let result: CallToolResult;
 
@@ -33,7 +34,7 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 				// that's flagged as an error.
 				outcome = env.category ?? 'upstream_failure';
 				if (env.message) {
-					errorMessage = env.message;
+					errorText = env.message;
 				}
 			}
 		} catch (err) {
@@ -46,13 +47,13 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 			// If a special case produced a tailored message (e.g. "Section X does not exist"),
 			// use it verbatim. Otherwise prepend the standard "Failed to <verb>: " prefix to
 			// the raw error message — matching today's per-tool conventions.
-			const rawMessage = (err as Error).message ?? 'Unknown error';
+			const rawMessage = errorMessage(err);
 			const tailored = overridden.message !== rawMessage;
 			const verb = tool.failureVerb ?? tool.name;
 			const finalMessage = tailored
 				? overridden.message
 				: `Failed to ${verb}: ${overridden.message}`;
-			errorMessage = finalMessage;
+			errorText = finalMessage;
 
 			ctx.logger.error('Tool failed', {
 				tool: tool.name,
@@ -70,7 +71,7 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 			result,
 			outcome,
 			upstreamStatus,
-			errorMessage,
+			errorMessage: errorText,
 			runtimeToken: getRuntimeToken(),
 			sessionId: getSessionId(),
 			wikiKey: ctx.selection.getCurrent().key,

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -38,14 +38,34 @@ export interface ParsedEnvelope {
 	message?: string;
 }
 
+/**
+ * Narrows an unknown JSON value to a ParsedEnvelope. Both fields are
+ * optional, so the predicate verifies "object shape with compatibly-typed
+ * fields if present" rather than enforcing any required key. Unknown
+ * `category` strings still pass through; downstream callers compare them
+ * against the ErrorCategory union and ignore mismatches.
+ */
+function isParsedEnvelope(obj: unknown): obj is ParsedEnvelope {
+	if (obj === null || typeof obj !== 'object') {
+		return false;
+	}
+	if ('category' in obj && obj.category !== undefined && typeof obj.category !== 'string') {
+		return false;
+	}
+	if ('message' in obj && obj.message !== undefined && typeof obj.message !== 'string') {
+		return false;
+	}
+	return true;
+}
+
 export function parseEnvelope(text: string | undefined): ParsedEnvelope {
 	if (!text) {
 		return {};
 	}
 	try {
-		const obj = JSON.parse(text);
-		if (obj && typeof obj === 'object') {
-			return obj as ParsedEnvelope;
+		const obj: unknown = JSON.parse(text);
+		if (isParsedEnvelope(obj)) {
+			return obj;
 		}
 	} catch {
 		// leave empty

--- a/src/runtime/register.ts
+++ b/src/runtime/register.ts
@@ -25,6 +25,7 @@ export function register<TSchema extends ZodRawShape, TCtx extends ToolContext>(
 		// `ZodRawShape` constraint from zod is the same shape as the SDK's
 		// `ZodRawShapeCompat` (Record<string, AnySchema>) — TypeScript just
 		// can't unify them through the generic boundary.
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generic boundary; MCP SDK's ToolCallback can't be unified with our typed handler
 		handler as unknown as ToolCallback<TSchema>,
 	);
 }

--- a/src/runtime/shutdown.ts
+++ b/src/runtime/shutdown.ts
@@ -47,6 +47,15 @@ export interface ShutdownDeps {
 
 const DEFAULT_POLL_MS = 50;
 
+function hasCloseIdleConnections(server: unknown): server is { closeIdleConnections: () => void } {
+	return (
+		server !== null &&
+		typeof server === 'object' &&
+		'closeIdleConnections' in server &&
+		typeof server.closeIdleConnections === 'function'
+	);
+}
+
 export function registerShutdownHandlers(deps: ShutdownDeps): void {
 	const proc = deps.process ?? process;
 	let draining = false;
@@ -94,10 +103,8 @@ async function runDrain(
 			// Node 18.2+ exposes closeIdleConnections, which lets keep-alive
 			// idle sockets close so the listener can finish closing during the
 			// grace window. Feature-detected so older runtimes still build.
-			const idleCloser = (deps.httpServer as unknown as { closeIdleConnections?: () => void })
-				.closeIdleConnections;
-			if (typeof idleCloser === 'function') {
-				idleCloser.call(deps.httpServer);
+			if (hasCloseIdleConnections(deps.httpServer)) {
+				deps.httpServer.closeIdleConnections();
 			}
 		}
 		if (deps.sessions) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { reconcileTools } from './runtime/reconcile.js';
 import type { ToolContext } from './runtime/context.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- compile-time JSON import; ESM `import ... assert { type: 'json' }` migration is a separate follow-up
 const serverInfo = createRequire(import.meta.url)('../server.json') as {
 	title: string;
 	description: string;

--- a/src/services/editService.ts
+++ b/src/services/editService.ts
@@ -30,6 +30,7 @@ export class EditServiceImpl implements EditService {
 		if (tags !== null && tags !== undefined) {
 			fullParams.tags = tags;
 		}
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn ApiParams shape; we assemble fullParams to match the typed contract
 		return mwn.request(fullParams as ApiParams);
 	}
 

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -10,12 +10,14 @@ interface PageSectionsApi {
 
 export class SectionServiceImpl implements SectionService {
 	public async list(mwn: Mwn, title: string): Promise<string[]> {
-		const response = (await mwn.request({
-			action: 'parse',
-			page: title,
-			prop: 'sections',
-			formatversion: '2',
-		})) as { parse?: { sections?: PageSectionsApi[] } } | undefined;
+		const response =
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+			(await mwn.request({
+				action: 'parse',
+				page: title,
+				prop: 'sections',
+				formatversion: '2',
+			})) as { parse?: { sections?: PageSectionsApi[] } } | undefined;
 		const apiSections: PageSectionsApi[] = response?.parse?.sections ?? [];
 		return ['', ...apiSections.map((s) => s.line ?? '')];
 	}

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -186,6 +186,7 @@ export const comparePages: Tool<typeof inputSchema> = {
 			...buildSideParams('from', args),
 			...buildSideParams('to', args),
 		});
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		const compare = response.compare as CompareResponse | undefined;
 		if (!compare) {
 			return ctx.format.error(

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -39,6 +39,7 @@ export const createPage: Tool<typeof inputSchema> = {
 		const mwn = await ctx.mwn();
 		const baseOptions: ApiEditPageParams = {};
 		if (contentModel !== undefined) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- input is validated against ApiEditPageParams.contentmodel via the inputSchema enum
 			baseOptions.contentmodel = contentModel as ApiEditPageParams['contentmodel'];
 		}
 		const options = ctx.edit.applyTags<ApiEditPageParams>(baseOptions);

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -35,6 +35,7 @@ export const deletePage: Tool<typeof inputSchema> = {
 			options,
 		);
 		return ctx.format.ok({
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 			title: data.title as string,
 			deleted: true as const,
 			logId: data.logid,

--- a/src/tools/get-file.ts
+++ b/src/tools/get-file.ts
@@ -37,6 +37,7 @@ export const getFile: Tool<typeof inputSchema> = {
 			formatversion: '2',
 		});
 
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		const page = response.query?.pages?.[0] as ApiPage | undefined;
 
 		if (!page || page.missing) {

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -76,6 +76,7 @@ export const getPageHistory: Tool<typeof inputSchema> = {
 		}
 
 		const response = await mwn.request(params);
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		const page = response.query?.pages?.[0] as ApiPage | undefined;
 
 		if (page?.missing) {

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -156,13 +156,16 @@ async function fetchPages(
 			continue;
 		}
 		type Alias = { from: string; to: string };
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		for (const entry of (query.normalized ?? []) as Alias[]) {
 			result.aliasTo.set(entry.from, entry.to);
 		}
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		for (const entry of (query.redirects ?? []) as Alias[]) {
 			result.aliasTo.set(entry.from, entry.to);
 			result.redirectFrom.add(entry.from);
 		}
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		for (const page of (query.pages ?? []) as ApiPageLike[]) {
 			result.byResolvedTitle.set(page.title, normalisePage(page, ctx));
 		}

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -163,6 +163,7 @@ export const getRecentChanges: Tool<typeof inputSchema> = {
 		}
 
 		const response = await mwn.request(params);
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 		const changes = (response.query?.recentchanges ?? []) as RecentChange[];
 
 		const nextCursor: string | undefined = response.continue?.rccontinue;

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -75,6 +75,7 @@ export const getRevision: Tool<typeof inputSchema> = {
 				formatversion: '2',
 			});
 
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 			const page = response.query?.pages?.[0] as ApiPage | undefined;
 			const rev: ApiRevision | undefined = page?.revisions?.[0];
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { errorMessage } from '../errors/isErrnoException.js';
 import { logger } from '../runtime/logger.js';
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext, ManagementContext } from '../runtime/context.js';
@@ -71,8 +72,7 @@ export function registerAllTools(
 		try {
 			registered.set(tool.name, register(server, tool, dispatch(tool, ctx)));
 		} catch (error) {
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from McpServer.tool; trusted Error subtype at this boundary
-			logger.error('Error registering tool', { error: (error as Error).message });
+			logger.error('Error registering tool', { error: errorMessage(error) });
 		}
 	}
 
@@ -81,8 +81,7 @@ export function registerAllTools(
 		try {
 			registered.set(tool.name, register(server, tool, dispatch(tool, mgmtCtx)));
 		} catch (error) {
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from McpServer.tool; trusted Error subtype at this boundary
-			logger.error('Error registering tool', { error: (error as Error).message });
+			logger.error('Error registering tool', { error: errorMessage(error) });
 		}
 	}
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -71,6 +71,7 @@ export function registerAllTools(
 		try {
 			registered.set(tool.name, register(server, tool, dispatch(tool, ctx)));
 		} catch (error) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from McpServer.tool; trusted Error subtype at this boundary
 			logger.error('Error registering tool', { error: (error as Error).message });
 		}
 	}
@@ -80,6 +81,7 @@ export function registerAllTools(
 		try {
 			registered.set(tool.name, register(server, tool, dispatch(tool, mgmtCtx)));
 		} catch (error) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from McpServer.tool; trusted Error subtype at this boundary
 			logger.error('Error registering tool', { error: (error as Error).message });
 		}
 	}

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -36,6 +36,7 @@ export const undeletePage: Tool<typeof inputSchema> = {
 		);
 
 		return ctx.format.ok({
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 			title: data.title as string,
 			restored: true as const,
 			revisionCount: data.revisions,

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -51,6 +51,7 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 		try {
 			data = await mwn.uploadFromUrl(url, title, '', params);
 		} catch (error) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from mwn; trusted Error subtype at this boundary
 			const errorMessage = (error as Error).message;
 			// Mirror upload-file-from-url: redirect the model away from retrying via URL when
 			// the wiki has copyuploads disabled. Routing hint points at the update-file (local)

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -4,6 +4,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext } from '../runtime/context.js';
+import { errorMessage } from '../errors/isErrnoException.js';
 import { assertFileExists, FileNotFoundError } from '../transport/fileExistence.js';
 import { formatEditComment, getPageUrl } from '../wikis/utils.js';
 
@@ -51,12 +52,11 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 		try {
 			data = await mwn.uploadFromUrl(url, title, '', params);
 		} catch (error) {
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from mwn; trusted Error subtype at this boundary
-			const errorMessage = (error as Error).message;
+			const errorText = errorMessage(error);
 			// Mirror upload-file-from-url: redirect the model away from retrying via URL when
 			// the wiki has copyuploads disabled. Routing hint points at the update-file (local)
 			// sibling for this tool's update intent.
-			if (errorMessage.includes('copyuploaddisabled')) {
+			if (errorText.includes('copyuploaddisabled')) {
 				return ctx.format.error(
 					'invalid_input',
 					'Upload by URL is disabled on this wiki. Download the file locally, then use update-file with the local file path.',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -107,9 +107,9 @@ export const updatePage: Tool<typeof inputSchema> = {
 		}
 
 		const mwn = await ctx.mwn();
-		const response = (await ctx.edit.submit(mwn, buildEditParams(args))) as
-			| { edit?: ApiEditResponse }
-			| undefined;
+		const response =
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+			(await ctx.edit.submit(mwn, buildEditParams(args))) as { edit?: ApiEditResponse } | undefined;
 		const edit = response?.edit;
 		if (!edit || edit.result !== 'Success') {
 			return ctx.format.error(

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -4,6 +4,7 @@ import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext } from '../runtime/context.js';
+import { errorMessage } from '../errors/isErrnoException.js';
 import { formatEditComment, getPageUrl } from '../wikis/utils.js';
 
 const inputSchema = {
@@ -39,11 +40,10 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 		try {
 			data = await mwn.uploadFromUrl(url, title, text, params);
 		} catch (error) {
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from mwn; trusted Error subtype at this boundary
-			const errorMessage = (error as Error).message;
+			const errorText = errorMessage(error);
 			// Prevent the LLM from attempting to find an existing image on the wiki
 			// after failing to upload by URL.
-			if (errorMessage.includes('copyuploaddisabled')) {
+			if (errorText.includes('copyuploaddisabled')) {
 				return ctx.format.error(
 					'invalid_input',
 					'Upload by URL is disabled on this wiki. Download the file locally, then use upload-file with the local file path.',

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -39,6 +39,7 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 		try {
 			data = await mwn.uploadFromUrl(url, title, text, params);
 		} catch (error) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from mwn; trusted Error subtype at this boundary
 			const errorMessage = (error as Error).message;
 			// Prevent the LLM from attempting to find an existing image on the wiki
 			// after failing to upload by URL.

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -62,6 +62,7 @@ async function fetchCore(
 	}
 
 	// response is always assigned inside the loop (loop runs at least once).
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- definite-assignment via the loop's at-least-once invariant; TS can't prove it
 	const finalResponse = response as Response;
 	if (!finalResponse.ok) {
 		const errorBody = await finalResponse.text().catch(() => 'Could not read error response body');
@@ -77,6 +78,7 @@ export async function makeApiRequest<T>(url: string, params?: Record<string, str
 		params,
 		headers: { Accept: 'application/json' },
 	});
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- HTTP response body; trusted JSON envelope at this boundary
 	return (await response.json()) as T;
 }
 

--- a/src/transport/ssrfGuard.ts
+++ b/src/transport/ssrfGuard.ts
@@ -91,7 +91,12 @@ function assertAddressIsUnicast(address: string, urlString: string): void {
 		);
 	}
 
-	if (parsed.kind() === 'ipv6' && (parsed as ipaddr.IPv6).isIPv4MappedAddress()) {
+	if (
+		parsed.kind() === 'ipv6' &&
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by parsed.kind() === 'ipv6'; ipaddr.js doesn't expose a type predicate
+		(parsed as ipaddr.IPv6).isIPv4MappedAddress()
+	) {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by parsed.kind() === 'ipv6'; ipaddr.js doesn't expose a type predicate
 		parsed = (parsed as ipaddr.IPv6).toIPv4Address();
 	}
 
@@ -103,6 +108,7 @@ function assertAddressIsUnicast(address: string, urlString: string): void {
 	}
 
 	if (parsed.kind() === 'ipv6') {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by parsed.kind() === 'ipv6'; ipaddr.js doesn't expose a type predicate
 		const extraMatch = ipaddr.subnetMatch(parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast');
 		if (extraMatch !== 'unicast') {
 			throw new SsrfValidationError(

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -139,6 +139,7 @@ export function createMcpPostHandler(
 ): RequestHandler {
 	const { allowedOrigins } = options;
 	return async (req, res) => {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Express headers are string|string[]|undefined; MCP transport sends a single header
 		const sessionId = req.headers['mcp-session-id'] as string | undefined;
 		const bearer = extractBearerToken(req);
 		let transport: StreamableHTTPServerTransport;
@@ -193,6 +194,7 @@ export function createMcpPostHandler(
 
 export function createSessionRequestHandler(sessions: SessionRegistry): RequestHandler {
 	return async (req, res) => {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Express headers are string|string[]|undefined; MCP transport sends a single header
 		const sessionId = req.headers['mcp-session-id'] as string | undefined;
 		if (!sessionId || !sessions[sessionId]) {
 			res.status(400).send('Invalid or missing session ID');
@@ -218,6 +220,7 @@ export function payloadTooLargeHandler(limit: string): ErrorRequestHandler {
 		const tooLarge =
 			typeof err === 'object' &&
 			err !== null &&
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- predicate body's required cast to inspect body-parser PayloadTooLargeError
 			(err as { type?: unknown }).type === 'entity.too.large';
 		if (!tooLarge) {
 			next(err);

--- a/src/transport/uploadGuard.ts
+++ b/src/transport/uploadGuard.ts
@@ -27,6 +27,7 @@ export async function assertAllowedPath(
 	try {
 		resolved = await realpath(filepath);
 	} catch (err) {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Node fs error shape; classified by errno code
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
 			throw new UploadValidationError(
 				`file not found at "${filepath}". Verify the path exists and is inside an allowed upload directory.`,

--- a/src/wikis/mwnErrorSanitizer.ts
+++ b/src/wikis/mwnErrorSanitizer.ts
@@ -6,6 +6,13 @@ function isRecord(x: unknown): x is Record<string, unknown> {
 	return x !== null && typeof x === 'object';
 }
 
+function isThenable(x: unknown): x is Promise<unknown> {
+	if (x === null || typeof x !== 'object') return false;
+	if (!('then' in x) || typeof x.then !== 'function') return false;
+	if (!('catch' in x) || typeof x.catch !== 'function') return false;
+	return true;
+}
+
 function redactHeadersObject(obj: unknown): void {
 	if (!isRecord(obj)) {
 		return;
@@ -44,6 +51,7 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
 	return (
 		value !== null &&
 		typeof value === 'object' &&
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- predicate body's required cast to inspect Symbol.asyncIterator
 		typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === 'function'
 	);
 }
@@ -82,12 +90,11 @@ export function wrapMwnErrors<T extends object>(target: T, token?: string): T {
 			}
 			return function (this: unknown, ...args: unknown[]): unknown {
 				try {
-					const result = (value as (...a: unknown[]) => unknown).apply(
-						this === receiver ? obj : this,
-						args,
-					);
-					if (result && typeof (result as Promise<unknown>).then === 'function') {
-						return (result as Promise<unknown>).catch((err: unknown) => {
+					const result =
+						// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Reflect.get returns unknown; the trapped property is the original function
+						(value as (...a: unknown[]) => unknown).apply(this === receiver ? obj : this, args);
+					if (isThenable(result)) {
+						return result.catch((err: unknown) => {
 							redactAuthorizationHeader(err, token);
 							throw err;
 						});

--- a/src/wikis/mwnErrorSanitizer.ts
+++ b/src/wikis/mwnErrorSanitizer.ts
@@ -2,30 +2,33 @@ const REDACTED = '[REDACTED]';
 
 const SENSITIVE_HEADER_PATTERN = /^(?:proxy-)?authorization$/i;
 
+function isRecord(x: unknown): x is Record<string, unknown> {
+	return x !== null && typeof x === 'object';
+}
+
 function redactHeadersObject(obj: unknown): void {
-	if (!obj || typeof obj !== 'object') {
+	if (!isRecord(obj)) {
 		return;
 	}
-	const headers = (obj as Record<string, unknown>).headers;
-	if (!headers || typeof headers !== 'object') {
+	const headers = obj.headers;
+	if (!isRecord(headers)) {
 		return;
 	}
 	for (const key of Object.keys(headers)) {
 		if (SENSITIVE_HEADER_PATTERN.test(key)) {
-			(headers as Record<string, unknown>)[key] = REDACTED;
+			headers[key] = REDACTED;
 		}
 	}
 }
 
 export function redactAuthorizationHeader(err: unknown, token?: string): void {
-	if (!(err instanceof Error)) {
+	if (!(err instanceof Error) || !isRecord(err)) {
 		return;
 	}
-	const e = err as unknown as Record<string, unknown>;
-	redactHeadersObject(e.request);
-	redactHeadersObject(e.config);
-	if (e.response && typeof e.response === 'object') {
-		redactHeadersObject((e.response as Record<string, unknown>).config);
+	redactHeadersObject(err.request);
+	redactHeadersObject(err.config);
+	if (isRecord(err.response)) {
+		redactHeadersObject(err.response.config);
 	}
 	// replaceAll with a string pattern does literal (non-regex) replacement —
 	// do not "refactor" this to a RegExp, which would misbehave on special chars in the token.

--- a/src/wikis/mwnErrorSanitizer.ts
+++ b/src/wikis/mwnErrorSanitizer.ts
@@ -29,6 +29,8 @@ function redactHeadersObject(obj: unknown): void {
 }
 
 export function redactAuthorizationHeader(err: unknown, token?: string): void {
+	// `isRecord( err )` is redundant at runtime (every Error instance is an object)
+	// but lets TS narrow `err` to `Error & Record<string, unknown>` for property indexing below.
 	if (!(err instanceof Error) || !isRecord(err)) {
 		return;
 	}

--- a/src/wikis/wikiDiscovery.ts
+++ b/src/wikis/wikiDiscovery.ts
@@ -1,3 +1,4 @@
+import { errorMessage } from '../errors/isErrnoException.js';
 import { makeApiRequest, fetchPageHtml } from '../transport/httpFetch.js';
 import { assertPublicDestination } from '../transport/ssrfGuard.js';
 import { logger } from '../runtime/logger.js';
@@ -47,8 +48,7 @@ async function fetchWikiInfoFromApi(
 	} catch (error) {
 		logger.error('Error fetching wiki info', {
 			baseUrl,
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from fetch helper; trusted Error subtype at this boundary
-			error: (error as Error).message,
+			error: errorMessage(error),
 		});
 		return null;
 	}
@@ -97,8 +97,7 @@ function extractScriptPathFromSearchForm(htmlContent: string, wikiServer: string
 			}
 		} catch (error) {
 			logger.warning('Error extracting script path from search form', {
-				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from URL parsing; trusted Error subtype at this boundary
-				error: (error as Error).message,
+				error: errorMessage(error),
 			});
 		}
 	}

--- a/src/wikis/wikiDiscovery.ts
+++ b/src/wikis/wikiDiscovery.ts
@@ -47,6 +47,7 @@ async function fetchWikiInfoFromApi(
 	} catch (error) {
 		logger.error('Error fetching wiki info', {
 			baseUrl,
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from fetch helper; trusted Error subtype at this boundary
 			error: (error as Error).message,
 		});
 		return null;
@@ -96,6 +97,7 @@ function extractScriptPathFromSearchForm(htmlContent: string, wikiServer: string
 			}
 		} catch (error) {
 			logger.warning('Error extracting script path from search form', {
+				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- caught error from URL parsing; trusted Error subtype at this boundary
 				error: (error as Error).message,
 			});
 		}


### PR DESCRIPTION
## Summary

- Resolved the ~353 type-aware lint warnings deferred from the TypeScript 7 upgrade.
- Tests get a category override on the two type-assertion rules (`no-unsafe-type-assertion`, `no-unnecessary-type-assertion`) — silenced where the value-to-noise ratio is poor for mock setup and fixture types.
- Source code uses type-predicate functions (`isErrnoException`, `errorMessage`, `isRecord`, `isParsedEnvelope`, `isThenable`, `hasCloseIdleConnections`) to satisfy the rules via TS narrowing instead of inline casts.
- Remaining boundary casts (config parsing, build-time JSON imports, mwn API responses, generic-boundary unifications) carry one-line rationales pointing at follow-up work where applicable.
- Lint now reports 0 errors / 0 warnings.

## Commits

- `079b93e` — Disable type-assertion rules in tests
- `d741cab` — Remove redundant type assertion in loadConfig
- `ae64e08` — Replace caught-error casts with type predicate and helper
- `79f7938` — Replace runtime-guarded casts with type predicates
- `623ef11` — Suppress unavoidable type-assertion casts with rationale
- `5d9dca6` — Apply errorMessage helper to remaining caught-error sites

## Before / after

| | Before | After |
|---|---:|---:|
| Lint warnings (total) | ~353 | 0 |
| Lint warnings in tests/ | ~294 | 0 (silenced via override) |
| Lint warnings in src/ | ~59 | 0 |
| Lint errors | 0 | 0 |
| Tests | 716/716 | 716/716 |

## Out-of-scope follow-ups

- Introduce ajv-validated `WikiConfig` parsing in `src/config/loadConfig.ts`. Removes the four config-boundary rationale suppressions naturally. Separate design conversation about boot behavior on invalid config.
- Migrate build-time JSON imports from `createRequire(...) as { ... }` to ESM `import ... assert { type: 'json' }`. Removes the build-time-import suppressions.

## Test plan

- [x] `npm ci && npm run lint && npm run fmt:check && npm test && npm run build` from a clean clone
- [x] `docker build .` succeeds
- [x] Pre-push hook (`tsgo --noEmit` + vitest) runs and exits 0