### PR TITLE
Refactor extension-gated tools into ExtensionPack modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ A pack is a self-describing module exposing tools that share an extension gate. 
 2. Create `src/tools/extensions/<id>/index.ts` exporting the pack:
 	```ts
 	import type { ExtensionPack } from '../types.js';
-	import { … } from './….js';
+	import { myTool } from './<id>-<verb>.js';
 
 	export const <id>Pack: ExtensionPack = {
 		id: '<id>',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ Project context for AI coding agents working on this repo. For human users, star
 
 ## Repo layout
 
-- `src/tools/` — one file per MCP tool (descriptor + handler + registration).
+- `src/tools/` — one file per non-extension MCP tool (descriptor + handler + registration).
+- `src/tools/extensions/<id>/` — extension packs: tools gated on a specific MediaWiki extension (SMW / Bucket / Cargo / …), grouped under a per-pack module.
 - `src/runtime/` — context, dispatcher, register, reconcile, logger, constants.
 - `src/wikis/` — wiki registry, selection, mwn provider, discovery, error sanitiser.
 - `src/transport/` — stdio and streamable HTTP entry points, SSRF/upload guards, request context, low-level HTTP helpers.
@@ -42,6 +43,26 @@ A PR that adds, removes, or renames a tool — or that materially changes a tool
 - **`CHANGELOG.md`** — an entry under `## [Unreleased]` (Added / Changed / Removed / Breaking changes as appropriate, per [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)).
 
 Pure-internal refactors that don't change tool surface or behaviour don't need either.
+
+## Adding an extension pack
+
+A pack is a self-describing module exposing tools that share an extension gate. To add one:
+
+1. Create `src/tools/extensions/<id>/<id>-<verb>.ts` for each tool, following the conventions in `docs/tool-conventions.md`.
+2. Create `src/tools/extensions/<id>/index.ts` exporting the pack:
+	```ts
+	import type { ExtensionPack } from '../types.js';
+	import { … } from './….js';
+
+	export const <id>Pack: ExtensionPack = {
+		id: '<id>',
+		extensionNames: ['CanonicalExtensionName' /*, aliases */],
+		tools: [/* tool descriptors */],
+	};
+	```
+3. Add the pack to the `extensionPacks` array in `src/tools/extensions/index.ts`.
+
+Reconcile picks up the new pack automatically — no edits to `src/runtime/reconcile.ts`. README.md and CHANGELOG.md still need updating per the policy in "Adding or changing tools".
 
 ## Adding or changing environment variables
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ A pack is a self-describing module exposing tools that share an extension gate. 
 	import type { ExtensionPack } from '../types.js';
 	import { myTool } from './<id>-<verb>.js';
 
