### PR TITLE
Document /mcp endpoint path in deployment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the `/mcp` endpoint path explicitly in `docs/deployment.md`.
+
 ### Fixed
 
 - Bootstrap error path no longer leaks an unhandled-rejection warning when `main()` fails (e.g. config-loading errors). The fatal-error catch now exits with code 1 instead of re-throwing into a detached `.catch` chain.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,22 @@
 
 The server can run as a remote HTTP endpoint for clients that only accept URLs (e.g. hosted LLM chat products).
 
+## Endpoint
+
+MCP clients connect to the `/mcp` path on the configured host and port. For the local default:
+
+    http://localhost:3000/mcp
+
+For the Docker default:
+
+    http://localhost:8080/mcp
+
+Behind a reverse proxy, the same shape applies:
+
+    https://wiki.example.org/mcp
+
+The path is fixed and not configurable.
+
 ## Environment
 
 | Name | Default | Description |
@@ -175,7 +191,7 @@ docker run --rm -p 8080:8080 \
   ghcr.io/professionalwiki/mediawiki-mcp-server:latest
 ```
 
-The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` — `MCP_BIND` is set so container port forwarding reaches the listener, since `127.0.0.1` (the host-default) is per-netns and unreachable from the bridge network. It runs as a non-root user and exposes `/health` and `/ready` for orchestration probes.
+The image sets `MCP_TRANSPORT=http`, `PORT=8080`, and `MCP_BIND=0.0.0.0` — `MCP_BIND` is set so container port forwarding reaches the listener, since `127.0.0.1` (the host-default) is per-netns and unreachable from the bridge network. It runs as a non-root user and exposes `/mcp` for MCP traffic plus `/health` and `/ready` for orchestration probes.
 
 ### Build from source
 


### PR DESCRIPTION
## Summary

- Adds a `## Endpoint` section near the top of `docs/deployment.md` listing the three forms of the client URL (local default `http://localhost:3000/mcp`, Docker default `http://localhost:8080/mcp`, reverse-proxied `https://wiki.example.org/mcp`) and stating the path is fixed.
- Splices `/mcp` into the `/health`/`/ready` listing in the Docker section so readers scanning Docker guidance also see it.
- CHANGELOG `[Unreleased]` entry under `### Changed`.

Closes #356.

## Test plan

- [x] Render `docs/deployment.md` on GitHub and confirm `## Endpoint` appears in the rendered TOC right after the intro paragraph.
- [x] Confirm the three URL examples render as indented code blocks.
- [x] Confirm the Docker `### Public deployments` paragraph still reads cleanly with `/mcp` added to the route listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)