### PR TITLE
Run CI on ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Switches the preflight job in `.github/workflows/ci.yml` from `ubuntu-latest` (x64) to `ubuntu-24.04-arm`.

## Why
GitHub's ARM runners are typically 20-40% faster on JS/TS workloads, and they're free for public repos. The expected saving on this workflow is modest (a few tens of seconds per run) but it lands on every PR push, where contributors actually feel CI latency.

## Risk
Low. All runtime dependencies are pure JS. The dev-dep native bindings used during preflight (`@oxlint/*`, `@oxfmt/*`, `@rolldown/*`, `lightningcss-*`) all publish `linux-arm64-gnu` prebuilds, so `npm ci` will resolve a clean install. If anything breaks, the revert is one line.

## Test plan
- [x] CI run on this PR is green.
- [x] Compare wall-clock time of this PR's CI run against recent runs on `master` to confirm the speedup is real (or at least not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)