### PR TITLE
Refactor wiki state into a factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Replaced ESLint and `eslint-config-wikimedia` with oxlint and oxfmt. Coding-style settings live in `.oxlintrc.json` and `.oxfmtrc.json`. Code reformatted to `useTabs: true`, `singleQuote: true`, otherwise oxfmt defaults (trailing commas everywhere, no spaces inside parens or brackets, default print width).
 - Pinned the Dockerfile base image to a specific `node:lts-alpine` digest. Dependabot's new `docker` ecosystem entry tracks digest updates and opens PRs when Alpine/Node publish new images, so base-image patches reach published builds via auditable git history rather than silent rebuilds.
 - The Docker builder stage now installs dependencies with `npm ci --ignore-scripts`, matching the production stage. Stops third-party postinstall scripts from running during the build that the SLSA provenance attestation vouches for.
+- Server startup constructs wiki state explicitly rather than as a side effect of module imports. Internal restructuring; no user-visible behaviour change.
 
 ### Removed
 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -4,7 +4,6 @@ import type { Resource } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext } from '../runtime/context.js';
 import type { WikiConfig, PublicWikiConfig } from '../config/loadConfig.js';
 import { WIKI_RESOURCE_URI_PREFIX } from '../runtime/constants.js';
-import { licenseCache } from '../wikis/state.js';
 import type { LicenseInfo } from '../wikis/licenseCache.js';
 
 function sanitize(wikiConfig: Readonly<WikiConfig>): PublicWikiConfig {
@@ -13,7 +12,7 @@ function sanitize(wikiConfig: Readonly<WikiConfig>): PublicWikiConfig {
 }
 
 async function getLicenseInfo(ctx: ToolContext, wikiKey: string): Promise<LicenseInfo | undefined> {
-	const cached = licenseCache.get(wikiKey);
+	const cached = ctx.licenseCache.get(wikiKey);
 	if (cached) {
 		return cached;
 	}
@@ -30,7 +29,7 @@ async function getLicenseInfo(ctx: ToolContext, wikiKey: string): Promise<Licens
 		const rightsInfo = response.query?.rightsinfo;
 		if (rightsInfo?.url && rightsInfo.text) {
 			const info: LicenseInfo = { url: rightsInfo.url, title: rightsInfo.text };
-			licenseCache.set(wikiKey, info);
+			ctx.licenseCache.set(wikiKey, info);
 			return info;
 		}
 	} catch {

--- a/src/runtime/banner.ts
+++ b/src/runtime/banner.ts
@@ -1,7 +1,9 @@
 import { createRequire } from 'node:module';
 import { logger } from './logger.js';
 import { classifyAuthShape } from '../transport/bearerGuard.js';
-import { wikiRegistry, wikiSelection, uploadDirs } from '../wikis/state.js';
+import type { WikiRegistry } from '../wikis/wikiRegistry.js';
+import type { WikiSelection } from '../wikis/wikiSelection.js';
+import type { UploadDirs } from '../wikis/uploadDirs.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
 const serverInfo = createRequire(import.meta.url)('../../server.json') as {
@@ -23,17 +25,23 @@ export type CreateServerOptions =
 			};
 	  };
 
-export function emitStartupBanner(opts: CreateServerOptions): void {
-	const wikis = wikiRegistry.getAll();
+export interface BannerDeps {
+	readonly wikiRegistry: WikiRegistry;
+	readonly wikiSelection: WikiSelection;
+	readonly uploadDirs: UploadDirs;
+}
+
+export function emitStartupBanner(opts: CreateServerOptions, deps: BannerDeps): void {
+	const wikis = deps.wikiRegistry.getAll();
 	const data: Record<string, unknown> = {
 		event: 'startup',
 		version: serverInfo.version,
 		transport: opts.transport,
 		auth_shape: classifyAuthShape(wikis, opts.transport),
-		default_wiki: wikiSelection.getCurrent().key,
+		default_wiki: deps.wikiSelection.getCurrent().key,
 		wikis: Object.keys(wikis),
-		allow_wiki_management: wikiRegistry.isManagementAllowed(),
-		upload_dirs_configured: uploadDirs.list().length > 0,
+		allow_wiki_management: deps.wikiRegistry.isManagementAllowed(),
+		upload_dirs_configured: deps.uploadDirs.list().length > 0,
 	};
 	if (opts.transport === 'http') {
 		data.host = opts.http.host;

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -3,6 +3,7 @@ import type { WikiRegistry } from '../wikis/wikiRegistry.js';
 import type { WikiSelection } from '../wikis/wikiSelection.js';
 import type { UploadDirs } from '../wikis/uploadDirs.js';
 import type { WikiCache } from '../wikis/wikiCache.js';
+import type { LicenseCache } from '../wikis/licenseCache.js';
 import type { SectionService } from '../services/sectionService.js';
 import type { EditService } from '../services/editService.js';
 import type { RevisionNormalizer } from '../services/revisionNormalize.js';
@@ -16,6 +17,7 @@ export interface ToolContext {
 	readonly selection: WikiSelection;
 	readonly uploadDirs: UploadDirs;
 	readonly wikiCache: WikiCache;
+	readonly licenseCache: LicenseCache;
 	readonly sections: SectionService;
 	readonly edit: EditService;
 	readonly revision: RevisionNormalizer;

--- a/src/runtime/createContext.ts
+++ b/src/runtime/createContext.ts
@@ -1,12 +1,6 @@
 import type { Logger } from './logger.js';
 import type { ToolContext } from './context.js';
-import {
-	wikiRegistry,
-	wikiSelection,
-	uploadDirs,
-	mwnProvider,
-	licenseCache,
-} from '../wikis/state.js';
+import type { AppState } from '../wikis/state.js';
 import { WikiCacheImpl } from '../wikis/wikiCache.js';
 import { SectionServiceImpl } from '../services/sectionService.js';
 import { EditServiceImpl } from '../services/editService.js';
@@ -14,18 +8,20 @@ import { RevisionNormalizerImpl } from '../services/revisionNormalize.js';
 import { ResponseFormatterImpl } from '../results/response.js';
 import { ErrorClassifierImpl } from '../errors/classifyError.js';
 
-export function createToolContext(deps: { logger: Logger }): ToolContext {
+export function createToolContext(deps: { logger: Logger; state: AppState }): ToolContext {
+	const { logger, state } = deps;
 	return {
-		mwn: (wikiKey?: string) => mwnProvider.get(wikiKey),
-		wikis: wikiRegistry,
-		selection: wikiSelection,
-		uploadDirs,
-		wikiCache: new WikiCacheImpl(mwnProvider, licenseCache),
+		mwn: (wikiKey?: string) => state.mwnProvider.get(wikiKey),
+		wikis: state.wikiRegistry,
+		selection: state.wikiSelection,
+		uploadDirs: state.uploadDirs,
+		wikiCache: new WikiCacheImpl(state.mwnProvider, state.licenseCache),
+		licenseCache: state.licenseCache,
 		sections: new SectionServiceImpl(),
-		edit: new EditServiceImpl(wikiSelection),
+		edit: new EditServiceImpl(state.wikiSelection),
 		revision: new RevisionNormalizerImpl(),
 		format: new ResponseFormatterImpl(),
 		errors: new ErrorClassifierImpl(),
-		logger: deps.logger,
+		logger,
 	};
 }

--- a/src/runtime/reconcile.ts
+++ b/src/runtime/reconcile.ts
@@ -1,6 +1,7 @@
 import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { WikiConfig } from '../config/loadConfig.js';
-import { wikiRegistry, wikiSelection } from '../wikis/state.js';
+import type { WikiRegistry } from '../wikis/wikiRegistry.js';
+import type { WikiSelection } from '../wikis/wikiSelection.js';
 
 export type Reconcile = () => void;
 
@@ -13,7 +14,11 @@ const WRITE_TOOL_NAMES: readonly string[] = [
 	'upload-file-from-url',
 ];
 
-export function reconcileTools(tools: Map<string, RegisteredTool>): void {
+export function reconcileTools(
+	tools: Map<string, RegisteredTool>,
+	wikiRegistry: WikiRegistry,
+	wikiSelection: WikiSelection,
+): void {
 	const activeWiki = wikiSelection.getCurrent().config;
 	const wikiCount = Object.keys(wikiRegistry.getAll()).length;
 	const allowManagement = wikiRegistry.isManagementAllowed();

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ export const createServer = (ctx: ToolContext): McpServer => {
 
 	const tools = new Map<string, RegisteredTool>();
 	const reconcile = (): void => {
-		reconcileTools(tools);
+		reconcileTools(tools, ctx.wikis, ctx.selection);
 		// Notify clients that the wiki resource list may have changed (e.g. after
 		// add-wiki / remove-wiki). Also covers tool-list changes since toggling a
 		// RegisteredTool's enabled state already emits its own listChanged event.

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -55,7 +55,7 @@ export const createPage: Tool<typeof inputSchema> = {
 			latestRevisionId: result.newrevid,
 			latestRevisionTimestamp: result.newtimestamp,
 			contentModel: result.contentmodel,
-			url: getPageUrl(result.title),
+			url: getPageUrl(result.title, ctx.selection),
 		});
 	},
 };

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -107,7 +107,7 @@ export const getPage: Tool<typeof inputSchema> = {
 				if (sections !== undefined) {
 					payload.sections = sections;
 				}
-				payload.url = getPageUrl(page.title);
+				payload.url = getPageUrl(page.title, ctx.selection);
 			}
 
 			if (needsSource && rev?.content !== undefined) {
@@ -153,7 +153,7 @@ export const getPage: Tool<typeof inputSchema> = {
 					if (parseResult.parse?.pageid !== undefined) {
 						payload.pageId = parseResult.parse.pageid;
 					}
-					payload.url = getPageUrl(resolvedTitle);
+					payload.url = getPageUrl(resolvedTitle, ctx.selection);
 				}
 
 				if (truncated.truncated) {

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -177,13 +177,14 @@ function buildPageEntry(
 	args: GetPagesArgs,
 	entryIndex: number,
 	pending: PendingTruncation[],
+	ctx: ToolContext,
 ): PageEntry {
 	const rev = page.revisions?.[0];
 	const entry: PageEntry = {
 		requestedTitle: requested,
 		pageId: page.pageid,
 		title: page.title,
-		url: getPageUrl(page.title),
+		url: getPageUrl(page.title, ctx.selection),
 		...(viaRedirect ? { redirectedFrom: requested } : {}),
 		...(args.metadata
 			? {
@@ -234,6 +235,7 @@ async function applyTruncations(
 function assembleEntries(
 	args: GetPagesArgs,
 	fetched: FetchResult,
+	ctx: ToolContext,
 ): { entries: PageEntry[]; missing: string[]; pending: PendingTruncation[] } {
 	const entries: PageEntry[] = [];
 	const emitted = new Set<string>();
@@ -256,7 +258,7 @@ function assembleEntries(
 			continue;
 		}
 		emitted.add(page.title);
-		entries.push(buildPageEntry(requested, page, viaRedirect, args, entries.length, pending));
+		entries.push(buildPageEntry(requested, page, viaRedirect, args, entries.length, pending, ctx));
 	}
 	return { entries, missing, pending };
 }
@@ -286,7 +288,7 @@ export const getPages: Tool<typeof inputSchema> = {
 				? 'ids|timestamp|contentmodel|content'
 				: 'ids|timestamp|contentmodel';
 		const fetched = await fetchPages(mwn, ctx, args, rvprop);
-		const { entries, missing, pending } = assembleEntries(args, fetched);
+		const { entries, missing, pending } = assembleEntries(args, fetched, ctx);
 		await applyTruncations(mwn, ctx, entries, pending);
 
 		return ctx.format.ok({

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -85,7 +85,7 @@ export const getRevision: Tool<typeof inputSchema> = {
 			payload.revisionId = rev.revid;
 			payload.pageId = page.pageid;
 			payload.title = page.title;
-			payload.url = getPageUrl(page.title);
+			payload.url = getPageUrl(page.title, ctx.selection);
 
 			if (needsMetadata) {
 				payload.userid = rev.userid;
@@ -117,7 +117,7 @@ export const getRevision: Tool<typeof inputSchema> = {
 				}
 				if (parseResult.parse?.title !== undefined) {
 					payload.title = parseResult.parse.title;
-					payload.url = getPageUrl(parseResult.parse.title);
+					payload.url = getPageUrl(parseResult.parse.title, ctx.selection);
 				}
 			}
 		}

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -69,7 +69,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 				size: r.size,
 				wordCount: (r as ApiSearchResult & { wordcount?: number }).wordcount,
 				timestamp: r.timestamp,
-				url: getPageUrl(r.title),
+				url: getPageUrl(r.title, ctx.selection),
 			})),
 			...(truncation !== null ? { truncation } : {}),
 		});

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -73,7 +73,7 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 		const filename = data.filename ?? title.replace(/^File:/, '');
 		return ctx.format.ok({
 			filename,
-			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`),
+			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`, ctx.selection),
 			...(imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {}),
 		});
 	},

--- a/src/tools/update-file.ts
+++ b/src/tools/update-file.ts
@@ -72,7 +72,7 @@ export const updateFile: Tool<typeof inputSchema> = {
 		const filename = data.filename ?? title.replace(/^File:/, '');
 		return ctx.format.ok({
 			filename,
-			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`),
+			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`, ctx.selection),
 			...(imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {}),
 		});
 	},

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -124,7 +124,7 @@ export const updatePage: Tool<typeof inputSchema> = {
 			latestRevisionId: edit.newrevid,
 			latestRevisionTimestamp: edit.newtimestamp,
 			contentModel: edit.contentmodel,
-			url: getPageUrl(resolvedTitle),
+			url: getPageUrl(resolvedTitle, ctx.selection),
 		});
 	},
 };

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -60,7 +60,7 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 		const filename = data.filename ?? title.replace(/^File:/, '');
 		return ctx.format.ok({
 			filename,
-			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`),
+			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`, ctx.selection),
 			...(imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {}),
 		});
 	},

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -60,7 +60,7 @@ export const uploadFile: Tool<typeof inputSchema> = {
 		const filename = data.filename ?? title.replace(/^File:/, '');
 		return ctx.format.ok({
 			filename,
-			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`),
+			pageUrl: imageinfo?.descriptionurl ?? getPageUrl(`File:${filename}`, ctx.selection),
 			...(imageinfo?.url !== undefined ? { fileUrl: imageinfo.url } : {}),
 		});
 	},

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -25,6 +25,8 @@ async function main(): Promise<void> {
 	const server = createServer(ctx);
 
 	await server.connect(transport);
+	// Stdio has no in-flight queue, so grace doesn't apply — log graceMs: 0
+	// to make that explicit in the shutdown event.
 	registerShutdownHandlers({
 		transport: 'stdio',
 		graceMs: 0,
@@ -33,6 +35,9 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
+	// Bootstrap fail-safe: see the equivalent block in src/index.ts. Logger
+	// module not used here intentionally so a logger import failure can't
+	// suppress this path.
 	console.error('Server error:', error);
 	throw error;
 });

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -6,16 +6,25 @@ import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
 import { createToolContext } from '../runtime/createContext.js';
 import { registerShutdownHandlers } from '../runtime/shutdown.js';
+import { loadConfigFromFile } from '../config/loadConfig.js';
+import { createAppState } from '../wikis/state.js';
 
 async function main(): Promise<void> {
-	emitStartupBanner({ transport: 'stdio' });
+	const config = loadConfigFromFile();
+	const state = createAppState(config);
+	emitStartupBanner(
+		{ transport: 'stdio' },
+		{
+			wikiRegistry: state.wikiRegistry,
+			wikiSelection: state.wikiSelection,
+			uploadDirs: state.uploadDirs,
+		},
+	);
 	const transport = new StdioServerTransport();
-	const ctx = createToolContext({ logger });
+	const ctx = createToolContext({ logger, state });
 	const server = createServer(ctx);
 
 	await server.connect(transport);
-	// Stdio has no in-flight queue, so grace doesn't apply — log graceMs: 0
-	// to make that explicit in the shutdown event.
 	registerShutdownHandlers({
 		transport: 'stdio',
 		graceMs: 0,
@@ -24,9 +33,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
-	// Bootstrap fail-safe: see the equivalent block in src/index.ts. Logger
-	// module not used here intentionally so a logger import failure can't
-	// suppress this path.
 	console.error('Server error:', error);
 	throw error;
 });

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -25,6 +25,8 @@ import {
 } from '../runtime/metrics.js';
 import { runtimeTokenStore } from './requestContext.js';
 import { loadConfigFromFile } from '../config/loadConfig.js';
+import type { MwnProvider } from '../wikis/mwnProvider.js';
+import type { WikiSelection } from '../wikis/wikiSelection.js';
 import { createAppState } from '../wikis/state.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
@@ -250,8 +252,8 @@ export function __resetReadyCacheForTesting(): void {
 }
 
 async function probeDefaultWiki(
-	wikiSelection: import('../wikis/wikiSelection.js').WikiSelection,
-	mwnProvider: import('../wikis/mwnProvider.js').MwnProvider,
+	wikiSelection: WikiSelection,
+	mwnProvider: MwnProvider,
 ): Promise<ReadyCacheEntry> {
 	const wiki = wikiSelection.getCurrent().key;
 	const checkedAt = new Date().toISOString();
@@ -293,6 +295,8 @@ async function probeDefaultWiki(
 	}
 }
 
+// Test seam: exported so the timeout test can call the probe directly,
+// bypassing supertest's lazy request sending under vi.useFakeTimers.
 export const __probeDefaultWikiForTesting = probeDefaultWiki;
 
 export function mountMetricsEndpoint(app: express.Express): void {
@@ -309,13 +313,16 @@ export function mountMetricsEndpoint(app: express.Express): void {
 export function mountReadyEndpoint(
 	app: express.Express,
 	deps: {
-		wikiSelection: import('../wikis/wikiSelection.js').WikiSelection;
-		mwnProvider: import('../wikis/mwnProvider.js').MwnProvider;
+		wikiSelection: WikiSelection;
+		mwnProvider: MwnProvider;
 	},
 ): void {
 	app.get('/ready', async (_req, res) => {
 		if (!readyCache || Date.now() >= readyCache.expiresAt) {
 			readyCache = await probeDefaultWiki(deps.wikiSelection, deps.mwnProvider);
+			// Count distinct probe failures, not cached replays — K8s readiness
+			// probes that fire every second would otherwise inflate the counter
+			// 5x against a 5s cache for the same underlying outage.
 			if (readyCache.httpStatus !== 200) {
 				recordReadyFailure();
 			}
@@ -324,6 +331,10 @@ export function mountReadyEndpoint(
 	});
 }
 
+// Wiki config must load before HTTP config so evaluateBearerGuard below
+// can inspect wikiRegistry.getAll() to decide whether static credentials
+// are configured. resolveHttpConfig() reads only env vars and is order-
+// independent — placed after for visual grouping with the HTTP setup.
 const config = loadConfigFromFile();
 const state = createAppState(config);
 const { host, port, allowedHosts, allowedOrigins, maxRequestBody, warnings } = resolveHttpConfig();

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -24,7 +24,8 @@ import {
 	setSessionsProvider,
 } from '../runtime/metrics.js';
 import { runtimeTokenStore } from './requestContext.js';
-import { wikiRegistry, wikiSelection, mwnProvider } from '../wikis/state.js';
+import { loadConfigFromFile } from '../config/loadConfig.js';
+import { createAppState } from '../wikis/state.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
 import { createToolContext } from '../runtime/createContext.js';
@@ -248,7 +249,10 @@ export function __resetReadyCacheForTesting(): void {
 	readyCache = null;
 }
 
-async function probeDefaultWiki(): Promise<ReadyCacheEntry> {
+async function probeDefaultWiki(
+	wikiSelection: import('../wikis/wikiSelection.js').WikiSelection,
+	mwnProvider: import('../wikis/mwnProvider.js').MwnProvider,
+): Promise<ReadyCacheEntry> {
 	const wiki = wikiSelection.getCurrent().key;
 	const checkedAt = new Date().toISOString();
 	let timer: ReturnType<typeof setTimeout> | undefined;
@@ -289,8 +293,6 @@ async function probeDefaultWiki(): Promise<ReadyCacheEntry> {
 	}
 }
 
-// Test seam: exported so the timeout test can call the probe directly,
-// bypassing supertest's lazy request sending under vi.useFakeTimers.
 export const __probeDefaultWikiForTesting = probeDefaultWiki;
 
 export function mountMetricsEndpoint(app: express.Express): void {
@@ -304,13 +306,16 @@ export function mountMetricsEndpoint(app: express.Express): void {
 	}
 }
 
-export function mountReadyEndpoint(app: express.Express): void {
+export function mountReadyEndpoint(
+	app: express.Express,
+	deps: {
+		wikiSelection: import('../wikis/wikiSelection.js').WikiSelection;
+		mwnProvider: import('../wikis/mwnProvider.js').MwnProvider;
+	},
+): void {
 	app.get('/ready', async (_req, res) => {
 		if (!readyCache || Date.now() >= readyCache.expiresAt) {
-			readyCache = await probeDefaultWiki();
-			// Count distinct probe failures, not cached replays — K8s readiness
-			// probes that fire every second would otherwise inflate the counter
-			// 5x against a 5s cache for the same underlying outage.
+			readyCache = await probeDefaultWiki(deps.wikiSelection, deps.mwnProvider);
 			if (readyCache.httpStatus !== 200) {
 				recordReadyFailure();
 			}
@@ -319,8 +324,10 @@ export function mountReadyEndpoint(app: express.Express): void {
 	});
 }
 
+const config = loadConfigFromFile();
+const state = createAppState(config);
 const { host, port, allowedHosts, allowedOrigins, maxRequestBody, warnings } = resolveHttpConfig();
-const guard = evaluateBearerGuard(wikiRegistry.getAll(), process.env);
+const guard = evaluateBearerGuard(state.wikiRegistry.getAll(), process.env);
 if (guard.kind === 'block') {
 	logger.error(
 		'HTTP transport refuses to start because static credentials are configured for wiki(s): ' +
@@ -345,12 +352,14 @@ if (guard.kind === 'override') {
 for (const warning of warnings) {
 	logger.warning(warning);
 }
-// Emit the process-level startup banner before any HTTP request
-// can spin up a per-session McpServer.
-emitStartupBanner({
-	transport: 'http',
-	http: { host, port, allowedHosts, allowedOrigins, maxRequestBody },
-});
+emitStartupBanner(
+	{ transport: 'http', http: { host, port, allowedHosts, allowedOrigins, maxRequestBody } },
+	{
+		wikiRegistry: state.wikiRegistry,
+		wikiSelection: state.wikiSelection,
+		uploadDirs: state.uploadDirs,
+	},
+);
 
 const app = express();
 app.use(express.json({ limit: maxRequestBody }));
@@ -371,7 +380,7 @@ if ((host === '0.0.0.0' || host === '::') && !allowedOrigins) {
 
 const sessions: SessionRegistry = {};
 const sessionRequestHandler = createSessionRequestHandler(sessions);
-const ctx = createToolContext({ logger });
+const ctx = createToolContext({ logger, state });
 
 const inFlight = createInFlightCounter();
 app.use('/mcp', inFlight.middleware);
@@ -383,12 +392,11 @@ app.post(
 app.get('/mcp', sessionRequestHandler);
 app.delete('/mcp', sessionRequestHandler);
 
-// Used for the health check in the container
 app.get('/health', (_req: Request, res: Response) => {
 	res.status(200).json({ status: 'ok' });
 });
 
-mountReadyEndpoint(app);
+mountReadyEndpoint(app, { wikiSelection: state.wikiSelection, mwnProvider: state.mwnProvider });
 mountMetricsEndpoint(app);
 setSessionsProvider(() => Object.keys(sessions).length);
 

--- a/src/wikis/state.ts
+++ b/src/wikis/state.ts
@@ -15,10 +15,7 @@ export interface AppState {
 }
 
 export function createAppState(config: Config): AppState {
-	const wikiRegistry = new WikiRegistryImpl(
-		config.wikis,
-		config.allowWikiManagement !== false,
-	);
+	const wikiRegistry = new WikiRegistryImpl(config.wikis, config.allowWikiManagement !== false);
 	const wikiSelection = new WikiSelectionImpl(config.defaultWiki, wikiRegistry);
 	const uploadDirs = new UploadDirsImpl(config.uploadDirs);
 	const mwnProvider = new MwnProviderImpl(wikiRegistry, wikiSelection, getRuntimeToken);

--- a/src/wikis/state.ts
+++ b/src/wikis/state.ts
@@ -1,22 +1,27 @@
-import { loadConfigFromFile, type Config } from '../config/loadConfig.js';
+import type { Config } from '../config/loadConfig.js';
 import { getRuntimeToken } from '../transport/requestContext.js';
-import { WikiRegistryImpl } from './wikiRegistry.js';
-import { WikiSelectionImpl } from './wikiSelection.js';
-import { UploadDirsImpl } from './uploadDirs.js';
-import { MwnProviderImpl } from './mwnProvider.js';
-import { LicenseCacheImpl } from './licenseCache.js';
+import { WikiRegistryImpl, type WikiRegistry } from './wikiRegistry.js';
+import { WikiSelectionImpl, type WikiSelection } from './wikiSelection.js';
+import { UploadDirsImpl, type UploadDirs } from './uploadDirs.js';
+import { MwnProviderImpl, type MwnProvider } from './mwnProvider.js';
+import { LicenseCacheImpl, type LicenseCache } from './licenseCache.js';
 
-const config: Config = loadConfigFromFile();
+export interface AppState {
+	readonly wikiRegistry: WikiRegistry;
+	readonly wikiSelection: WikiSelection;
+	readonly uploadDirs: UploadDirs;
+	readonly mwnProvider: MwnProvider;
+	readonly licenseCache: LicenseCache;
+}
 
-export const wikiRegistry = new WikiRegistryImpl(
-	config.wikis,
-	config.allowWikiManagement !== false,
-);
-
-export const wikiSelection = new WikiSelectionImpl(config.defaultWiki, wikiRegistry);
-
-export const uploadDirs = new UploadDirsImpl(config.uploadDirs);
-
-export const mwnProvider = new MwnProviderImpl(wikiRegistry, wikiSelection, getRuntimeToken);
-
-export const licenseCache = new LicenseCacheImpl();
+export function createAppState(config: Config): AppState {
+	const wikiRegistry = new WikiRegistryImpl(
+		config.wikis,
+		config.allowWikiManagement !== false,
+	);
+	const wikiSelection = new WikiSelectionImpl(config.defaultWiki, wikiRegistry);
+	const uploadDirs = new UploadDirsImpl(config.uploadDirs);
+	const mwnProvider = new MwnProviderImpl(wikiRegistry, wikiSelection, getRuntimeToken);
+	const licenseCache = new LicenseCacheImpl();
+	return { wikiRegistry, wikiSelection, uploadDirs, mwnProvider, licenseCache };
+}

--- a/src/wikis/utils.ts
+++ b/src/wikis/utils.ts
@@ -1,6 +1,6 @@
-import { wikiSelection } from './state.js';
+import type { WikiSelection } from './wikiSelection.js';
 
-export function getPageUrl(title: string): string {
+export function getPageUrl(title: string, wikiSelection: WikiSelection): string {
 	const { server, articlepath } = wikiSelection.getCurrent().config;
 	// MediaWiki convention: spaces become underscores. encodeURI preserves
 	// '/' (subpages) and ':' (namespace prefixes) while encoding spaces and

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -34,6 +34,11 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 		},
 		uploadDirs: { list: () => [] },
 		wikiCache: { invalidate: throws('wikiCache.invalidate') as never },
+		licenseCache: {
+			get: () => undefined,
+			set: () => {},
+			delete: () => {},
+		},
 		sections: { list: throws('sections.list') as never },
 		edit: {
 			submit: throws('edit.submit') as never,

--- a/tests/runtime/createContext.test.ts
+++ b/tests/runtime/createContext.test.ts
@@ -1,16 +1,36 @@
 import { describe, it, expect } from 'vitest';
 import { createToolContext } from '../../src/runtime/createContext.js';
+import { createAppState } from '../../src/wikis/state.js';
 import { logger } from '../../src/runtime/logger.js';
+import type { Config } from '../../src/config/loadConfig.js';
+
+const testConfig: Config = {
+	defaultWiki: 'w',
+	wikis: {
+		w: {
+			sitename: 'Test',
+			server: 'https://test.wiki',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+			token: null,
+			username: null,
+			password: null,
+		},
+	},
+	uploadDirs: [],
+};
 
 describe('createToolContext', () => {
 	it('populates all ToolContext fields', () => {
-		const ctx = createToolContext({ logger });
+		const state = createAppState(testConfig);
+		const ctx = createToolContext({ logger, state });
 		expect(ctx.mwn).toBeTypeOf('function');
 		expect(ctx.wikis).toBeDefined();
 		expect(ctx.selection).toBeDefined();
 		expect(ctx.uploadDirs).toBeDefined();
 		expect(ctx.wikiCache).toBeDefined();
 		expect(typeof ctx.wikiCache.invalidate).toBe('function');
+		expect(ctx.licenseCache).toBeDefined();
 		expect(ctx.sections).toBeDefined();
 		expect(ctx.edit).toBeDefined();
 		expect(ctx.revision).toBeDefined();

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -1,19 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
+import type { WikiRegistry } from '../../src/wikis/wikiRegistry.js';
+import type { WikiSelection } from '../../src/wikis/wikiSelection.js';
 import { reconcileTools } from '../../src/runtime/reconcile.js';
-
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: vi.fn(),
-		isManagementAllowed: vi.fn(),
-	},
-	wikiSelection: {
-		getCurrent: vi.fn(),
-	},
-}));
-
-import { wikiRegistry, wikiSelection } from '../../src/wikis/state.js';
 
 const WRITE_TOOL_NAMES = [
 	'create-page',
@@ -67,7 +57,7 @@ const baseWiki: WikiConfig = {
 	scriptpath: '/w',
 };
 
-function setup({
+function makeMocks({
 	activeWiki,
 	wikis,
 	allowManagement,
@@ -75,28 +65,35 @@ function setup({
 	activeWiki: WikiConfig;
 	wikis: Record<string, WikiConfig>;
 	allowManagement: boolean;
-}): void {
-	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-	vi.mocked(wikiSelection.getCurrent).mockReturnValue({
-		key: Object.keys(wikis).find((k) => wikis[k] === activeWiki) ?? 'a',
-		config: activeWiki,
-	});
-	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-	vi.mocked(wikiRegistry.getAll).mockReturnValue(wikis);
-	// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-	vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(allowManagement);
+}): { registry: WikiRegistry; selection: WikiSelection } {
+	const registry: WikiRegistry = {
+		getAll: () => wikis,
+		get: (key: string) => wikis[key],
+		add: () => {},
+		remove: () => {},
+		isManagementAllowed: () => allowManagement,
+	};
+	const selection: WikiSelection = {
+		getCurrent: () => ({
+			key: Object.keys(wikis).find((k) => wikis[k] === activeWiki) ?? 'a',
+			config: activeWiki,
+		}),
+		setCurrent: () => {},
+		reset: () => {},
+	};
+	return { registry, selection };
 }
 
 describe('reconcileTools — applyReadOnlyRule', () => {
 	it('disables every write tool when the active wiki is readOnly', () => {
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
 			expect(mocks.get(name)!.enable).not.toHaveBeenCalled();
@@ -106,12 +103,12 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('does not touch non-write tools', () => {
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of NON_WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).not.toHaveBeenCalled();
 			expect(mocks.get(name)!.enable).not.toHaveBeenCalled();
@@ -121,12 +118,12 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('enables every write tool when the active wiki is not readOnly', () => {
 		const { tools, mocks } = makeToolMap(false);
 		const wiki = { ...baseWiki, readOnly: false };
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
 			expect(mocks.get(name)!.disable).not.toHaveBeenCalled();
@@ -135,12 +132,12 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 
 	it('treats missing readOnly as non-readOnly', () => {
 		const { tools, mocks } = makeToolMap(false);
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
 		}
@@ -149,22 +146,14 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('is idempotent: a second call with identical state performs zero toggles', () => {
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		setup({
-			activeWiki: wiki,
-			wikis: { a: wiki },
-			allowManagement: true,
-		});
-		reconcileTools(tools);
+		const m1 = makeMocks({ activeWiki: wiki, wikis: { a: wiki }, allowManagement: true });
+		reconcileTools(tools, m1.registry, m1.selection);
 		for (const m of mocks.values()) {
 			m.enable.mockClear();
 			m.disable.mockClear();
 		}
-		setup({
-			activeWiki: wiki,
-			wikis: { a: wiki },
-			allowManagement: true,
-		});
-		reconcileTools(tools);
+		const m2 = makeMocks({ activeWiki: wiki, wikis: { a: wiki }, allowManagement: true });
+		reconcileTools(tools, m2.registry, m2.selection);
 		for (const m of mocks.values()) {
 			expect(m.enable).not.toHaveBeenCalled();
 			expect(m.disable).not.toHaveBeenCalled();
@@ -175,12 +164,12 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 		const { tools, mocks } = makeToolMap(true);
 		tools.delete('upload-file');
 		const wiki = { ...baseWiki, readOnly: true };
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
-		expect(() => reconcileTools(tools)).not.toThrow();
+		expect(() => reconcileTools(tools, registry, selection)).not.toThrow();
 		for (const name of WRITE_TOOL_NAMES) {
 			if (name === 'upload-file') {
 				continue;
@@ -193,12 +182,12 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 describe('reconcileTools — applyWikiSetRule', () => {
 	it('disables add-wiki, remove-wiki, set-wiki when count is 1 and management is disallowed', () => {
 		const { tools, mocks } = makeToolMap(true);
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: false,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of ['add-wiki', 'remove-wiki', 'set-wiki']) {
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
 		}
@@ -206,12 +195,12 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('enables add-wiki only when count is 1 and management is allowed', () => {
 		const { tools, mocks } = makeToolMap(false);
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		expect(mocks.get('add-wiki')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('remove-wiki')!.disable).not.toHaveBeenCalled();
 		expect(mocks.get('set-wiki')!.disable).not.toHaveBeenCalled();
@@ -219,12 +208,12 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('enables set-wiki when count is 2 even if management is disallowed', () => {
 		const { tools, mocks } = makeToolMap(false);
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki, b: baseWiki },
 			allowManagement: false,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		expect(mocks.get('set-wiki')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('add-wiki')!.enable).not.toHaveBeenCalled();
 		expect(mocks.get('remove-wiki')!.enable).not.toHaveBeenCalled();
@@ -232,12 +221,12 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('enables all three when count is 2 and management is allowed', () => {
 		const { tools, mocks } = makeToolMap(false);
-		setup({
+		const { registry, selection } = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki, b: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, registry, selection);
 		for (const name of ['add-wiki', 'remove-wiki', 'set-wiki']) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
 		}
@@ -245,39 +234,39 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('transitions: count 1 to 2 enables set-wiki', () => {
 		const { tools, mocks } = makeToolMap(false);
-		setup({
+		const m1 = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, m1.registry, m1.selection);
 		expect(mocks.get('set-wiki')!.enabled).toBe(false);
 
-		setup({
+		const m2 = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki, b: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, m2.registry, m2.selection);
 		expect(mocks.get('set-wiki')!.enabled).toBe(true);
 	});
 
 	it('transitions: count 2 to 1 disables remove-wiki', () => {
 		const { tools, mocks } = makeToolMap(true);
-		setup({
+		const m1 = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki, b: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, m1.registry, m1.selection);
 		expect(mocks.get('remove-wiki')!.enabled).toBe(true);
 
-		setup({
+		const m2 = makeMocks({
 			activeWiki: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
-		reconcileTools(tools);
+		reconcileTools(tools, m2.registry, m2.selection);
 		expect(mocks.get('remove-wiki')!.enabled).toBe(false);
 	});
 });

--- a/tests/runtime/startup-banner.test.ts
+++ b/tests/runtime/startup-banner.test.ts
@@ -1,16 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { emitStartupBanner } from '../../src/runtime/banner.js';
+import type { WikiRegistry } from '../../src/wikis/wikiRegistry.js';
+import type { WikiSelection } from '../../src/wikis/wikiSelection.js';
+import type { WikiConfig } from '../../src/config/loadConfig.js';
 
-const mockWikiRegistry = {
-	getAll: () => ({ 'a.example': { sitename: 'A', server: 'https://a' } }),
+const baseWikiConfig: WikiConfig = {
+	sitename: 'A',
+	server: 'https://a',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+};
+
+const mockWikiRegistry: WikiRegistry = {
+	getAll: () => ({ 'a.example': baseWikiConfig }),
 	get: () => undefined,
 	add: () => {},
 	remove: () => {},
 	isManagementAllowed: () => false,
 };
 
-const mockWikiSelection = {
-	getCurrent: () => ({ key: 'a.example', config: {} }),
+const mockWikiSelection: WikiSelection = {
+	getCurrent: () => ({ key: 'a.example', config: baseWikiConfig }),
 	setCurrent: () => {},
 	reset: () => {},
 };
@@ -39,8 +49,8 @@ describe('startup banner', () => {
 		emitStartupBanner(
 			{ transport: 'stdio' },
 			{
-				wikiRegistry: mockWikiRegistry as never,
-				wikiSelection: mockWikiSelection as never,
+				wikiRegistry: mockWikiRegistry,
+				wikiSelection: mockWikiSelection,
 				uploadDirs: mockUploadDirs,
 			},
 		);
@@ -75,8 +85,8 @@ describe('startup banner', () => {
 				},
 			},
 			{
-				wikiRegistry: mockWikiRegistry as never,
-				wikiSelection: mockWikiSelection as never,
+				wikiRegistry: mockWikiRegistry,
+				wikiSelection: mockWikiSelection,
 				uploadDirs: mockUploadDirs,
 			},
 		);
@@ -100,8 +110,8 @@ describe('startup banner', () => {
 				http: { host: '127.0.0.1', port: 3000, maxRequestBody: '1mb' },
 			},
 			{
-				wikiRegistry: mockWikiRegistry as never,
-				wikiSelection: mockWikiSelection as never,
+				wikiRegistry: mockWikiRegistry,
+				wikiSelection: mockWikiSelection,
 				uploadDirs: mockUploadDirs,
 			},
 		);
@@ -115,9 +125,9 @@ describe('startup banner', () => {
 	});
 
 	it('classifies static-credential and never logs the token value', () => {
-		const staticRegistry = {
+		const staticRegistry: WikiRegistry = {
 			getAll: () => ({
-				'a.example': { sitename: 'A', server: 'https://a', token: 'SUPER-SECRET' },
+				'a.example': { ...baseWikiConfig, token: 'SUPER-SECRET' },
 			}),
 			get: () => undefined,
 			add: () => {},
@@ -128,8 +138,8 @@ describe('startup banner', () => {
 		emitStartupBanner(
 			{ transport: 'stdio' },
 			{
-				wikiRegistry: staticRegistry as never,
-				wikiSelection: mockWikiSelection as never,
+				wikiRegistry: staticRegistry,
+				wikiSelection: mockWikiSelection,
 				uploadDirs: mockUploadDirs,
 			},
 		);

--- a/tests/runtime/startup-banner.test.ts
+++ b/tests/runtime/startup-banner.test.ts
@@ -1,31 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: () => ({ 'a.example': { sitename: 'A', server: 'https://a' } }),
-		get: () => undefined,
-		add: () => {},
-		remove: () => {},
-		isManagementAllowed: () => false,
-	},
-	wikiSelection: {
-		getCurrent: () => ({ key: 'a.example', config: {} }),
-		setCurrent: () => {},
-		reset: () => {},
-	},
-	uploadDirs: { list: () => [] },
-	mwnProvider: {
-		get: () => Promise.reject(new Error('mwn not available in tests')),
-		invalidate: () => {},
-	},
-	licenseCache: {
-		get: () => undefined,
-		set: () => {},
-		delete: () => {},
-	},
-}));
-
 import { emitStartupBanner } from '../../src/runtime/banner.js';
+
+const mockWikiRegistry = {
+	getAll: () => ({ 'a.example': { sitename: 'A', server: 'https://a' } }),
+	get: () => undefined,
+	add: () => {},
+	remove: () => {},
+	isManagementAllowed: () => false,
+};
+
+const mockWikiSelection = {
+	getCurrent: () => ({ key: 'a.example', config: {} }),
+	setCurrent: () => {},
+	reset: () => {},
+};
+
+const mockUploadDirs = { list: () => [] };
 
 function captureLines(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown>[] {
 	return spy.mock.calls
@@ -46,7 +36,14 @@ describe('startup banner', () => {
 	});
 
 	it('emits exactly one startup event for stdio', () => {
-		emitStartupBanner({ transport: 'stdio' });
+		emitStartupBanner(
+			{ transport: 'stdio' },
+			{
+				wikiRegistry: mockWikiRegistry as never,
+				wikiSelection: mockWikiSelection as never,
+				uploadDirs: mockUploadDirs,
+			},
+		);
 
 		const events = captureLines(stderrSpy).filter((e) => e.event === 'startup');
 		expect(events).toHaveLength(1);
@@ -66,16 +63,23 @@ describe('startup banner', () => {
 	});
 
 	it('includes http fields when transport is http', () => {
-		emitStartupBanner({
-			transport: 'http',
-			http: {
-				host: '0.0.0.0',
-				port: 8080,
-				allowedHosts: ['wiki.example.org'],
-				allowedOrigins: ['https://wiki.example.org'],
-				maxRequestBody: '2mb',
+		emitStartupBanner(
+			{
+				transport: 'http',
+				http: {
+					host: '0.0.0.0',
+					port: 8080,
+					allowedHosts: ['wiki.example.org'],
+					allowedOrigins: ['https://wiki.example.org'],
+					maxRequestBody: '2mb',
+				},
 			},
-		});
+			{
+				wikiRegistry: mockWikiRegistry as never,
+				wikiSelection: mockWikiSelection as never,
+				uploadDirs: mockUploadDirs,
+			},
+		);
 
 		const events = captureLines(stderrSpy).filter((e) => e.event === 'startup');
 		expect(events).toHaveLength(1);
@@ -90,10 +94,17 @@ describe('startup banner', () => {
 	});
 
 	it('omits allowed_hosts/origins when not provided but always emits max_request_body', () => {
-		emitStartupBanner({
-			transport: 'http',
-			http: { host: '127.0.0.1', port: 3000, maxRequestBody: '1mb' },
-		});
+		emitStartupBanner(
+			{
+				transport: 'http',
+				http: { host: '127.0.0.1', port: 3000, maxRequestBody: '1mb' },
+			},
+			{
+				wikiRegistry: mockWikiRegistry as never,
+				wikiSelection: mockWikiSelection as never,
+				uploadDirs: mockUploadDirs,
+			},
+		);
 
 		const e = captureLines(stderrSpy).find((x) => x.event === 'startup');
 		expect(e).toBeDefined();
@@ -103,37 +114,25 @@ describe('startup banner', () => {
 		expect(e!.max_request_body).toBe('1mb');
 	});
 
-	it('classifies static-credential and never logs the token value', async () => {
-		vi.resetModules();
-		vi.doMock('../../src/wikis/state.js', () => ({
-			wikiRegistry: {
-				getAll: () => ({
-					'a.example': { sitename: 'A', server: 'https://a', token: 'SUPER-SECRET' },
-				}),
-				get: () => undefined,
-				add: () => {},
-				remove: () => {},
-				isManagementAllowed: () => false,
-			},
-			wikiSelection: {
-				getCurrent: () => ({ key: 'a.example', config: {} }),
-				setCurrent: () => {},
-				reset: () => {},
-			},
-			uploadDirs: { list: () => [] },
-			mwnProvider: {
-				get: () => Promise.reject(new Error('mwn not available in tests')),
-				invalidate: () => {},
-			},
-			licenseCache: {
-				get: () => undefined,
-				set: () => {},
-				delete: () => {},
-			},
-		}));
+	it('classifies static-credential and never logs the token value', () => {
+		const staticRegistry = {
+			getAll: () => ({
+				'a.example': { sitename: 'A', server: 'https://a', token: 'SUPER-SECRET' },
+			}),
+			get: () => undefined,
+			add: () => {},
+			remove: () => {},
+			isManagementAllowed: () => false,
+		};
 
-		const { emitStartupBanner: esb } = await import('../../src/runtime/banner.js');
-		esb({ transport: 'stdio' });
+		emitStartupBanner(
+			{ transport: 'stdio' },
+			{
+				wikiRegistry: staticRegistry as never,
+				wikiSelection: mockWikiSelection as never,
+				uploadDirs: mockUploadDirs,
+			},
+		);
 
 		const allOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
 		expect(allOutput).not.toContain('SUPER-SECRET');

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -4,6 +4,8 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
 import { reconcileTools } from '../../src/runtime/reconcile.js';
+import { registerAllTools } from '../../src/tools/index.js';
+import { fakeContext } from '../helpers/fakeContext.js';
 
 const wikiA: WikiConfig = {
 	sitename: 'Writeable',
@@ -26,30 +28,7 @@ const wikiStore: { current: WikiConfig; byKey: Record<string, WikiConfig> } = {
 	byKey: { a: wikiA, b: wikiB },
 };
 
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: vi.fn(() => wikiStore.byKey),
-		get: vi.fn((key: string) => wikiStore.byKey[key]),
-		isManagementAllowed: vi.fn(),
-	},
-	wikiSelection: {
-		getCurrent: vi.fn(() => ({
-			key:
-				Object.keys(wikiStore.byKey).find((k) => wikiStore.byKey[k] === wikiStore.current) ?? 'a',
-			config: wikiStore.current,
-		})),
-		setCurrent: vi.fn((key: string) => {
-			if (!wikiStore.byKey[key]) {
-				throw new Error(`Wiki "${key}" not found`);
-			}
-			wikiStore.current = wikiStore.byKey[key];
-		}),
-	},
-}));
-
-import { wikiRegistry } from '../../src/wikis/state.js';
-import { registerAllTools } from '../../src/tools/index.js';
-import { fakeContext } from '../helpers/fakeContext.js';
+const isManagementAllowedRef = { current: true };
 
 const WRITE_TOOLS = [
 	'create-page',
@@ -70,25 +49,27 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 		{ capabilities: { tools: { listChanged: true } } },
 	);
 	const tools = new Map<string, RegisteredTool>();
-	const reconcile = () => reconcileTools(tools);
+	const wikiRegistryMock = {
+		getAll: () => wikiStore.byKey,
+		get: (key: string) => wikiStore.byKey[key],
+		add: () => {},
+		remove: () => {},
+		isManagementAllowed: () => isManagementAllowedRef.current,
+	};
+	const wikiSelectionMock = {
+		getCurrent: () => ({ key: currentKey(), config: wikiStore.current }),
+		setCurrent: (key: string) => {
+			if (!wikiStore.byKey[key]) {
+				throw new Error(`Wiki "${key}" not found`);
+			}
+			wikiStore.current = wikiStore.byKey[key];
+		},
+		reset: () => {},
+	};
+	const reconcile = () => reconcileTools(tools, wikiRegistryMock, wikiSelectionMock);
 	const ctx = fakeContext({
-		wikis: {
-			getAll: () => wikiStore.byKey,
-			get: (key: string) => wikiStore.byKey[key],
-			add: () => {},
-			remove: () => {},
-			isManagementAllowed: () => wikiRegistry.isManagementAllowed(),
-		},
-		selection: {
-			getCurrent: () => ({ key: currentKey(), config: wikiStore.current }),
-			setCurrent: (key: string) => {
-				if (!wikiStore.byKey[key]) {
-					throw new Error(`Wiki "${key}" not found`);
-				}
-				wikiStore.current = wikiStore.byKey[key];
-			},
-			reset: () => {},
-		},
+		wikis: wikiRegistryMock,
+		selection: wikiSelectionMock,
 	});
 	const registered = registerAllTools(server, reconcile, ctx);
 	for (const [name, tool] of registered) {
@@ -109,8 +90,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('lists add-wiki and remove-wiki when wiki management is allowed', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
+		isManagementAllowedRef.current = true;
 		const { client } = await connectClientAndServer();
 
 		const { tools } = await client.listTools();
@@ -122,8 +102,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('omits add-wiki and remove-wiki but keeps set-wiki when management is disallowed and 2+ wikis are configured', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
+		isManagementAllowedRef.current = false;
 		const { client } = await connectClientAndServer();
 
 		const { tools } = await client.listTools();
@@ -136,8 +115,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('hides set-wiki, add-wiki, and remove-wiki on the hosted single-wiki shape (1 wiki + management disallowed)', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
+		isManagementAllowedRef.current = false;
 		const originalByKey = wikiStore.byKey;
 		wikiStore.byKey = { a: wikiA };
 		try {
@@ -156,8 +134,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('rejects calls to add-wiki with a disabled error when wiki management is disallowed', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(false);
+		isManagementAllowedRef.current = false;
 		const { client } = await connectClientAndServer();
 
 		const result = await client.callTool({
@@ -171,8 +148,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('shows set-wiki and remove-wiki when 2 wikis are configured and management is allowed', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
+		isManagementAllowedRef.current = true;
 		const { client } = await connectClientAndServer();
 
 		const names = (await client.listTools()).tools.map((t) => t.name);
@@ -182,8 +158,7 @@ describe('registerAllTools — wiki management gating', () => {
 	});
 
 	it('hides set-wiki and remove-wiki when only 1 wiki is configured and management is allowed', async () => {
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
+		isManagementAllowedRef.current = true;
 		const originalByKey = wikiStore.byKey;
 		wikiStore.byKey = { a: wikiA };
 		try {
@@ -202,8 +177,7 @@ describe('registerAllTools — wiki management gating', () => {
 describe('registerAllTools — per-wiki readOnly', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		// oxlint-disable-next-line typescript/unbound-method -- vitest mock, bound at call time
-		vi.mocked(wikiRegistry.isManagementAllowed).mockReturnValue(true);
+		isManagementAllowedRef.current = true;
 		wikiStore.current = wikiA;
 	});
 

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -85,7 +85,6 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 
 describe('registerAllTools — wiki management gating', () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
 		wikiStore.current = wikiA;
 	});
 
@@ -176,7 +175,6 @@ describe('registerAllTools — wiki management gating', () => {
 
 describe('registerAllTools — per-wiki readOnly', () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
 		isManagementAllowedRef.current = true;
 		wikiStore.current = wikiA;
 	});

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -50,7 +50,10 @@ const mockMwnProvider = {
 function makeApp(): express.Express {
 	const app = express();
 	mountMetricsEndpoint(app);
-	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection as never, mwnProvider: mockMwnProvider as never });
+	mountReadyEndpoint(app, {
+		wikiSelection: mockWikiSelection as never,
+		mwnProvider: mockMwnProvider as never,
+	});
 	return app;
 }
 

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -2,28 +2,28 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const mockRequest = vi.fn();
 
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: () => ({}),
-		get: () => undefined,
-		add: () => {},
-		remove: () => {},
-		isManagementAllowed: () => false,
-	},
-	wikiSelection: {
-		getCurrent: () => ({ key: 'example.org', config: {} }),
-		setCurrent: () => {},
-		reset: () => {},
-	},
-	uploadDirs: { list: () => [] },
-	mwnProvider: {
-		get: async () => ({ request: mockRequest }),
-		invalidate: () => {},
-	},
-	licenseCache: {
-		get: () => undefined,
-		set: () => {},
-		delete: () => {},
+vi.mock('../../src/config/loadConfig.js', () => ({
+	loadConfigFromFile: () => ({
+		defaultWiki: 'example.org',
+		wikis: {
+			'example.org': {
+				sitename: 'Example',
+				server: 'https://example.org',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				token: null,
+				username: null,
+				password: null,
+			},
+		},
+		uploadDirs: [],
+	}),
+}));
+
+vi.mock('../../src/wikis/mwnProvider.js', () => ({
+	MwnProviderImpl: class {
+		get = async () => ({ request: mockRequest });
+		invalidate = () => {};
 	},
 }));
 
@@ -36,10 +36,21 @@ import {
 } from '../../src/transport/streamableHttp.js';
 import { __resetMetricsForTesting, setSessionsProvider } from '../../src/runtime/metrics.js';
 
+const mockWikiSelection = {
+	getCurrent: () => ({ key: 'example.org', config: {} }),
+	setCurrent: () => {},
+	reset: () => {},
+};
+
+const mockMwnProvider = {
+	get: async () => ({ request: mockRequest }),
+	invalidate: () => {},
+};
+
 function makeApp(): express.Express {
 	const app = express();
 	mountMetricsEndpoint(app);
-	mountReadyEndpoint(app);
+	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection as never, mwnProvider: mockMwnProvider as never });
 	return app;
 }
 

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const mockRequest = vi.fn();
 
+// Two mock layers are needed and they serve different purposes:
+//
+// 1. The vi.mock() calls below intercept module imports so that the top-level
+//    bootstrap in streamableHttp.ts (loadConfigFromFile, evaluateBearerGuard,
+//    emitStartupBanner, app.listen) can run on import without needing a real
+//    config.json or a reachable wiki. These keep the *module's own* state
+//    benign so importing it doesn't crash.
+//
+// 2. The mockWikiSelection and mockMwnProvider objects below are passed
+//    explicitly to mountReadyEndpoint() in each test's makeApp(). The tests
+//    create their own express app independent of the module-level one, so
+//    these inline mocks are what actually drive the test logic. Do not
+//    collapse the two layers — they target different code paths.
+
 vi.mock('../../src/config/loadConfig.js', () => ({
 	loadConfigFromFile: () => ({
 		defaultWiki: 'example.org',
@@ -35,25 +49,33 @@ import {
 	__resetReadyCacheForTesting,
 } from '../../src/transport/streamableHttp.js';
 import { __resetMetricsForTesting, setSessionsProvider } from '../../src/runtime/metrics.js';
+import type { WikiSelection } from '../../src/wikis/wikiSelection.js';
+import type { MwnProvider } from '../../src/wikis/mwnProvider.js';
+import type { WikiConfig } from '../../src/config/loadConfig.js';
 
-const mockWikiSelection = {
-	getCurrent: () => ({ key: 'example.org', config: {} }),
+const exampleWikiConfig: WikiConfig = {
+	sitename: 'Example',
+	server: 'https://example.org',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+};
+
+const mockWikiSelection: WikiSelection = {
+	getCurrent: () => ({ key: 'example.org', config: exampleWikiConfig }),
 	setCurrent: () => {},
 	reset: () => {},
 };
 
-const mockMwnProvider = {
-	get: async () => ({ request: mockRequest }),
+const mockMwnProvider: MwnProvider = {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Mwn has 100+ methods; tests only use request().
+	get: async () => ({ request: mockRequest }) as never,
 	invalidate: () => {},
 };
 
 function makeApp(): express.Express {
 	const app = express();
 	mountMetricsEndpoint(app);
-	mountReadyEndpoint(app, {
-		wikiSelection: mockWikiSelection as never,
-		mwnProvider: mockMwnProvider as never,
-	});
+	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection, mwnProvider: mockMwnProvider });
 	return app;
 }
 

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockRequest = vi.fn();
 
+// Two mock layers are needed and they serve different purposes:
+//
+// 1. The vi.mock() calls below intercept module imports so that the top-level
+//    bootstrap in streamableHttp.ts (loadConfigFromFile, evaluateBearerGuard,
+//    emitStartupBanner, app.listen) can run on import without needing a real
+//    config.json or a reachable wiki. These keep the *module's own* state
+//    benign so importing it doesn't crash.
+//
+// 2. The mockWikiSelection and mockMwnProvider objects below are passed
+//    explicitly to mountReadyEndpoint() in each test's makeApp(). The tests
+//    create their own express app independent of the module-level one, so
+//    these inline mocks are what actually drive the test logic. Do not
+//    collapse the two layers — they target different code paths.
+
 vi.mock('../../src/config/loadConfig.js', () => ({
 	loadConfigFromFile: () => ({
 		defaultWiki: 'example.org',
@@ -34,24 +48,32 @@ import {
 	__resetReadyCacheForTesting,
 	__probeDefaultWikiForTesting,
 } from '../../src/transport/streamableHttp.js';
+import type { WikiSelection } from '../../src/wikis/wikiSelection.js';
+import type { MwnProvider } from '../../src/wikis/mwnProvider.js';
+import type { WikiConfig } from '../../src/config/loadConfig.js';
 
-const mockWikiSelection = {
-	getCurrent: () => ({ key: 'example.org', config: {} }),
+const exampleWikiConfig: WikiConfig = {
+	sitename: 'Example',
+	server: 'https://example.org',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+};
+
+const mockWikiSelection: WikiSelection = {
+	getCurrent: () => ({ key: 'example.org', config: exampleWikiConfig }),
 	setCurrent: () => {},
 	reset: () => {},
 };
 
-const mockMwnProvider = {
-	get: async () => ({ request: mockRequest }),
+const mockMwnProvider: MwnProvider = {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Mwn has 100+ methods; tests only use request().
+	get: async () => ({ request: mockRequest }) as never,
 	invalidate: () => {},
 };
 
 function makeApp() {
 	const app = express();
-	mountReadyEndpoint(app, {
-		wikiSelection: mockWikiSelection as never,
-		mwnProvider: mockMwnProvider as never,
-	});
+	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection, mwnProvider: mockMwnProvider });
 	return app;
 }
 
@@ -100,10 +122,7 @@ describe('/ready', () => {
 		vi.useFakeTimers();
 		mockRequest.mockReturnValue(new Promise(() => undefined));
 
-		const probePromise = __probeDefaultWikiForTesting(
-			mockWikiSelection as never,
-			mockMwnProvider as never,
-		);
+		const probePromise = __probeDefaultWikiForTesting(mockWikiSelection, mockMwnProvider);
 		await vi.advanceTimersByTimeAsync(3001);
 		const entry = await probePromise;
 

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -2,28 +2,28 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockRequest = vi.fn();
 
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: () => ({}),
-		get: () => undefined,
-		add: () => {},
-		remove: () => {},
-		isManagementAllowed: () => false,
-	},
-	wikiSelection: {
-		getCurrent: () => ({ key: 'example.org', config: {} }),
-		setCurrent: () => {},
-		reset: () => {},
-	},
-	uploadDirs: { list: () => [] },
-	mwnProvider: {
-		get: async () => ({ request: mockRequest }),
-		invalidate: () => {},
-	},
-	licenseCache: {
-		get: () => undefined,
-		set: () => {},
-		delete: () => {},
+vi.mock('../../src/config/loadConfig.js', () => ({
+	loadConfigFromFile: () => ({
+		defaultWiki: 'example.org',
+		wikis: {
+			'example.org': {
+				sitename: 'Example',
+				server: 'https://example.org',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				token: null,
+				username: null,
+				password: null,
+			},
+		},
+		uploadDirs: [],
+	}),
+}));
+
+vi.mock('../../src/wikis/mwnProvider.js', () => ({
+	MwnProviderImpl: class {
+		get = async () => ({ request: mockRequest });
+		invalidate = () => {};
 	},
 }));
 
@@ -35,9 +35,20 @@ import {
 	__probeDefaultWikiForTesting,
 } from '../../src/transport/streamableHttp.js';
 
+const mockWikiSelection = {
+	getCurrent: () => ({ key: 'example.org', config: {} }),
+	setCurrent: () => {},
+	reset: () => {},
+};
+
+const mockMwnProvider = {
+	get: async () => ({ request: mockRequest }),
+	invalidate: () => {},
+};
+
 function makeApp() {
 	const app = express();
-	mountReadyEndpoint(app);
+	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection as never, mwnProvider: mockMwnProvider as never });
 	return app;
 }
 
@@ -86,7 +97,10 @@ describe('/ready', () => {
 		vi.useFakeTimers();
 		mockRequest.mockReturnValue(new Promise(() => undefined));
 
-		const probePromise = __probeDefaultWikiForTesting();
+		const probePromise = __probeDefaultWikiForTesting(
+			mockWikiSelection as never,
+			mockMwnProvider as never,
+		);
 		await vi.advanceTimersByTimeAsync(3001);
 		const entry = await probePromise;
 

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -48,7 +48,10 @@ const mockMwnProvider = {
 
 function makeApp() {
 	const app = express();
-	mountReadyEndpoint(app, { wikiSelection: mockWikiSelection as never, mwnProvider: mockMwnProvider as never });
+	mountReadyEndpoint(app, {
+		wikiSelection: mockWikiSelection as never,
+		mwnProvider: mockMwnProvider as never,
+	});
 	return app;
 }
 

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -1,35 +1,27 @@
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../../src/wikis/state.js', () => ({
-	wikiRegistry: {
-		getAll: () => ({}),
-		get: () => undefined,
-		add: () => {},
-		remove: () => {},
-		isManagementAllowed: () => true,
-	},
-	wikiSelection: {
-		getCurrent: () => ({
-			key: 'test',
-			config: {
+vi.mock('../../src/config/loadConfig.js', () => ({
+	loadConfigFromFile: () => ({
+		defaultWiki: 'test',
+		wikis: {
+			test: {
 				sitename: 'Test',
 				server: 'https://test.example',
 				articlepath: '/wiki',
 				scriptpath: '/w',
+				token: null,
+				username: null,
+				password: null,
 			},
-		}),
-		setCurrent: () => {},
-		reset: () => {},
-	},
-	uploadDirs: { list: () => [] },
-	mwnProvider: {
-		get: () => Promise.reject(new Error('mwn not available in tests')),
-		invalidate: () => {},
-	},
-	licenseCache: {
-		get: () => undefined,
-		set: () => {},
-		delete: () => {},
+		},
+		uploadDirs: [],
+	}),
+}));
+
+vi.mock('../../src/wikis/mwnProvider.js', () => ({
+	MwnProviderImpl: class {
+		get = () => Promise.reject(new Error('mwn not available in tests'));
+		invalidate = () => {};
 	},
 }));
 


### PR DESCRIPTION
### Summary

Refactor `src/wikis/state.ts` from eager singleton exports + top-level `loadConfigFromFile()` to a `createAppState(config: Config): AppState` factory invoked by the transport composition roots (`stdio.ts`, `streamableHttp.ts`). Production behaviour is byte-identical (verified by 716 tests + manual MCP Inspector smoke against `en.wikipedia.org`).

### Why

`src/wikis/state.ts` was the only module in the source tree doing eager filesystem I/O at import (`loadConfigFromFile()` ran as a top-level side effect). Two consequences:

- A clean clone whose `config.json` referenced any path that didn't exist (e.g. `/tmp/cdx-icons` from the example config) caused every test that transitively imported state.js to fail at import time, before any test logic ran.
- The five exported singletons (`wikiRegistry`, `wikiSelection`, `uploadDirs`, `mwnProvider`, `licenseCache`) were module-level mutable state backed by the loaded config, blocking dependency injection in tests and making any future per-request or multi-tenant config story structurally impossible.

The codebase already follows DI elsewhere — every tool receives a `ToolContext`, `fakeContext()` constructs one for tests. `state.ts` was the outlier. This PR extracts it into a factory and threads the result through existing helpers.

### What changes

- `src/wikis/state.ts` exports `interface AppState` and `function createAppState(config)`. No top-level side effects.
- `src/transport/stdio.ts` and `src/transport/streamableHttp.ts` call `loadConfigFromFile()` then `createAppState(config)` at startup, then pass state into `createToolContext`, `emitStartupBanner`, and `mountReadyEndpoint`.
- `src/runtime/createContext.ts`, `src/runtime/banner.ts`, `src/runtime/reconcile.ts` accept their dependencies as parameters instead of importing from state.
- `src/resources/index.ts` reads `licenseCache` from `ctx` (newly added field on `ToolContext`).
- `src/wikis/utils.ts` — `getPageUrl` accepts `wikiSelection` as a parameter; ten tool files pass `ctx.selection` at the call site.
- Six test files migrated from `vi.mock('../../src/wikis/state.js', …)` to direct mock injection (`tests/runtime/reconcile.test.ts`, `tests/runtime/startup-banner.test.ts`, `tests/tools/index.test.ts`, `tests/transport/metrics.test.ts`, `tests/transport/ready.test.ts`, `tests/transport/streamableHttp.test.ts`).

### What this PR does NOT do

I initially scoped a follow-on round of vitest config flips (`pool: 'threads'`, `isolate: false`) on top of this refactor. The wins were modest (~16% wall-time reduction on the reference machine), surfaced module-cache leaks in three more test files (each requiring its own production-code seam or mock-pattern migration), and one of those leaks shipped a CI failure that needed a follow-up commit. The complexity-vs-gain trade didn't justify keeping it. Reverted to leave just the structural refactor, which stands on its own merits.

### Test plan

- [x] `npm test` — 716 passing, 59 files
- [x] `npx tsgo --noEmit` clean
- [x] `npm run lint` clean
- [x] Manual smoke via MCP Inspector CLI against `en.wikipedia.org`: `tools/list`, `set-wiki`, and `get-page "Web browser"` all return expected results (exercises `MwnProvider`, `WikiSelection`, `ToolContext` end-to-end)

### Notes

- `src/wikis/state.ts` no longer reads `config.json` at import. The bootstrap path in both transports loads it explicitly and constructs state once. Same effective order as before, just triggered by an explicit call rather than module-load side effects.
- `ToolContext` gains a `licenseCache: LicenseCache` field so `src/resources/index.ts` can read it via `ctx` instead of importing from state. `fakeContext` stubs it.
