### PR TITLE
Add MCP_LOG_LEVEL env var to gate logger output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- `MCP_LOG_LEVEL` env var (default `debug`) sets the minimum severity for logger output. Filters both stderr telemetry and the `sendLoggingMessage` broadcast. Accepts the eight RFC 5424 levels plus `silent`. Invalid values throw on first log call.
 - Optional `GET /metrics` Prometheus endpoint on the HTTP transport, enabled with `MCP_METRICS=true`. Exposes tool-call counters, duration histograms, upstream status totals, active sessions, and readiness-probe failures.
 - `SIGTERM` and `SIGINT` now drain in-flight `/mcp` calls and close active StreamableHTTP sessions before exit, with a structured `event: "shutdown"` / `event: "shutdown_complete"` pair on stderr. Configurable via `MCP_SHUTDOWN_GRACE_MS` (default `10000`). Stdio transport closes its single transport on the same signals.
 - `MCP_MAX_REQUEST_BODY` env var (default `1mb`) caps HTTP request body size, replacing body-parser's silent 100 kB default that was rejecting long-form wikitext edits. Oversize requests return a JSON-RPC 413; the resolved value appears in the startup banner.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. Otherwise the server refuses to start, preventing silent shared-identity fallback for unauthenticated requests. | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by `get-page`, `get-pages`, `parse-wikitext`, and `compare-pages`. Oversized bodies are truncated with a trailing marker. Tune to the target LLM client's tool-response budget. | `50000` |