-	export const <id>Pack: ExtensionPack = {
+	// Convention: export name folds the id — `smwPack`, `bucketPack`, etc.
+	export const myPack: ExtensionPack = {
 		id: '<id>',
 		extensionNames: ['CanonicalExtensionName' /*, aliases */],
 		tools: [/* tool descriptors */],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
+- Group extension-gated tools (SMW, Bucket, Cargo) into self-describing extension packs under `src/tools/extensions/<id>/`. `runtime/reconcile.ts` no longer hard-codes per-extension knowledge. No behavioural change to any tool — names, descriptions, telemetry, and gating are identical on the wire.
 - Resolved the type-aware lint warnings deferred from the TypeScript 7 upgrade. Tests are no longer subject to the type-assertion rules, and source code is tightened to satisfy them. Published packages are unaffected.
 - Build, watch, and type-check now run on the TypeScript 7 native compiler. Editors continue to use the TypeScript 6 language service. Published packages are unaffected.
 - Lint now runs type-aware checks and catches a class of bugs that syntactic lint misses: unawaited Promises, unbound class methods used as callbacks, and stringifying objects without a meaningful `toString`. Additional non-blocking warnings on type-assertion smells remain and will be tackled in a follow-up.

--- a/src/runtime/reconcile.ts
+++ b/src/runtime/reconcile.ts
@@ -3,6 +3,7 @@ import type { WikiConfig } from '../config/loadConfig.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
 import type { WikiSelection } from '../wikis/wikiSelection.js';
 import type { ExtensionDetector } from '../wikis/extensionDetector.js';
+import type { ExtensionPack } from '../tools/extensions/types.js';
 
 export type Reconcile = () => Promise<void>;
 
@@ -11,6 +12,7 @@ export interface ReconcileDeps {
 	readonly wikiSelection: WikiSelection;
 	readonly transport: 'http' | 'stdio';
 	readonly extensions: ExtensionDetector;
+	readonly extensionPacks: readonly ExtensionPack[];
 }
 
 export interface ReconcileContext {
@@ -41,22 +43,7 @@ const WRITE_TOOL_NAMES: readonly string[] = [
 
 const STDIO_ONLY_TOOLS: readonly string[] = ['oauth-status', 'oauth-logout'];
 
-export const SMW_GATED_TOOLS: readonly string[] = ['smw-query', 'smw-list-properties'];
-
-export const BUCKET_GATED_TOOLS: readonly string[] = ['bucket-query'];
-
-export const CARGO_GATED_TOOLS: readonly string[] = [
-	'cargo-list-tables',
-	'cargo-describe-table',
-	'cargo-query',
-];
-
-// wiki.gg-hosted wikis (Helldivers, Terraria, Ark, etc.) ship Cargo under the
-// rebranded name `LIBRARIAN`. Same author (Yaron Koren), same upstream, same
-// API. Accept either name when probing the active wiki's extensions.
-const CARGO_EXTENSION_NAMES: readonly string[] = ['Cargo', 'LIBRARIAN'];
-
-const RULES: readonly ToolGatingRule[] = [
+const STATIC_RULES: readonly ToolGatingRule[] = [
 	{
 		name: 'read-only',
 		affects: WRITE_TOOL_NAMES,
@@ -82,22 +69,15 @@ const RULES: readonly ToolGatingRule[] = [
 		affects: ['set-wiki'],
 		isAllowed: (c) => c.wikiCount >= 2,
 	},
-	{
-		name: 'smw-extension',
-		affects: SMW_GATED_TOOLS,
-		isAllowed: (c) => c.extensions.has(c.activeWikiKey, 'SemanticMediaWiki'),
-	},
-	{
-		name: 'bucket-extension',
-		affects: BUCKET_GATED_TOOLS,
-		isAllowed: (c) => c.extensions.has(c.activeWikiKey, 'Bucket'),
-	},
-	{
-		name: 'cargo-extension',
-		affects: CARGO_GATED_TOOLS,
-		isAllowed: (c) => c.extensions.hasAny(c.activeWikiKey, CARGO_EXTENSION_NAMES),
-	},
 ];
+
+function buildExtensionRules(packs: readonly ExtensionPack[]): readonly ToolGatingRule[] {
+	return packs.map((pack) => ({
+		name: `${pack.id}-extension`,
+		affects: pack.tools.map((t) => t.name),
+		isAllowed: (c) => c.extensions.hasAny(c.activeWikiKey, pack.extensionNames),
+	}));
+}
 
 function buildContext(deps: ReconcileDeps): ReconcileContext {
 	const { key, config } = deps.wikiSelection.getCurrent();
@@ -144,7 +124,8 @@ export async function reconcileTools(
 	deps: ReconcileDeps,
 ): Promise<void> {
 	const ctx = buildContext(deps);
-	const desired = await computeDesiredEnabledState(tools.keys(), ctx, RULES);
+	const rules = [...STATIC_RULES, ...buildExtensionRules(deps.extensionPacks)];
+	const desired = await computeDesiredEnabledState(tools.keys(), ctx, rules);
 	for (const [name, shouldEnable] of desired) {
 		toggle(tools.get(name), shouldEnable);
 	}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { registerServer, unregisterServer } from './runtime/logger.js';
 import { registerAllTools } from './tools/index.js';
 import { registerAllResources } from './resources/index.js';
 import { reconcileTools } from './runtime/reconcile.js';
+import { extensionPacks } from './tools/extensions/index.js';
 import type { ToolContext } from './runtime/context.js';
 
 // https://github.com/nodejs/node/issues/51347#issuecomment-2111337854
@@ -64,6 +65,7 @@ export const createServer = async (ctx: ToolContext): Promise<McpServer> => {
 			wikiSelection: ctx.selection,
 			transport: ctx.transport,
 			extensions: ctx.extensions,
+			extensionPacks,
 		});
 		// Notify clients that the wiki resource list may have changed (e.g. after
 		// add-wiki / remove-wiki). Also covers tool-list changes since toggling a

--- a/src/tools/extensions/bucket/bucket-query.ts
+++ b/src/tools/extensions/bucket/bucket-query.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
-import type { TruncationInfo } from '../results/truncation.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
 
 const HARD_LIMIT = 500;
 

--- a/src/tools/extensions/bucket/index.ts
+++ b/src/tools/extensions/bucket/index.ts
@@ -1,0 +1,8 @@
+import type { ExtensionPack } from '../types.js';
+import { bucketQuery } from '../../bucket-query.js';
+
+export const bucketPack: ExtensionPack = {
+	id: 'bucket',
+	extensionNames: ['Bucket'],
+	tools: [bucketQuery],
+};

--- a/src/tools/extensions/bucket/index.ts
+++ b/src/tools/extensions/bucket/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionPack } from '../types.js';
-import { bucketQuery } from '../../bucket-query.js';
+import { bucketQuery } from './bucket-query.js';
 
 export const bucketPack: ExtensionPack = {
 	id: 'bucket',

--- a/src/tools/extensions/cargo/cargo-describe-table.ts
+++ b/src/tools/extensions/cargo/cargo-describe-table.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
 
 const inputSchema = {
 	table: z.string().min(1).describe('Cargo table name. Use cargo-list-tables to discover.'),

--- a/src/tools/extensions/cargo/cargo-list-tables.ts
+++ b/src/tools/extensions/cargo/cargo-list-tables.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
 
 const inputSchema = {} as const;
 

--- a/src/tools/extensions/cargo/cargo-query.ts
+++ b/src/tools/extensions/cargo/cargo-query.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
-import type { TruncationInfo } from '../results/truncation.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
 
 const HARD_LIMIT = 500;
 

--- a/src/tools/extensions/cargo/index.ts
+++ b/src/tools/extensions/cargo/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionPack } from '../types.js';
-import { cargoListTables } from '../../cargo-list-tables.js';
-import { cargoDescribeTable } from '../../cargo-describe-table.js';
-import { cargoQuery } from '../../cargo-query.js';
+import { cargoListTables } from './cargo-list-tables.js';
+import { cargoDescribeTable } from './cargo-describe-table.js';
+import { cargoQuery } from './cargo-query.js';
 
 // wiki.gg-hosted wikis (Helldivers, Terraria, Ark, etc.) ship Cargo under the
 // rebranded name `LIBRARIAN`. Same author (Yaron Koren), same upstream, same

--- a/src/tools/extensions/cargo/index.ts
+++ b/src/tools/extensions/cargo/index.ts
@@ -1,0 +1,15 @@
+import type { ExtensionPack } from '../types.js';
+import { cargoListTables } from '../../cargo-list-tables.js';
+import { cargoDescribeTable } from '../../cargo-describe-table.js';
+import { cargoQuery } from '../../cargo-query.js';
+
+// wiki.gg-hosted wikis (Helldivers, Terraria, Ark, etc.) ship Cargo under the
+// rebranded name `LIBRARIAN`. Same author (Yaron Koren), same upstream, same
+// API. Accept either name when probing the active wiki's extensions.
+const CARGO_EXTENSION_NAMES: readonly string[] = ['Cargo', 'LIBRARIAN'];
+
+export const cargoPack: ExtensionPack = {
+	id: 'cargo',
+	extensionNames: CARGO_EXTENSION_NAMES,
+	tools: [cargoListTables, cargoDescribeTable, cargoQuery],
+};

--- a/src/tools/extensions/index.ts
+++ b/src/tools/extensions/index.ts
@@ -1,0 +1,7 @@
+import type { ExtensionPack } from './types.js';
+import { smwPack } from './smw/index.js';
+import { bucketPack } from './bucket/index.js';
+import { cargoPack } from './cargo/index.js';
+
+export type { ExtensionPack } from './types.js';
+export const extensionPacks: readonly ExtensionPack[] = [smwPack, bucketPack, cargoPack];

--- a/src/tools/extensions/smw/index.ts
+++ b/src/tools/extensions/smw/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionPack } from '../types.js';
-import { smwQuery } from '../../smw-query.js';
-import { smwListProperties } from '../../smw-list-properties.js';
+import { smwQuery } from './smw-query.js';
+import { smwListProperties } from './smw-list-properties.js';
 
 export const smwPack: ExtensionPack = {
 	id: 'smw',

--- a/src/tools/extensions/smw/index.ts
+++ b/src/tools/extensions/smw/index.ts
@@ -1,0 +1,9 @@
+import type { ExtensionPack } from '../types.js';
+import { smwQuery } from '../../smw-query.js';
+import { smwListProperties } from '../../smw-list-properties.js';
+
+export const smwPack: ExtensionPack = {
+	id: 'smw',
+	extensionNames: ['SemanticMediaWiki'],
+	tools: [smwQuery, smwListProperties],
+};

--- a/src/tools/extensions/smw/smw-list-properties.ts
+++ b/src/tools/extensions/smw/smw-list-properties.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
-import type { TruncationInfo } from '../results/truncation.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;

--- a/src/tools/extensions/smw/smw-query.ts
+++ b/src/tools/extensions/smw/smw-query.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '../runtime/tool.js';
-import type { ToolContext } from '../runtime/context.js';
-import type { TruncationInfo } from '../results/truncation.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
 
 const HARD_LIMIT = 500;
 

--- a/src/tools/extensions/types.ts
+++ b/src/tools/extensions/types.ts
@@ -1,0 +1,17 @@
+import type { Tool } from '../../runtime/tool.js';
+
+export interface ExtensionPack {
+	/** Stable id used for rule names and telemetry; e.g. 'cargo'. Conventionally
+	 *  matches the tool-name prefix shared by tools in the pack. */
+	readonly id: string;
+
+	/** MediaWiki extension names accepted as proof the pack applies to the
+	 *  active wiki. Multiple entries handle aliases (Cargo / LIBRARIAN). The
+	 *  pack is allowed iff `extensions.hasAny(activeWikiKey, extensionNames)`. */
+	readonly extensionNames: readonly string[];
+
+	/** Tools provided by this pack. The unifying property is the gate, not the
+	 *  transport — pack tools may use action API, rawRequest, or REST. */
+	// oxlint-disable-next-line typescript/no-explicit-any
+	readonly tools: readonly Tool<any>[];
+}

--- a/src/tools/extensions/types.ts
+++ b/src/tools/extensions/types.ts
@@ -11,7 +11,7 @@ export interface ExtensionPack {
 	readonly extensionNames: readonly string[];
 
 	/** Tools provided by this pack. The unifying property is the gate, not the
-	 *  transport — pack tools may use action API, rawRequest, or REST. */
+	 *  request mechanism — pack tools may use action API, rawRequest, or REST. */
 	// oxlint-disable-next-line typescript/no-explicit-any
 	readonly tools: readonly Tool<any>[];
 }

--- a/src/tools/extensions/types.ts
+++ b/src/tools/extensions/types.ts
@@ -12,6 +12,8 @@ export interface ExtensionPack {
 
 	/** Tools provided by this pack. The unifying property is the gate, not the
 	 *  request mechanism — pack tools may use action API, rawRequest, or REST. */
+	// `Tool<any>[]` widens the heterogeneous-schema array; see `standardTools`
+	// in `src/tools/index.ts` for the variance rationale.
 	// oxlint-disable-next-line typescript/no-explicit-any
 	readonly tools: readonly Tool<any>[];
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,12 +4,7 @@ import { errorMessage } from '../errors/isErrnoException.js';
 import { logger } from '../runtime/logger.js';
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext, ManagementContext } from '../runtime/context.js';
-import {
-	type Reconcile,
-	SMW_GATED_TOOLS,
-	BUCKET_GATED_TOOLS,
-	CARGO_GATED_TOOLS,
-} from '../runtime/reconcile.js';
+import type { Reconcile } from '../runtime/reconcile.js';
 import { dispatch } from '../runtime/dispatcher.js';
 import { register } from '../runtime/register.js';
 
@@ -24,12 +19,7 @@ import { comparePages } from './compare-pages.js';
 import { getFile } from './get-file.js';
 import { getRevision } from './get-revision.js';
 import { getCategoryMembers } from './get-category-members.js';
-import { smwQuery } from './smw-query.js';
-import { smwListProperties } from './smw-list-properties.js';
-import { bucketQuery } from './bucket-query.js';
-import { cargoListTables } from './cargo-list-tables.js';
-import { cargoDescribeTable } from './cargo-describe-table.js';
-import { cargoQuery } from './cargo-query.js';
+import { extensionPacks } from './extensions/index.js';
 import { createPage } from './create-page.js';
 import { updatePage } from './update-page.js';
 import { deletePage } from './delete-page.js';
@@ -61,12 +51,6 @@ export const standardTools: Tool<any>[] = [
 	getFile,
 	getRevision,
 	getCategoryMembers,
-	smwQuery,
-	smwListProperties,
-	bucketQuery,
-	cargoListTables,
-	cargoDescribeTable,
-	cargoQuery,
 	createPage,
 	updatePage,
 	deletePage,
@@ -89,7 +73,12 @@ export function registerAllTools(
 ): Map<string, RegisteredTool> {
 	const registered = new Map<string, RegisteredTool>();
 
-	for (const tool of standardTools) {
+	// oxlint-disable-next-line typescript/no-explicit-any
+	const allStandardTools: Tool<any>[] = [
+		...standardTools,
+		...extensionPacks.flatMap((p) => p.tools),
+	];
+	for (const tool of allStandardTools) {
 		try {
 			registered.set(tool.name, register(server, tool, dispatch(tool, ctx)));
 		} catch (error) {
@@ -110,10 +99,12 @@ export function registerAllTools(
 	// the extension detector confirms the relevant extension is installed on
 	// the active wiki. This avoids a race where tools/list arrives before the
 	// initial reconcile completes.
-	for (const name of [...SMW_GATED_TOOLS, ...BUCKET_GATED_TOOLS, ...CARGO_GATED_TOOLS]) {
-		const tool = registered.get(name);
-		if (tool && tool.enabled) {
-			tool.disable();
+	for (const pack of extensionPacks) {
+		for (const tool of pack.tools) {
+			const reg = registered.get(tool.name);
+			if (reg && reg.enabled) {
+				reg.disable();
+			}
 		}
 	}
 

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -6,6 +6,8 @@ import type { WikiSelection } from '../../src/wikis/wikiSelection.js';
 import type { ExtensionDetector } from '../../src/wikis/extensionDetector.js';
 import { reconcileTools, computeDesiredEnabledState } from '../../src/runtime/reconcile.js';
 import type { ToolGatingRule, ReconcileContext } from '../../src/runtime/reconcile.js';
+import type { ExtensionPack } from '../../src/tools/extensions/types.js';
+import type { Tool } from '../../src/runtime/tool.js';
 
 const WRITE_TOOL_NAMES = [
 	'create-page',
@@ -104,6 +106,29 @@ function makeFakeDetector(answers: Record<string, boolean> = {}): ExtensionDetec
 	};
 }
 
+function makeFakePack(
+	id: string,
+	extensionNames: readonly string[],
+	toolNames: readonly string[],
+): ExtensionPack {
+	return {
+		id,
+		extensionNames,
+		// Synthetic tools — only `name` matters for reconcile (gating works on names).
+		// oxlint-disable-next-line typescript/no-explicit-any
+		tools: toolNames.map((name) => ({ name }) as unknown as Tool<any>),
+	};
+}
+
+const SMW_PACK = makeFakePack('smw', ['SemanticMediaWiki'], ['smw-query', 'smw-list-properties']);
+const BUCKET_PACK = makeFakePack('bucket', ['Bucket'], ['bucket-query']);
+const CARGO_PACK = makeFakePack(
+	'cargo',
+	['Cargo', 'LIBRARIAN'],
+	['cargo-list-tables', 'cargo-describe-table', 'cargo-query'],
+);
+const ALL_PACKS: readonly ExtensionPack[] = [SMW_PACK, BUCKET_PACK, CARGO_PACK];
+
 describe('reconcileTools — applyReadOnlyRule', () => {
 	it('disables every write tool when the active wiki is readOnly', async () => {
 		const { tools, mocks } = makeToolMap(true);
@@ -118,6 +143,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
@@ -138,6 +164,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of NON_WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).not.toHaveBeenCalled();
@@ -158,6 +185,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
@@ -177,6 +205,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
@@ -192,6 +221,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: m1.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const m of mocks.values()) {
 			m.enable.mockClear();
@@ -203,6 +233,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			wikiSelection: m2.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const m of mocks.values()) {
 			expect(m.enable).not.toHaveBeenCalled();
@@ -225,6 +256,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 				wikiSelection: selection,
 				transport: 'stdio',
 				extensions: makeFakeDetector(),
+				extensionPacks: ALL_PACKS,
 			}),
 		).resolves.not.toThrow();
 		for (const name of WRITE_TOOL_NAMES) {
@@ -249,6 +281,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of ['add-wiki', 'remove-wiki', 'set-wiki']) {
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
@@ -267,6 +300,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('add-wiki')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('remove-wiki')!.disable).not.toHaveBeenCalled();
@@ -285,6 +319,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('set-wiki')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('add-wiki')!.enable).not.toHaveBeenCalled();
@@ -303,6 +338,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of ['add-wiki', 'remove-wiki', 'set-wiki']) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
@@ -321,6 +357,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: m1.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('set-wiki')!.enabled).toBe(false);
 
@@ -334,6 +371,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: m2.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('set-wiki')!.enabled).toBe(true);
 	});
@@ -350,6 +388,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: m1.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('remove-wiki')!.enabled).toBe(true);
 
@@ -363,6 +402,7 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			wikiSelection: m2.selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('remove-wiki')!.enabled).toBe(false);
 	});
@@ -381,6 +421,7 @@ describe('reconcileTools — applyTransportRule', () => {
 			wikiSelection: selection,
 			transport: 'http',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of STDIO_ONLY_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
@@ -400,6 +441,7 @@ describe('reconcileTools — applyTransportRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of STDIO_ONLY_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
@@ -419,6 +461,7 @@ describe('reconcileTools — applyTransportRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of STDIO_ONLY_TOOL_NAMES) {
 			expect(mocks.get(name)!.enable).toHaveBeenCalledTimes(1);
@@ -437,6 +480,7 @@ describe('reconcileTools — applyTransportRule', () => {
 			wikiSelection: selection,
 			transport: 'http',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		for (const name of NON_WRITE_TOOL_NAMES) {
 			expect(mocks.get(name)!.disable).not.toHaveBeenCalled();
@@ -460,6 +504,7 @@ describe('reconcileTools — AND semantics across rules', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
 		});
 		// create-page is write-gated → disabled.
 		expect(mocks.get('create-page')!.enabled).toBe(false);
@@ -597,6 +642,7 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('smw-query')!.disable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('smw-list-properties')!.disable).toHaveBeenCalledTimes(1);
@@ -615,6 +661,7 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:SemanticMediaWiki': true }),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('smw-query')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('smw-list-properties')!.enable).toHaveBeenCalledTimes(1);
@@ -622,10 +669,10 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 
 	it('queries the detector with the active wiki key', async () => {
 		const { tools } = makeToolMapWithSmw(false);
-		const hasSpy = vi.fn(async () => true);
+		const hasAnySpy = vi.fn(async () => true);
 		const detector: ExtensionDetector = {
-			has: hasSpy,
-			hasAny: vi.fn(async () => false),
+			has: vi.fn(async () => false),
+			hasAny: hasAnySpy,
 			invalidate: vi.fn(),
 		};
 		const { registry, selection } = makeMocks({
@@ -638,8 +685,9 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: detector,
+			extensionPacks: ALL_PACKS,
 		});
-		expect(hasSpy).toHaveBeenCalledWith('a', 'SemanticMediaWiki');
+		expect(hasAnySpy).toHaveBeenCalledWith('a', ['SemanticMediaWiki']);
 	});
 });
 
@@ -670,6 +718,7 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('bucket-query')!.disable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('get-page')!.disable).not.toHaveBeenCalled();
@@ -687,16 +736,17 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:Bucket': true }),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('bucket-query')!.enable).toHaveBeenCalledTimes(1);
 	});
 
-	it('queries the detector with the active wiki key and the string "Bucket"', async () => {
+	it('queries the detector with the active wiki key and ["Bucket"]', async () => {
 		const { tools } = makeToolMapWithBucket(false);
-		const hasSpy = vi.fn(async () => true);
+		const hasAnySpy = vi.fn(async () => true);
 		const detector: ExtensionDetector = {
-			has: hasSpy,
-			hasAny: vi.fn(async () => false),
+			has: vi.fn(async () => false),
+			hasAny: hasAnySpy,
 			invalidate: vi.fn(),
 		};
 		const { registry, selection } = makeMocks({
@@ -709,8 +759,9 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: detector,
+			extensionPacks: ALL_PACKS,
 		});
-		expect(hasSpy).toHaveBeenCalledWith('a', 'Bucket');
+		expect(hasAnySpy).toHaveBeenCalledWith('a', ['Bucket']);
 	});
 });
 
@@ -741,6 +792,7 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('cargo-list-tables')!.disable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('cargo-describe-table')!.disable).toHaveBeenCalledTimes(1);
@@ -760,6 +812,7 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:Cargo': true }),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('cargo-list-tables')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('cargo-describe-table')!.enable).toHaveBeenCalledTimes(1);
@@ -784,6 +837,7 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: detector,
+			extensionPacks: ALL_PACKS,
 		});
 		expect(hasAnySpy).toHaveBeenCalledWith('a', ['Cargo', 'LIBRARIAN']);
 	});
