### PR TITLE
Document natural-language eval as a description-validation rule

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,8 +62,6 @@ Like the MCP Inspector, but with a built-in MCP client that can drive the server
 npm run mcpjam
 ```
 
-For tools that surface a domain-specific syntax to the LLM (query tools, parser-function wrappers), spot-check the description with a few natural-language prompts here before merge — this catches description gaps that unit tests can't.
-
 ## MCP Inspector CLI (integration tests)
 
 The [MCP Inspector CLI](https://github.com/modelcontextprotocol/inspector) exercises tools against a real wiki. Build first with `npm run build`, then:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,6 +62,8 @@ Like the MCP Inspector, but with a built-in MCP client that can drive the server
 npm run mcpjam
 ```
 
+For tools that surface a domain-specific syntax to the LLM (query tools, parser-function wrappers), spot-check the description with a few natural-language prompts here before merge — this catches description gaps that unit tests can't.
+
 ## MCP Inspector CLI (integration tests)
 
 The [MCP Inspector CLI](https://github.com/modelcontextprotocol/inspector) exercises tools against a real wiki. Build first with `npm run build`, then:

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -99,6 +99,10 @@ Imperative instructions to the model ("You should...", "You MUST...") in tool de
 
 Annotation hints (`destructiveHint`, `idempotentHint`, `openWorldHint`) carry the boolean classification. The description carries the *specific* effect when it isn't obvious from the verb. `delete-page` is obvious; `upload-file-from-url` is not — the description should make clear that the file is fetched server-side, whether it overwrites, and whether the upload is logged. State only effects that are observable to the caller or visible on the wiki, not implementation incidentals.
 
+#### Validate descriptions with natural-language eval
+
+Unit tests verify the handler — not the description. For tools that surface a domain-specific syntax (query tools, parser-function wrappers — anywhere the caller writes a string in a non-obvious dialect), spot-check the description with a few natural-language prompts before merge. Any LLM-driving setup works: MCPJam Inspector, Claude Desktop pointed at the local build, an ad-hoc subagent driving the Inspector CLI. Watch for hallucinated syntax, failure to use companion discovery tools, and ungrounded names — consistent confusion in one direction is a description gap, not a model failure.
+
 ### Parameter docs
 
 #### Parameter descriptions


### PR DESCRIPTION
## Summary

Adds a "Validate descriptions with natural-language eval" subsection to `docs/tool-conventions.md` under Descriptions, pointing future contributors at NL eval as a pre-merge description-quality check for tools that surface a domain-specific syntax to the LLM.

## Motivation

Three tools now ship the same shape:

- `smw-query` — caller writes an SMW `#ask` string
- `bucket-query` — caller writes a Bucket Lua chain
- `cargo-query` — caller writes Cargo SQL clauses

Unit tests verify that our handler routes inputs and shapes responses correctly, but they don't verify that the *description* guides an LLM into composing valid input on the first attempt. The bucket-query PR (#343) found this the hard way: initial smoke-testing produced 0/5 on natural-language prompts because the description didn't surface the title-to-bucket-name normalisation rule. The description was iterated based on those eval results, and post-fix the same prompts succeeded on first attempt.

Cargo-query (#344) confirmed the methodology generalises: a fresh model went 5/5 against an unfamiliar wiki on the first eval, validating that the description was sufficient before merge.

This is a recurring pre-merge step for a recurring class of tool. The note documents it as a description-design rule alongside the existing rules in `tool-conventions.md` (voice, tautology, hedging, sibling routing, side effects).

## Why tool-conventions.md, not testing.md

`testing.md` is recipe-shaped — every section is "here's how to run X" (vitest, MCP Inspector, MCPJam, Inspector CLI). The NL-eval point isn't a recipe; any LLM-driving setup works. It's a description-quality principle, which is what `tool-conventions.md` already covers (voice, tautology, hedging, etc.). The first pushed version put it under MCPJam Inspector — wrong fit for the same reason; the second commit moves it to its natural home.

## Scope

Three lines added to `docs/tool-conventions.md`. No source changes, no test changes, no CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)