### PR TITLE
Stop OAuth gate from blocking management and oauth-* tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- The dispatcher OAuth gate no longer fires for `add-wiki`, `set-wiki`, `remove-wiki`, `oauth-status`, or `oauth-logout`. These tools operate on server-local state (the wiki registry, the OAuth token store) and don't need a token for the active wiki. Without this fix, a wiki whose OAuth had gone stale would render those five tools unreachable — leaving no way to switch away from it or clear its tokens.
 - Markdown payload formatter no longer renders class instances and other non-plain objects as the bare `[object Object]`.
 - `scripts/validate-server-json.cjs` now exits with status 1 on validation failure instead of leaving an unhandled rejection.
 

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -13,6 +13,20 @@ import {
 } from './instrument.js';
 import { acquireToken } from '../auth/acquireToken.js';
 
+// Tools that operate on server-local state (the wiki registry, the OAuth token
+// store) rather than the active wiki's API. They must not be blocked by an
+// OAuth gate keyed on the active wiki — otherwise a wiki whose OAuth has gone
+// stale would render set-wiki, remove-wiki, and the oauth-* tools unreachable,
+// with no way for the caller to escape it. add-wiki targets a different wiki
+// entirely and equally has no business borrowing the active wiki's token.
+const TOOLS_BYPASSING_ACTIVE_WIKI_AUTH: ReadonlySet<string> = new Set([
+	'add-wiki',
+	'set-wiki',
+	'remove-wiki',
+	'oauth-status',
+	'oauth-logout',
+]);
+
 export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext = ToolContext>(
 	tool: Tool<TSchema, TCtx>,
 	ctx: TCtx,
@@ -21,6 +35,7 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 		const { key: wikiKey, config: wiki } = ctx.selection.getCurrent();
 		const useOauth =
 			ctx.transport === 'stdio' &&
+			!TOOLS_BYPASSING_ACTIVE_WIKI_AUTH.has(tool.name) &&
 			typeof wiki.oauth2ClientId === 'string' &&
 			wiki.oauth2ClientId.trim() !== '';
 

--- a/tests/runtime/dispatch.oauth.test.ts
+++ b/tests/runtime/dispatch.oauth.test.ts
@@ -162,4 +162,48 @@ describe('dispatch OAuth integration', () => {
 		expect(envelope.category).toBe('authentication');
 		expect(envelope.message).toContain('OAuth login required:');
 	});
+
+	it.each(['add-wiki', 'set-wiki', 'remove-wiki', 'oauth-status', 'oauth-logout'])(
+		'%s bypasses the OAuth gate even when the active wiki has oauth2ClientId set',
+		async (toolName) => {
+			// Active wiki points at a URL where nothing is listening — so if the
+			// dispatcher tried to acquire a token, it would fail with "authentication"
+			// just like the previous test. The bypass means the tool runs anyway.
+			const ctx = fakeContext({
+				transport: 'stdio',
+				selection: {
+					getCurrent: () => ({
+						key: 'oauth-configured',
+						config: {
+							sitename: 'OAuth-Configured',
+							server: 'http://127.0.0.1:1',
+							articlepath: '/wiki',
+							scriptpath: '/w',
+							oauth2ClientId: 'my-client',
+							tags: null,
+						} as never,
+					}),
+					setCurrent: () => {},
+					reset: () => {},
+				},
+			});
+
+			let toolInvoked = false;
+			const bypassTool: Tool<Record<string, never>> = {
+				name: toolName,
+				description: 'd',
+				inputSchema: {},
+				annotations: {},
+				async handle(): Promise<CallToolResult> {
+					toolInvoked = true;
+					return { content: [{ type: 'text', text: 'ran' }] };
+				},
+			};
+
+			const result = await dispatch(bypassTool, ctx)({});
+			expect(toolInvoked).toBe(true);
+			expect(result.isError).toBeUndefined();
+			expect((result.content[0] as { text: string }).text).toBe('ran');
+		},
+	);
 });


### PR DESCRIPTION
## Summary

The dispatcher's OAuth gate (`src/runtime/dispatcher.ts`) fires on every tool call when the active wiki has `oauth2ClientId` set, regardless of whether the tool actually authenticates against that wiki. This bypass adds 5 tool names that never need an active-wiki token:

- `add-wiki` — registers a new wiki; doesn't authenticate against the active one
- `set-wiki` — changes registry state; the outgoing wiki's OAuth shouldn't be required to leave it
- `remove-wiki` — changes registry state
- `oauth-status` / `oauth-logout` — manage the OAuth token store; must work even when OAuth is broken

## The bug it fixes

Without this, a wiki whose OAuth has gone stale renders the five tools above unreachable. Specifically: calling `set-wiki` to switch *away* from the broken wiki still triggers the gate on the *outgoing* (broken) wiki, returns `401`, and leaves the user with no way to escape. Same for `oauth-logout`, which is supposed to be the recovery tool but itself goes through the same gate.

Encountered while smoke-testing #340 against `starcitizen.tools`: my session's default wiki had `oauth2ClientId` set with an unreachable token endpoint, blocking every tool call including `set-wiki` to a different wiki.

## Test plan

- [x] `npm test` → 843/843 pass (5 new parameterised tests added; one per bypass tool name verifying the handler runs even when the active wiki is OAuth-configured against an unreachable token endpoint)
- [x] `npm run lint` → clean
- [x] `npm run build` → clean
- [x] **Live verify**: with the active wiki configured for OAuth (any `oauth2ClientId` will do) and the token endpoint reachable or not, confirm `set-wiki` to a different wiki succeeds without an OAuth roundtrip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)