@@ -800,6 +854,7 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 			wikiSelection: selection,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:LIBRARIAN': true }),
+			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('cargo-list-tables')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('cargo-describe-table')!.enable).toHaveBeenCalledTimes(1);

--- a/tests/tools/extensions/bucket/bucket-query.test.ts
+++ b/tests/tools/extensions/bucket/bucket-query.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { bucketQuery } from '../../src/tools/bucket-query.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { bucketQuery } from '../../../../src/tools/extensions/bucket/bucket-query.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 // rawRequest is called with `{url, method, data, headers}` where `data` is a
 // form-urlencoded string. Tests assert the rendered Lua chain by parsing the

--- a/tests/tools/extensions/cargo/cargo-describe-table.test.ts
+++ b/tests/tools/extensions/cargo/cargo-describe-table.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { createMockMwnError } from '../helpers/mock-mwn-error.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { cargoDescribeTable } from '../../src/tools/cargo-describe-table.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { createMockMwnError } from '../../../helpers/mock-mwn-error.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { cargoDescribeTable } from '../../../../src/tools/extensions/cargo/cargo-describe-table.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 describe('cargo-describe-table', () => {
 	it('forwards table to action=cargofields and normalizes the response', async () => {

--- a/tests/tools/extensions/cargo/cargo-list-tables.test.ts
+++ b/tests/tools/extensions/cargo/cargo-list-tables.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { cargoListTables } from '../../src/tools/cargo-list-tables.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { cargoListTables } from '../../../../src/tools/extensions/cargo/cargo-list-tables.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 describe('cargo-list-tables', () => {
 	it('forwards to action=cargotables and returns the tables array', async () => {

--- a/tests/tools/extensions/cargo/cargo-query.test.ts
+++ b/tests/tools/extensions/cargo/cargo-query.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { createMockMwnError } from '../helpers/mock-mwn-error.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { cargoQuery } from '../../src/tools/cargo-query.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { createMockMwnError } from '../../../helpers/mock-mwn-error.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { cargoQuery } from '../../../../src/tools/extensions/cargo/cargo-query.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 describe('cargo-query', () => {
 	it('forwards tables and optional params to action=cargoquery and unwraps rows', async () => {

--- a/tests/tools/extensions/index.test.ts
+++ b/tests/tools/extensions/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { extensionPacks } from '../../../src/tools/extensions/index.js';
+
+describe('extensionPacks', () => {
+	it('contains smw, bucket, and cargo in registration order', () => {
+		expect(extensionPacks.map((p) => p.id)).toEqual(['smw', 'bucket', 'cargo']);
+	});
+
+	it('lists Cargo and LIBRARIAN as Cargo extension names', () => {
+		const cargo = extensionPacks.find((p) => p.id === 'cargo');
+		expect(cargo?.extensionNames).toEqual(['Cargo', 'LIBRARIAN']);
+	});
+
+	it('lists SemanticMediaWiki as the SMW extension name', () => {
+		const smw = extensionPacks.find((p) => p.id === 'smw');
+		expect(smw?.extensionNames).toEqual(['SemanticMediaWiki']);
+	});
+
+	it('lists Bucket as the Bucket extension name', () => {
+		const bucket = extensionPacks.find((p) => p.id === 'bucket');
+		expect(bucket?.extensionNames).toEqual(['Bucket']);
+	});
+
+	it('all tool names across packs are unique', () => {
+		const allNames = extensionPacks.flatMap((p) => p.tools.map((t) => t.name));
+		expect(new Set(allNames).size).toBe(allNames.length);
+	});
+
+	it('every tool name starts with its pack id followed by a dash', () => {
+		for (const pack of extensionPacks) {
+			for (const tool of pack.tools) {
+				expect(tool.name.startsWith(`${pack.id}-`)).toBe(true);
+			}
+		}
+	});
+});

--- a/tests/tools/extensions/smw/smw-list-properties.test.ts
+++ b/tests/tools/extensions/smw/smw-list-properties.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { smwListProperties } from '../../src/tools/smw-list-properties.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { smwListProperties } from '../../../../src/tools/extensions/smw/smw-list-properties.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 interface SmwBrowsePropertyMock {
 	label: string;

--- a/tests/tools/extensions/smw/smw-query.test.ts
+++ b/tests/tools/extensions/smw/smw-query.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.js';
-import { fakeContext } from '../helpers/fakeContext.js';
-import { smwQuery } from '../../src/tools/smw-query.js';
-import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { smwQuery } from '../../../../src/tools/extensions/smw/smw-query.js';
+import { dispatch } from '../../../../src/runtime/dispatcher.js';
+import {
+	assertStructuredError,
+	assertStructuredSuccess,
+} from '../../../helpers/structuredResult.js';
 
 describe('smw-query', () => {
 	it('calls action=ask with the user query and returns row-shaped results', async () => {

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -5,6 +5,7 @@ import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server
 import type { WikiConfig } from '../../src/config/loadConfig.js';
 import type { ExtensionDetector } from '../../src/wikis/extensionDetector.js';
 import { reconcileTools } from '../../src/runtime/reconcile.js';
+import { extensionPacks } from '../../src/tools/extensions/index.js';
 import { registerAllTools } from '../../src/tools/index.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 
@@ -80,6 +81,7 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 			wikiSelection: wikiSelectionMock,
 			transport: 'stdio',
 			extensions: fakeDetector,
+			extensionPacks,
 		});
 	const ctx = fakeContext({
 		wikis: wikiRegistryMock,


### PR DESCRIPTION
## Summary

- Group SMW / Bucket / Cargo tools into self-describing `ExtensionPack` modules under `src/tools/extensions/<id>/`. Each pack is a single object exposing `{ id, extensionNames, tools }` — extension-name aliases (Cargo / LIBRARIAN) live with the data they describe.
- Decouple `runtime/reconcile.ts` from per-extension knowledge: drop `*_GATED_TOOLS` exports, drop `CARGO_EXTENSION_NAMES`, replace the three hard-coded `*-extension` rules with a 5-line `buildExtensionRules` helper that consumes the pack registry. Adding a new extension is now a localised change — new files plus one entry in `src/tools/extensions/index.ts`.
- No behaviour change on the wire. Tool names, descriptions, annotations, and the rule names emitted in telemetry (`smw-extension`, `bucket-extension`, `cargo-extension`) are bit-identical to before.

## Test plan

- [x] Full vitest suite passes (951/951).
- [x] `oxlint` clean (0 warnings, 0 errors).
- [x] `oxfmt --check` clean.
- [x] `tsgo --noEmit` clean.
- [x] New `tests/tools/extensions/index.test.ts` pins registry shape: order, alias content, tool-name uniqueness across packs, `<id>-` prefix invariant.
- [x] `tests/runtime/reconcile.test.ts` covers gating mechanism via synthetic `ALL_PACKS`; LIBRARIAN-aliased install still asserted end-to-end.
- [x] `tests/tools/index.test.ts` covers integration with the production registry.
- [x] Verified no `*_GATED_TOOLS` references remain in `src/` or `tests/`.
- [x] Verified `src/runtime/` contains no extension-name string literals.

## Notes

- Six tool files moved with `git mv` (88-97% rename similarity); `git log --follow` recovers history.
- AGENTS.md gains a layout entry plus an "Adding an extension pack" subsection pointing at the registration seam. CHANGELOG entry under `[Unreleased] / Changed` flagged as no-behaviour-change.
- README intentionally unchanged — no tool surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)