+| `MCP_LOG_LEVEL` | Minimum severity for logger output (stderr telemetry and `sendLoggingMessage` broadcast). One of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, or `silent`. Invalid values fail loudly on first log call. | `debug` |
 | `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings like `512kb` or `1mb`. Oversize requests get a JSON-RPC 413. | `1mb` |
 | `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
 | `MCP_SHUTDOWN_GRACE_MS` | Maximum time in ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT` before exiting. Capped at 600000 (10 min); invalid values fall back to the default with a warning. | `10000` |

--- a/server.json
+++ b/server.json
@@ -34,6 +34,22 @@
           "default": "50000"
         },
         {
+          "name": "MCP_LOG_LEVEL",
+          "description": "Minimum severity for logger output (stderr telemetry and sendLoggingMessage broadcast). Invalid values fail loudly on first log call.",
+          "choices": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "error",
+            "critical",
+            "alert",
+            "emergency",
+            "silent"
+          ],
+          "default": "debug"
+        },
+        {
           "name": "MCP_MAX_REQUEST_BODY",
           "description": "Maximum HTTP request body size on the StreamableHTTP transport. Accepts size strings like 1mb or 512kb.",
           "default": "1mb"
@@ -89,6 +105,22 @@
           "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
           "format": "number",
           "default": "50000"
+        },
+        {
+          "name": "MCP_LOG_LEVEL",
+          "description": "Minimum severity for logger output (stderr telemetry and sendLoggingMessage broadcast). Invalid values fail loudly on first log call.",
+          "choices": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "error",
+            "critical",
+            "alert",
+            "emergency",
+            "silent"
+          ],
+          "default": "debug"
         },
         {
           "name": "MCP_MAX_REQUEST_BODY",

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -43,16 +43,20 @@ const LEVEL_RANK: Record<LogLevel | 'silent', number> = {
 	silent: 8,
 };
 
+function isThresholdKey(raw: string): raw is keyof typeof LEVEL_RANK {
+	return Object.hasOwn(LEVEL_RANK, raw);
+}
+
 function currentThreshold(): number {
 	const raw = process.env.MCP_LOG_LEVEL;
 	if (raw === undefined || raw === '') {
 		return LEVEL_RANK.debug;
 	}
-	if (!Object.hasOwn(LEVEL_RANK, raw)) {
+	if (!isThresholdKey(raw)) {
 		const valid = Object.keys(LEVEL_RANK).join(', ');
 		throw new Error(`Invalid MCP_LOG_LEVEL "${raw}". Valid values: ${valid}.`);
 	}
-	return LEVEL_RANK[raw as LogLevel | 'silent'];
+	return LEVEL_RANK[raw];
 }
 
 function buildLogObject(

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -48,7 +48,7 @@ function currentThreshold(): number {
 	if (raw === undefined || raw === '') {
 		return LEVEL_RANK.debug;
 	}
-	if (!(raw in LEVEL_RANK)) {
+	if (!Object.hasOwn(LEVEL_RANK, raw)) {
 		const valid = Object.keys(LEVEL_RANK).join(', ');
 		throw new Error(`Invalid MCP_LOG_LEVEL "${raw}". Valid values: ${valid}.`);
 	}

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -31,6 +31,30 @@ export function getRegisteredServerCount(): number {
 
 const RESERVED_KEYS = new Set<string>(['ts', 'level', 'message']);
 
+const LEVEL_RANK: Record<LogLevel | 'silent', number> = {
+	debug: 0,
+	info: 1,
+	notice: 2,
+	warning: 3,
+	error: 4,
+	critical: 5,
+	alert: 6,
+	emergency: 7,
+	silent: 8,
+};
+
+function currentThreshold(): number {
+	const raw = process.env.MCP_LOG_LEVEL;
+	if (raw === undefined || raw === '') {
+		return LEVEL_RANK.debug;
+	}
+	if (!(raw in LEVEL_RANK)) {
+		const valid = Object.keys(LEVEL_RANK).join(', ');
+		throw new Error(`Invalid MCP_LOG_LEVEL "${raw}". Valid values: ${valid}.`);
+	}
+	return LEVEL_RANK[raw as LogLevel | 'silent'];
+}
+
 function buildLogObject(
 	level: LogLevel,
 	message: string,
@@ -61,11 +85,17 @@ const swallowNotificationError = (): undefined => undefined;
 // sendLoggingMessage broadcast. Used for operator-facing telemetry
 // (e.g. tool_call events) that must not leak to connected clients.
 export function emitTelemetryEvent(level: LogLevel, data: LogContext): void {
+	if (LEVEL_RANK[level] < currentThreshold()) {
+		return;
+	}
 	const line = buildLogObject(level, '', data);
 	process.stderr.write(JSON.stringify(line) + '\n');
 }
 
 function emit(level: LogLevel, message: string, data?: LogContext): void {
+	if (LEVEL_RANK[level] < currentThreshold()) {
+		return;
+	}
 	const line = buildLogObject(level, message, data);
 	process.stderr.write(JSON.stringify(line) + '\n');
 

--- a/tests/config/loadConfig.test.ts
+++ b/tests/config/loadConfig.test.ts
@@ -23,6 +23,7 @@ describe('loadConfigFromFile', () => {
 
 	beforeEach(() => {
 		vi.resetModules();
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 

--- a/tests/runtime/dispatcher.test.ts
+++ b/tests/runtime/dispatcher.test.ts
@@ -102,12 +102,14 @@ describe('dispatcher emits tool_call telemetry', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
 		clearRegisteredServers();
+		vi.unstubAllEnvs();
 	});
 
 	it('emits a success tool_call event on a successful handler', async () => {

--- a/tests/runtime/instrument.test.ts
+++ b/tests/runtime/instrument.test.ts
@@ -156,12 +156,14 @@ describe('emitToolCall', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
 		clearRegisteredServers();
+		vi.unstubAllEnvs();
 	});
 
 	it('emits a success line with tool, outcome, duration_ms and integer rounding', () => {

--- a/tests/runtime/logger.test.ts
+++ b/tests/runtime/logger.test.ts
@@ -209,6 +209,11 @@ describe('logger', () => {
 			);
 		});
 
+		it('throws on prototype-chain keys like toString', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'toString');
+			expect(() => logger.info('x')).toThrow(/MCP_LOG_LEVEL.*toString/s);
+		});
+
 		it('does not broadcast to registered servers when below threshold', () => {
 			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
 			const fake = fakeServer();

--- a/tests/runtime/logger.test.ts
+++ b/tests/runtime/logger.test.ts
@@ -4,6 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
 	clearRegisteredServers,
+	emitTelemetryEvent,
 	getRegisteredServerCount,
 	logger,
 	registerServer,
@@ -30,12 +31,14 @@ describe('logger', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		clearRegisteredServers();
 		stderrSpy.mockRestore();
+		vi.unstubAllEnvs();
 	});
 
 	describe('stderr output (JSON per line)', () => {
@@ -165,6 +168,66 @@ describe('logger', () => {
 			expect(() => logger.error('boom')).not.toThrow();
 			// Allow microtask to flush so the .catch handler runs.
 			await new Promise((resolve) => setImmediate(resolve));
+		});
+	});
+
+	describe('MCP_LOG_LEVEL threshold', () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it('drops below-threshold stderr writes', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
+			logger.info('should be filtered');
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
+
+		it('emits at-or-above-threshold messages', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
+			logger.warning('kept');
+			logger.error('also kept');
+			expect(stderrSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('silent drops every level including emergency', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'silent');
+			logger.debug('no');
+			logger.info('no');
+			logger.warning('no');
+			logger.error('no');
+			logger.emergency('no');
+			expect(stderrSpy).not.toHaveBeenCalled();
+		});
+
+		it('unset env behaves like debug (everything emits)', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', '');
+			logger.debug('kept');
+			logger.info('kept');
+			expect(stderrSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('throws on first emit with an invalid value', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'verbose');
+			expect(() => logger.info('x')).toThrow(
+				/MCP_LOG_LEVEL.*verbose.*debug.*info.*notice.*warning.*error.*critical.*alert.*emergency.*silent/s,
+			);
+		});
+
+		it('does not broadcast to registered servers when below threshold', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
+			const fake = fakeServer();
+			registerServer(asMcpServer(fake));
+			logger.info('filtered');
+			expect(fake.sendLoggingMessage).not.toHaveBeenCalled();
+			unregisterServer(asMcpServer(fake));
+		});
+
+		it('gates emitTelemetryEvent with the same threshold', () => {
+			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
+			emitTelemetryEvent('info', { event: 'tool_call', tool: 'x' });
+			expect(stderrSpy).not.toHaveBeenCalled();
+			emitTelemetryEvent('error', { event: 'tool_call', tool: 'x' });
+			expect(stderrSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/tests/runtime/logger.test.ts
+++ b/tests/runtime/logger.test.ts
@@ -172,10 +172,6 @@ describe('logger', () => {
 	});
 
 	describe('MCP_LOG_LEVEL threshold', () => {
-		afterEach(() => {
-			vi.unstubAllEnvs();
-		});
-
 		it('drops below-threshold stderr writes', () => {
 			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
 			logger.info('should be filtered');

--- a/tests/runtime/shutdown.test.ts
+++ b/tests/runtime/shutdown.test.ts
@@ -5,11 +5,13 @@ describe('resolveShutdownGrace', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
+		vi.unstubAllEnvs();
 	});
 
 	function warningLines(): string[] {
@@ -81,11 +83,13 @@ describe('registerShutdownHandlers (http)', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
+		vi.unstubAllEnvs();
 	});
 
 	function setup(opts: { inFlight: number; sessions: number; graceMs?: number }) {
@@ -199,11 +203,13 @@ describe('registerShutdownHandlers (stdio)', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
+		vi.unstubAllEnvs();
 	});
 
 	it('closes the stdio transport and exits 0', async () => {

--- a/tests/runtime/startup-banner.test.ts
+++ b/tests/runtime/startup-banner.test.ts
@@ -38,11 +38,13 @@ describe('startup banner', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
 		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 	});
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
+		vi.unstubAllEnvs();
 	});
 
 	it('emits exactly one startup event for stdio', () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,4 @@
+// Silence logger output during vitest runs so structured JSON lines
+// don't leak into the reporter between test names. Tests that assert
+// on stderr output override this with vi.stubEnv('MCP_LOG_LEVEL', 'debug').
+process.env.MCP_LOG_LEVEL = 'silent';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig( {
 	test: {
 		root: '.',
 		include: [ 'tests/**/*.test.ts' ],
+		setupFiles: [ 'tests/setup.ts' ],
 		passWithNoTests: true
 	}
 } );


### PR DESCRIPTION
## Summary

- Add a `MCP_LOG_LEVEL` env var that gates both stderr telemetry and the `sendLoggingMessage` broadcast in `src/runtime/logger.ts`. Accepts the eight RFC 5424 levels plus `silent`. Default `debug` preserves prior behavior byte-for-byte.
- Read the threshold per-call in `currentThreshold()` so tests can `vi.stubEnv` mid-suite without `vi.resetModules()`. Validation uses `Object.hasOwn` (not `in`) so prototype-chain keys like `toString` don't slip through.
- Set `MCP_LOG_LEVEL=silent` in a new `tests/setup.ts` so structured telemetry stops leaking into vitest reporter output between test names. Six existing test files that assert on stderr opt back in to `debug` via a `vi.stubEnv` + `vi.unstubAllEnvs` pair.
- Document the var in `README.md`, `server.json` (both `mcpb` and `npm` package blocks), and `CHANGELOG.md` `[Unreleased]` → `Added`.

## Commits

- `eb1567c` — Add MCP_LOG_LEVEL env var to gate logger output
- `aa214ec` — Drop redundant inner afterEach in logger threshold tests
- `c5c41ea` — Document MCP_LOG_LEVEL env var
- `568466a` — Reject prototype-chain keys in MCP_LOG_LEVEL validation
- `f7027c1` — Use a type guard for MCP_LOG_LEVEL key narrowing

## Test plan

- [x] `npm test` — 724/724 pass
- [x] `npm test 2>&1 | grep -cE '^\{'` — 0 (no JSON telemetry leaks in reporter)
- [x] `node scripts/validate-server-json.cjs` — exit 0
- [x] `npm run lint` — 0 errors, 353 warnings (no new warnings introduced)
- [x] `npm run fmt:check` — clean
- [x] Banner still prints at default; suppressed at `MCP_LOG_LEVEL=warning`
- [x] Invalid value (`MCP_LOG_LEVEL=verbose` or `MCP_LOG_LEVEL=toString`) throws with operator-readable error naming the variable and accepted values

🤖 Generated with [Claude Code](https://claude.com/claude-code)