### PR TITLE
Resolve exec-backed wiki credentials lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- Wiki credentials backed by an `exec` command are now fetched the first time that wiki is used, instead of when the server starts. A slow or failing credential command no longer delays startup or prevents the server from starting — the error now appears only when that wiki is used.
+
 ## [0.9.1] - 2026-05-13
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ If a referenced variable is not set:
 
 ## Secret sources
 
-Secret fields can also run an external command at startup and use its output as the secret. This lets you fetch credentials from a password manager, keyring, or secret store without writing them to disk:
+Secret fields can also run an external command and use its output as the secret. This lets you fetch credentials from a password manager, keyring, or secret store without writing them to disk:
 
 ```json
 {
@@ -79,9 +79,9 @@ Secret fields can also run an external command at startup and use its output as 
 }
 ```
 
-The command runs directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies.
+The command runs the first time that wiki is used — not at startup — directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies, and the result is cached for the lifetime of the server process.
 
-If the command fails, times out, or prints nothing, the server exits at startup. Error messages identify the failing wiki and field — the secret value itself is never logged.
+If the command fails, times out, or prints nothing, the wiki cannot be used and tool calls against it return an authentication error identifying the wiki and field. Other wikis, and server startup, are unaffected. The secret value itself is never logged.
 
 Any CLI that prints a credential to stdout works: 1Password's `op`, `pass`, `secret-tool`, Bitwarden's `bw`, HashiCorp Vault, or a custom script.
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,8 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
 import { logger } from '../runtime/logger.js';
-import { isErrnoException, errorMessage } from '../errors/isErrnoException.js';
+import { errorMessage } from '../errors/isErrnoException.js';
 
 export interface WikiConfig {
 	/**
@@ -26,15 +25,15 @@ export interface WikiConfig {
 	 * Used as a fallback when no Authorization header is supplied
 	 * by the MCP client on the HTTP request.
 	 */
-	token?: string | null;
+	token?: string | ExecSecret | null;
 	/**
 	 * Username requested from Special:BotPasswords.
 	 */
-	username?: string | null;
+	username?: string | ExecSecret | null;
 	/**
 	 * Password requested from Special:BotPasswords.
 	 */
-	password?: string | null;
+	password?: string | ExecSecret | null;
 	/**
 	 * OAuth 2.0 client identifier registered at
 	 * Special:OAuthConsumerRegistration/propose/oauth2 on this wiki.
@@ -167,7 +166,7 @@ function resolveSecretField(
 	raw: unknown,
 	wikiKey: string,
 	fieldName: SecretFieldName,
-): string | null | undefined {
+): string | ExecSecret | null | undefined {
 	if (raw === null || raw === undefined) {
 		return raw;
 	}
@@ -190,72 +189,35 @@ function resolveSecretField(
 		return raw;
 	}
 	if (typeof raw === 'object' && !Array.isArray(raw)) {
-		return runExec(raw, wikiKey, fieldName);
+		return parseExecSecret(raw, `wikis.${wikiKey}.${fieldName}`);
 	}
 	throw new Error(
 		`Config error: wikis.${wikiKey}.${fieldName} must be a string, null, or an {exec: …} object`,
 	);
 }
 
-function runExec(raw: unknown, wikiKey: string, fieldName: SecretFieldName): string {
-	const path = `wikis.${wikiKey}.${fieldName}`;
-	if (typeof raw !== 'object' || raw === null) {
-		throw new Error(`Config error: ${path} must be a string, null, or an {exec: …} object`);
+function parseExecSecret(raw: unknown, fieldPath: string): ExecSecret {
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+		throw new Error(`Config error: ${fieldPath} must be a string, null, or an {exec: …} object`);
 	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
 	const src = raw as { exec?: unknown };
 	if (typeof src.exec !== 'object' || src.exec === null || Array.isArray(src.exec)) {
-		throw new Error(`Config error: ${path} must be a string, null, or an {exec: …} object`);
+		throw new Error(`Config error: ${fieldPath} must be a string, null, or an {exec: …} object`);
 	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
 	const exec = src.exec as { command?: unknown; args?: unknown };
 	if (typeof exec.command !== 'string' || exec.command === '') {
-		throw new Error(`Config error: ${path}.exec.command must be a non-empty string`);
+		throw new Error(`Config error: ${fieldPath}.exec.command must be a non-empty string`);
 	}
 	if (
 		exec.args !== undefined &&
 		(!Array.isArray(exec.args) || !exec.args.every((a) => typeof a === 'string'))
 	) {
-		throw new Error(`Config error: ${path}.exec.args must be an array of strings`);
+		throw new Error(`Config error: ${fieldPath}.exec.args must be an array of strings`);
 	}
-	const command = exec.command;
-	const args = exec.args ?? [];
-
-	let stdout: string;
-	try {
-		stdout = execFileSync(command, args, {
-			timeout: 10_000,
-			encoding: 'utf-8',
-			stdio: ['ignore', 'pipe', 'pipe'],
-		});
-	} catch (err: unknown) {
-		if (!isErrnoException(err)) {
-			throw err;
-		}
-		if (err.code === 'ENOENT') {
-			throw new Error(`Config error: failed to fetch ${path}: command "${command}" not found`);
-		}
-		if (err.signal === 'SIGTERM' || err.code === 'ETIMEDOUT') {
-			throw new Error(
-				`Config error: failed to fetch ${path}: command "${command}" timed out after 10s`,
-			);
-		}
-		if (typeof err.status === 'number' && err.status !== 0) {
-			const stderrText = err.stderr
-				? (Buffer.isBuffer(err.stderr) ? err.stderr.toString('utf-8') : err.stderr).slice(0, 200)
-				: '';
-			throw new Error(
-				`Config error: failed to fetch ${path}: command "${command}" exited with status ${err.status}. stderr: ${stderrText}`,
-			);
-		}
-		throw new Error(`Config error: failed to fetch ${path}: ${err.message}`);
-	}
-
-	const trimmed = stdout.replace(/\r?\n+$/, '');
-	if (trimmed === '') {
-		throw new Error(
-			`Config error: failed to fetch ${path}: command "${command}" produced no output`,
-		);
-	}
-	return trimmed;
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON.parse boundary; ajv-validated WikiConfig parsing is a separate follow-up
+	return { exec: { command: exec.command, args: (exec.args as string[]) ?? [] } };
 }
 
 function resolveUploadDirs(rawFromConfig: unknown): readonly string[] {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -118,6 +118,18 @@ export const defaultConfig: Config = {
 	},
 };
 
+/**
+ * A credential field whose value is produced by running an external command.
+ * Validated at config load (see parseExecSecret); the command itself runs
+ * lazily on first use of the wiki — see src/wikis/execSecret.ts.
+ */
+export interface ExecSecret {
+	exec: {
+		command: string;
+		args: string[];
+	};
+}
+
 const SECRET_FIELDS = ['token', 'username', 'password'] as const;
 type SecretFieldName = (typeof SECRET_FIELDS)[number];
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -129,6 +129,19 @@ export interface ExecSecret {
 	};
 }
 
+/**
+ * Whether a credential field is configured — i.e. carries a usable secret
+ * source. True for a non-empty string and for an {exec:…} object; false for
+ * an empty string, null, or undefined. Used to classify a wiki as having
+ * static credentials without resolving (running) an exec-backed secret.
+ */
+export function isCredentialConfigured(value: string | ExecSecret | null | undefined): boolean {
+	if (typeof value === 'string') {
+		return value.length > 0;
+	}
+	return value !== null && value !== undefined;
+}
+
 const SECRET_FIELDS = ['token', 'username', 'password'] as const;
 type SecretFieldName = (typeof SECRET_FIELDS)[number];
 

--- a/src/errors/classifyError.ts
+++ b/src/errors/classifyError.ts
@@ -1,3 +1,5 @@
+import { CredentialResolutionError } from './credentialResolutionError.js';
+
 export type ErrorCategory =
 	| 'not_found'
 	| 'permission_denied'
@@ -64,6 +66,9 @@ const MESSAGE_FALLBACK_PATTERNS: readonly (readonly [RegExp, string])[] = [
 ];
 
 export function classifyError(err: unknown): { category: ErrorCategory; code?: string } {
+	if (err instanceof CredentialResolutionError) {
+		return { category: 'authentication' };
+	}
 	if (err !== null && typeof err === 'object') {
 		const code = (err as { code?: unknown }).code;
 		if (typeof code === 'string') {

--- a/src/errors/credentialResolutionError.ts
+++ b/src/errors/credentialResolutionError.ts
@@ -1,0 +1,12 @@
+/**
+ * Thrown when a wiki's {exec:…} credential command fails, times out, or
+ * produces no output. Surfaces at first use of the wiki, never at startup.
+ * The message carries only the command name and truncated stderr — never the
+ * command's stdout and never the resolved secret.
+ */
+export class CredentialResolutionError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'CredentialResolutionError';
+	}
+}

--- a/src/transport/bearerGuard.ts
+++ b/src/transport/bearerGuard.ts
@@ -1,4 +1,5 @@
 import type { WikiConfig } from '../config/loadConfig.js';
+import { isCredentialConfigured } from '../config/loadConfig.js';
 
 export interface BearerGuardEnv {
 	MCP_ALLOW_STATIC_FALLBACK?: string;
@@ -9,15 +10,11 @@ export type BearerGuardResult =
 	| { readonly kind: 'override'; readonly wikis: readonly string[] }
 	| { readonly kind: 'block'; readonly wikis: readonly string[] };
 
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === 'string' && value.length > 0;
-}
-
 export function hasStaticCredentials(wiki: WikiConfig): boolean {
-	if (isNonEmptyString(wiki.token)) {
+	if (isCredentialConfigured(wiki.token)) {
 		return true;
 	}
-	return isNonEmptyString(wiki.username) && isNonEmptyString(wiki.password);
+	return isCredentialConfigured(wiki.username) && isCredentialConfigured(wiki.password);
 }
 
 export function evaluateBearerGuard(

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -26,7 +26,7 @@ import {
 import { withRequestContext } from './requestContext.js';
 
 export { withRequestContext } from './requestContext.js';
-import { loadConfigFromFile } from '../config/loadConfig.js';
+import { isCredentialConfigured, loadConfigFromFile } from '../config/loadConfig.js';
 import type { MwnProvider } from '../wikis/mwnProvider.js';
 import type { WikiSelection } from '../wikis/wikiSelection.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
@@ -200,11 +200,8 @@ export function createMcpPostHandler(
 			const cfg = wikiSelection.getCurrent().config;
 			const oauthOnly = typeof cfg.oauth2ClientId === 'string' && cfg.oauth2ClientId.trim() !== '';
 			const hasStatic =
-				(typeof cfg.token === 'string' && cfg.token.trim() !== '') ||
-				(typeof cfg.username === 'string' &&
-					typeof cfg.password === 'string' &&
-					cfg.username.trim() !== '' &&
-					cfg.password.trim() !== '');
+				isCredentialConfigured(cfg.token) ||
+				(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
 			const fallbackAllowed = process.env.MCP_ALLOW_STATIC_FALLBACK === 'true';
 			if (oauthOnly && !(hasStatic && fallbackAllowed)) {
 				const protoHeader = req.headers['x-forwarded-proto'];

--- a/src/wikis/execSecret.ts
+++ b/src/wikis/execSecret.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'node:child_process';
+import type { ExecSecret } from '../config/loadConfig.js';
+import { CredentialResolutionError } from '../errors/credentialResolutionError.js';
+
+const TIMEOUT_MS = 10_000;
+const STDERR_LIMIT = 200;
+
+function failureMessage(err: unknown, stderr: string, command: string, descriptor: string): string {
+	if (err !== null && typeof err === 'object') {
+		const code = (err as { code?: unknown }).code;
+		const killed = (err as { killed?: unknown }).killed;
+		const signal = (err as { signal?: unknown }).signal;
+
+		if (code === 'ENOENT') {
+			return `Could not resolve ${descriptor}: command "${command}" not found`;
+		}
+		if (killed === true || signal === 'SIGTERM' || code === 'ETIMEDOUT') {
+			return `Could not resolve ${descriptor}: command "${command}" timed out after 10s`;
+		}
+		if (typeof code === 'number' && code !== 0) {
+			return `Could not resolve ${descriptor}: command "${command}" exited with status ${code}. stderr: ${stderr.slice(0, STDERR_LIMIT)}`;
+		}
+	}
+	return `Could not resolve ${descriptor}: ${err instanceof Error ? err.message : typeof err === 'string' ? err : String(err)}`;
+}
+
+/**
+ * Run an {exec:…} credential command and return its trimmed stdout.
+ *
+ * `descriptor` is a human-readable label for the credential being fetched
+ * (e.g. `the "token" credential for wiki "x"`) — it appears in error messages
+ * so the caller does not need to re-wrap the thrown error.
+ *
+ * Uses the async (callback) form of execFile so a slow command never blocks
+ * the Node event loop. The child's stdin is closed immediately so a command
+ * that reads stdin sees EOF instead of hanging until the timeout. Failure
+ * messages carry only the command name and truncated stderr — never stdout,
+ * never the resolved secret.
+ */
+export async function runExecSecret(spec: ExecSecret, descriptor: string): Promise<string> {
+	const { command, args } = spec.exec;
+	const stdout = await new Promise<string>((resolve, reject) => {
+		const child = execFile(
+			command,
+			args,
+			{ timeout: TIMEOUT_MS, encoding: 'utf-8' },
+			(err, out, errOut) => {
+				if (err) {
+					reject(
+						new CredentialResolutionError(failureMessage(err, errOut ?? '', command, descriptor)),
+					);
+					return;
+				}
+				resolve(out);
+			},
+		);
+		child.stdin?.end();
+	});
+
+	const trimmed = stdout.replace(/\r?\n+$/, '');
+	if (trimmed === '') {
+		throw new CredentialResolutionError(
+			`Could not resolve ${descriptor}: command "${command}" produced no output`,
+		);
+	}
+	return trimmed;
+}

--- a/src/wikis/mwnProvider.ts
+++ b/src/wikis/mwnProvider.ts
@@ -1,6 +1,7 @@
 import { Mwn, type MwnOptions } from 'mwn';
 import { USER_AGENT } from '../runtime/constants.js';
-import type { WikiConfig } from '../config/loadConfig.js';
+import type { ExecSecret, WikiConfig } from '../config/loadConfig.js';
+import { runExecSecret } from './execSecret.js';
 import { redactAuthorizationHeader, wrapMwnErrors } from './mwnErrorSanitizer.js';
 import type { WikiRegistry } from './wikiRegistry.js';
 import type { WikiSelection } from './wikiSelection.js';
@@ -14,6 +15,11 @@ export class MwnProviderImpl implements MwnProvider {
 	// Cache the Promise, not the resolved instance, so concurrent first-calls
 	// for the same wiki share a single login / getSiteInfo round-trip.
 	private readonly cache = new Map<string, Promise<Mwn>>();
+
+	// Resolved exec-backed secrets, cached per `${wikiKey} ${field}` for the
+	// process lifetime. Caches the Promise so concurrent first-resolves share one
+	// command run; a rejection is evicted so a transient failure can retry.
+	private readonly secretCache = new Map<string, Promise<string | null>>();
 
 	public constructor(
 		private readonly wikis: WikiRegistry,
@@ -39,12 +45,12 @@ export class MwnProviderImpl implements MwnProvider {
 	private async getInstance(key: string, config: Readonly<WikiConfig>): Promise<Mwn> {
 		const runtimeToken = this.getRuntimeToken();
 		if (runtimeToken) {
-			return this.create(config, runtimeToken);
+			return this.create(key, config, runtimeToken);
 		}
 
 		let pending = this.cache.get(key);
 		if (!pending) {
-			pending = this.create(config);
+			pending = this.create(key, config);
 			this.cache.set(key, pending);
 			// On failure, remove from cache so the next call retries rather than
 			// permanently caching the rejected Promise.
@@ -56,12 +62,57 @@ export class MwnProviderImpl implements MwnProvider {
 	}
 
 	public invalidate(key: string): void {
+		// Only the live mwn instance is dropped — e.g. after an OAuth token
+		// refresh. secretCache is intentionally left intact: a config-derived
+		// exec secret is stable for the process, so re-running the command
+		// would be wasteful.
 		this.cache.delete(key);
 	}
 
-	private async create(config: Readonly<WikiConfig>, runtimeToken?: string): Promise<Mwn> {
-		const { server, scriptpath, token, username, password } = config;
+	private async resolveSecret(
+		wikiKey: string,
+		field: 'token' | 'username' | 'password',
+		raw: string | ExecSecret | null | undefined,
+	): Promise<string | null> {
+		if (raw === null || raw === undefined) {
+			return null;
+		}
+		if (typeof raw === 'string') {
+			return raw;
+		}
+		const cacheKey = `${wikiKey} ${field}`;
+		let pending = this.secretCache.get(cacheKey);
+		if (!pending) {
+			pending = runExecSecret(raw, `the "${field}" credential for wiki "${wikiKey}"`);
+			this.secretCache.set(cacheKey, pending);
+			// Evict a rejected resolution so the next use of the wiki retries
+			// rather than permanently caching a transient failure.
+			pending.catch(() => {
+				this.secretCache.delete(cacheKey);
+			});
+		}
+		return pending;
+	}
+
+	private async create(
+		key: string,
+		config: Readonly<WikiConfig>,
+		runtimeToken?: string,
+	): Promise<Mwn> {
+		const { server, scriptpath } = config;
+
+		// A runtime token always wins, so config secrets are not even resolved
+		// in that path. Otherwise resolve the config token; only if there is no
+		// token at all do we resolve the bot-password pair.
+		const token = runtimeToken ? undefined : await this.resolveSecret(key, 'token', config.token);
 		const effectiveToken: string | undefined = runtimeToken ?? token ?? undefined;
+
+		let username: string | null = null;
+		let password: string | null = null;
+		if (!effectiveToken) {
+			username = await this.resolveSecret(key, 'username', config.username);
+			password = await this.resolveSecret(key, 'password', config.password);
+		}
 
 		const options: MwnOptions = {
 			apiUrl: `${server}${scriptpath}/api.php`,

--- a/tests/config/loadConfig.test.ts
+++ b/tests/config/loadConfig.test.ts
@@ -335,10 +335,7 @@ describe('loadConfigFromFile', () => {
 	});
 
 	describe('exec credential source', () => {
-		const SENTINEL = 'SENTINEL-NEVER-LEAK';
-
-		it('resolves secret from trimmed stdout of the exec command', async () => {
-			vi.mocked(execFileSync).mockReturnValue('resolved-secret\n');
+		it('returns an ExecSecret marker without running the command', async () => {
 			setConfigFile({
 				defaultWiki: 'w',
 				wikis: {
@@ -349,25 +346,33 @@ describe('loadConfigFromFile', () => {
 				},
 			});
 			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(loadConfigFromFile().wikis.w.token).toBe('resolved-secret');
-			expect(vi.mocked(execFileSync)).toHaveBeenCalledWith('op', ['read', 'op://vault/token'], {
-				timeout: 10000,
-				encoding: 'utf-8',
-				stdio: ['ignore', 'pipe', 'pipe'],
+			const token = loadConfigFromFile().wikis.w.token;
+			expect(token).toEqual({ exec: { command: 'op', args: ['read', 'op://vault/token'] } });
+			expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+		});
+
+		it('normalises a missing args array to []', async () => {
+			setConfigFile({
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'my-helper' } } } },
+			});
+			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile().wikis.w.token).toEqual({
+				exec: { command: 'my-helper', args: [] },
 			});
 		});
 
-		it('calls execFileSync with [] when args is omitted', async () => {
-			vi.mocked(execFileSync).mockReturnValue('secret');
+		it('runs no exec command at load even across multiple exec-backed wikis', async () => {
 			setConfigFile({
-				defaultWiki: 'w',
+				defaultWiki: 'a',
 				wikis: {
-					w: { ...baseWiki, token: { exec: { command: 'my-helper' } } },
+					a: { ...baseWiki, token: { exec: { command: 'op', args: ['a'] } } },
+					b: { ...baseWiki, username: { exec: { command: 'op', args: ['b'] } } },
 				},
 			});
 			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
 			loadConfigFromFile();
-			expect(vi.mocked(execFileSync)).toHaveBeenCalledWith('my-helper', [], expect.any(Object));
+			expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
 		});
 
 		it('throws when exec.command is missing or empty', async () => {
@@ -384,104 +389,11 @@ describe('loadConfigFromFile', () => {
 		it('throws when exec.args is not a string array', async () => {
 			setConfigFile({
 				defaultWiki: 'w',
-				wikis: {
-					w: { ...baseWiki, token: { exec: { command: 'op', args: [1, 2] } } },
-				},
+				wikis: { w: { ...baseWiki, token: { exec: { command: 'op', args: [1, 2] } } } },
 			});
 			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
 			expect(() => loadConfigFromFile()).toThrow(
 				'Config error: wikis.w.token.exec.args must be an array of strings',
-			);
-		});
-
-		it('maps ENOENT to a clear error', async () => {
-			vi.mocked(execFileSync).mockImplementation(() => {
-				const e = new Error('spawn op ENOENT') as NodeJS.ErrnoException;
-				e.code = 'ENOENT';
-				throw e;
-			});
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(() => loadConfigFromFile()).toThrow(
-				'Config error: failed to fetch wikis.w.token: command "op" not found',
-			);
-		});
-
-		it('maps timeout (SIGTERM) to a clear error', async () => {
-			vi.mocked(execFileSync).mockImplementation(() => {
-				const e = new Error('timed out') as NodeJS.ErrnoException & { signal?: string };
-				e.signal = 'SIGTERM';
-				throw e;
-			});
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'slow' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(() => loadConfigFromFile()).toThrow(
-				'Config error: failed to fetch wikis.w.token: command "slow" timed out after 10s',
-			);
-		});
-
-		it('maps non-zero exit to a clear error with truncated stderr', async () => {
-			vi.mocked(execFileSync).mockImplementation(() => {
-				const e = new Error('command failed') as NodeJS.ErrnoException & {
-					status?: number;
-					stderr?: Buffer;
-				};
-				e.status = 1;
-				e.stderr = Buffer.from('auth required');
-				throw e;
-			});
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(() => loadConfigFromFile()).toThrow(
-				'Config error: failed to fetch wikis.w.token: command "op" exited with status 1. stderr: auth required',
-			);
-		});
-
-		it('truncates long stderr to 200 chars', async () => {
-			const longStderr = 'X'.repeat(500);
-			vi.mocked(execFileSync).mockImplementation(() => {
-				const e = new Error('fail') as NodeJS.ErrnoException & {
-					status?: number;
-					stderr?: Buffer;
-				};
-				e.status = 2;
-				e.stderr = Buffer.from(longStderr);
-				throw e;
-			});
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			try {
-				loadConfigFromFile();
-				expect.fail('should have thrown');
-			} catch (err) {
-				const msg = (err as Error).message;
-				expect(msg).toContain('exited with status 2');
-				// Count Xs in message: should be ≤200
-				expect((msg.match(/X/g) ?? []).length).toBeLessThanOrEqual(200);
-			}
-		});
-
-		it('throws when stdout is empty after trim', async () => {
-			vi.mocked(execFileSync).mockReturnValue('\n\n');
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(() => loadConfigFromFile()).toThrow(
-				'Config error: failed to fetch wikis.w.token: command "op" produced no output',
 			);
 		});
 
@@ -494,33 +406,6 @@ describe('loadConfigFromFile', () => {
 			expect(() => loadConfigFromFile()).toThrow(
 				'Config error: wikis.w.token must be a string, null, or an {exec: …} object',
 			);
-		});
-
-		it('never leaks subprocess stdout in error messages', async () => {
-			// If the subprocess printed the real secret on stdout and then errored,
-			// the error path must not reach into stdout for the message — only stderr.
-			vi.mocked(execFileSync).mockImplementation(() => {
-				const e = new Error('command failed') as NodeJS.ErrnoException & {
-					status?: number;
-					stderr?: Buffer;
-					stdout?: Buffer;
-				};
-				e.status = 1;
-				e.stderr = Buffer.from('auth needed');
-				e.stdout = Buffer.from(SENTINEL);
-				throw e;
-			});
-			setConfigFile({
-				defaultWiki: 'w',
-				wikis: { w: { ...baseWiki, token: { exec: { command: 'op' } } } },
-			});
-			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
-			expect(() => loadConfigFromFile()).toThrow(/exited with status 1/);
-			try {
-				loadConfigFromFile();
-			} catch (err) {
-				expect((err as Error).message).not.toContain(SENTINEL);
-			}
 		});
 	});
 

--- a/tests/errors/classifyError.test.ts
+++ b/tests/errors/classifyError.test.ts
@@ -4,6 +4,7 @@ import { classifyError } from '../../src/errors/classifyError.js';
 import { errorResult } from '../../src/results/response.js';
 import { createMockMwnError } from '../helpers/mock-mwn-error.js';
 import { assertStructuredError } from '../helpers/structuredResult.js';
+import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.js';
 
 describe('classifyError', () => {
 	describe('maps MW .code to category', () => {
@@ -89,6 +90,13 @@ describe('classifyError', () => {
 		['number', 42],
 	])('non-Error value (%s) → upstream_failure without code', (_label, value) => {
 		expect(classifyError(value)).toEqual({ category: 'upstream_failure' });
+	});
+
+	describe('CredentialResolutionError', () => {
+		it('classifies as authentication', () => {
+			const err = new CredentialResolutionError('Could not resolve the "token" credential');
+			expect(classifyError(err)).toEqual({ category: 'authentication' });
+		});
 	});
 });
 

--- a/tests/runtime/dispatcher.test.ts
+++ b/tests/runtime/dispatcher.test.ts
@@ -5,6 +5,9 @@ import type { Tool } from '../../src/runtime/tool.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { createMockMwnError } from '../helpers/mock-mwn-error.js';
 import { clearRegisteredServers } from '../../src/runtime/logger.js';
+import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.js';
+import { getPage } from '../../src/tools/get-page.js';
+import { ContentFormat } from '../../src/results/contentFormat.js';
 
 const noopTool = (handle: Tool<{ x: z.ZodString }>['handle']): Tool<{ x: z.ZodString }> => ({
 	name: 'get-page',
@@ -95,6 +98,34 @@ describe('dispatcher', () => {
 		const result = await dispatch(tool, ctx)({ x: 'y' });
 		const envelope = JSON.parse((result.content[0] as { text: string }).text);
 		expect(envelope.message).toBe('Failed to update page: boom');
+	});
+
+	it('surfaces a CredentialResolutionError from the mwn provider as authentication category', async () => {
+		// Simulate an exec-backed credential command failing on first use of the wiki.
+		const credError = new CredentialResolutionError(
+			'exec command "false" exited with code 1 (no output)',
+		);
+		const ctx = fakeContext({
+			mwn: async () => {
+				throw credError;
+			},
+		});
+
+		const result = await dispatch(
+			getPage,
+			ctx,
+		)({
+			title: 'Test Page',
+			content: ContentFormat.source,
+			metadata: false,
+		});
+
+		expect(result.isError).toBe(true);
+		const envelope = JSON.parse((result.content[0] as { text: string }).text);
+		expect(envelope.category).toBe('authentication');
+		// The error message must not contain the secret/stdout — only safe text.
+		expect(envelope.message).not.toContain('secret');
+		expect(envelope.message).not.toContain('stdout');
 	});
 });
 

--- a/tests/transport/bearerGuard.test.ts
+++ b/tests/transport/bearerGuard.test.ts
@@ -49,6 +49,17 @@ describe('hasStaticCredentials', () => {
 	it('is true when token and bot-password fields are all set', () => {
 		expect(hasStaticCredentials(wiki({ token: 't', username: 'u', password: 'p' }))).toBe(true);
 	});
+
+	it('is true when token is an ExecSecret object', () => {
+		const execToken = { exec: { command: 'op', args: ['read', 'x'] } };
+		expect(hasStaticCredentials(wiki({ token: execToken }))).toBe(true);
+	});
+
+	it('is true when username and password are both ExecSecret objects', () => {
+		const execUser = { exec: { command: 'op', args: ['read', 'user'] } };
+		const execPass = { exec: { command: 'op', args: ['read', 'pass'] } };
+		expect(hasStaticCredentials(wiki({ username: execUser, password: execPass }))).toBe(true);
+	});
 });
 
 describe('evaluateBearerGuard', () => {
@@ -112,6 +123,15 @@ describe('evaluateBearerGuard', () => {
 	it('returns ok regardless of MCP_ALLOW_STATIC_FALLBACK when no wiki has credentials', () => {
 		expect(evaluateBearerGuard({}, { MCP_ALLOW_STATIC_FALLBACK: 'true' })).toEqual({
 			kind: 'ok',
+		});
+	});
+
+	it('returns block for a wiki with an exec-backed token when MCP_ALLOW_STATIC_FALLBACK is unset', () => {
+		const execToken = { exec: { command: 'op', args: ['read', 'x'] } };
+		const wikis = { a: wiki({ token: execToken }) };
+		expect(evaluateBearerGuard(wikis, {})).toEqual({
+			kind: 'block',
+			wikis: ['a'],
 		});
 	});
 });

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -16,23 +16,27 @@ const mockRequest = vi.fn();
 //    these inline mocks are what actually drive the test logic. Do not
 //    collapse the two layers — they target different code paths.
 
-vi.mock('../../src/config/loadConfig.js', () => ({
-	loadConfigFromFile: () => ({
-		defaultWiki: 'example.org',
-		wikis: {
-			'example.org': {
-				sitename: 'Example',
-				server: 'https://example.org',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				token: null,
-				username: null,
-				password: null,
+vi.mock('../../src/config/loadConfig.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/config/loadConfig.js')>();
+	return {
+		...actual,
+		loadConfigFromFile: () => ({
+			defaultWiki: 'example.org',
+			wikis: {
+				'example.org': {
+					sitename: 'Example',
+					server: 'https://example.org',
+					articlepath: '/wiki',
+					scriptpath: '/w',
+					token: null,
+					username: null,
+					password: null,
+				},
 			},
-		},
-		uploadDirs: [],
-	}),
-}));
+			uploadDirs: [],
+		}),
+	};
+});
 
 vi.mock('../../src/wikis/mwnProvider.js', () => ({
 	MwnProviderImpl: class {

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -16,23 +16,27 @@ const mockRequest = vi.fn();
 //    these inline mocks are what actually drive the test logic. Do not
 //    collapse the two layers — they target different code paths.
 
-vi.mock('../../src/config/loadConfig.js', () => ({
-	loadConfigFromFile: () => ({
-		defaultWiki: 'example.org',
-		wikis: {
-			'example.org': {
-				sitename: 'Example',
-				server: 'https://example.org',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				token: null,
-				username: null,
-				password: null,
+vi.mock('../../src/config/loadConfig.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/config/loadConfig.js')>();
+	return {
+		...actual,
+		loadConfigFromFile: () => ({
+			defaultWiki: 'example.org',
+			wikis: {
+				'example.org': {
+					sitename: 'Example',
+					server: 'https://example.org',
+					articlepath: '/wiki',
+					scriptpath: '/w',
+					token: null,
+					username: null,
+					password: null,
+				},
 			},
-		},
-		uploadDirs: [],
-	}),
-}));
+			uploadDirs: [],
+		}),
+	};
+});
 
 vi.mock('../../src/wikis/mwnProvider.js', () => ({
 	MwnProviderImpl: class {

--- a/tests/transport/streamableHttp.oauth.test.ts
+++ b/tests/transport/streamableHttp.oauth.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
-vi.mock('../../src/config/loadConfig.js', () => ({
-	loadConfigFromFile: () => ({
-		defaultWiki: 'test',
-		wikis: {
-			test: {
-				sitename: 'Test',
-				server: 'https://test.example',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				token: null,
-				username: null,
-				password: null,
+vi.mock('../../src/config/loadConfig.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/config/loadConfig.js')>();
+	return {
+		...actual,
+		loadConfigFromFile: () => ({
+			defaultWiki: 'test',
+			wikis: {
+				test: {
+					sitename: 'Test',
+					server: 'https://test.example',
+					articlepath: '/wiki',
+					scriptpath: '/w',
+					token: null,
+					username: null,
+					password: null,
+				},
 			},
-		},
-		uploadDirs: [],
-	}),
-}));
+			uploadDirs: [],
+		}),
+	};
+});
 
 vi.mock('../../src/wikis/mwnProvider.js', () => ({
 	MwnProviderImpl: class {

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../../src/config/loadConfig.js', () => ({
-	loadConfigFromFile: () => ({
-		defaultWiki: 'test',
-		wikis: {
-			test: {
-				sitename: 'Test',
-				server: 'https://test.example',
-				articlepath: '/wiki',
-				scriptpath: '/w',
-				token: null,
-				username: null,
-				password: null,
+vi.mock('../../src/config/loadConfig.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../src/config/loadConfig.js')>();
+	return {
+		...actual,
+		loadConfigFromFile: () => ({
+			defaultWiki: 'test',
+			wikis: {
+				test: {
+					sitename: 'Test',
+					server: 'https://test.example',
+					articlepath: '/wiki',
+					scriptpath: '/w',
+					token: null,
+					username: null,
+					password: null,
+				},
 			},
-		},
-		uploadDirs: [],
-	}),
-}));
+			uploadDirs: [],
+		}),
+	};
+});
 
 vi.mock('../../src/wikis/mwnProvider.js', () => ({
 	MwnProviderImpl: class {

--- a/tests/wikis/execSecret.test.ts
+++ b/tests/wikis/execSecret.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFile } from 'node:child_process';
+
+vi.mock('node:child_process');
+
+import { runExecSecret } from '../../src/wikis/execSecret.js';
+import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.js';
+
+const SENTINEL = 'SECRET-NEVER-LEAK';
+const descriptor = 'the "token" credential for wiki "w"';
+
+/**
+ * Drive the mocked execFile callback. runExecSecret calls execFile with
+ * (file, args, options, callback) and then `.stdin?.end()` on the returned
+ * child; we capture the callback, invoke it, and return a stub child.
+ */
+function mockExecFile(
+	behaviour: (cb: (err: unknown, stdout: string, stderr: string) => void) => void,
+) {
+	vi.mocked(execFile).mockImplementation(((...callArgs: unknown[]) => {
+		const cb = callArgs[callArgs.length - 1] as (e: unknown, o: string, s: string) => void;
+		behaviour(cb);
+		return { stdin: { end: () => {} } } as unknown as ReturnType<typeof execFile>;
+	}) as unknown as typeof execFile);
+}
+
+describe('runExecSecret', () => {
+	beforeEach(() => {
+		vi.mocked(execFile).mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns the trimmed stdout on success', async () => {
+		mockExecFile((cb) => cb(null, 'resolved-secret\n', ''));
+		await expect(
+			runExecSecret({ exec: { command: 'op', args: ['read', 'x'] } }, descriptor),
+		).resolves.toBe('resolved-secret');
+	});
+
+	it('throws CredentialResolutionError when the command is not found', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('spawn op ENOENT') as NodeJS.ErrnoException;
+			e.code = 'ENOENT';
+			cb(e, '', '');
+		});
+		await expect(
+			runExecSecret({ exec: { command: 'op', args: [] } }, descriptor),
+		).rejects.toBeInstanceOf(CredentialResolutionError);
+		await expect(runExecSecret({ exec: { command: 'op', args: [] } }, descriptor)).rejects.toThrow(
+			'command "op" not found',
+		);
+	});
+
+	it('throws CredentialResolutionError on timeout', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('timed out') as Error & { killed?: boolean; signal?: string };
+			e.killed = true;
+			e.signal = 'SIGTERM';
+			cb(e, '', '');
+		});
+		await expect(
+			runExecSecret({ exec: { command: 'slow', args: [] } }, descriptor),
+		).rejects.toThrow('timed out after 10s');
+	});
+
+	it('throws CredentialResolutionError on non-zero exit with truncated stderr', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('failed') as Error & { code?: number };
+			e.code = 1;
+			cb(e, '', 'auth required');
+		});
+		await expect(runExecSecret({ exec: { command: 'op', args: [] } }, descriptor)).rejects.toThrow(
+			'exited with status 1. stderr: auth required',
+		);
+	});
+
+	it('truncates long stderr to 200 chars', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('failed') as Error & { code?: number };
+			e.code = 2;
+			cb(e, '', 'X'.repeat(500));
+		});
+		try {
+			await runExecSecret({ exec: { command: 'op', args: [] } }, descriptor);
+			expect.fail('should have thrown');
+		} catch (err) {
+			expect((err as Error).message.match(/X/g)?.length ?? 0).toBeLessThanOrEqual(200);
+		}
+	});
+
+	it('throws when the command produces no output', async () => {
+		mockExecFile((cb) => cb(null, '\n\n', ''));
+		await expect(runExecSecret({ exec: { command: 'op', args: [] } }, descriptor)).rejects.toThrow(
+			'produced no output',
+		);
+	});
+
+	it('never leaks the command stdout into a failure message', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('failed') as Error & { code?: number };
+			e.code = 1;
+			cb(e, SENTINEL, 'auth needed');
+		});
+		try {
+			await runExecSecret({ exec: { command: 'op', args: [] } }, descriptor);
+			expect.fail('should have thrown');
+		} catch (err) {
+			expect((err as Error).message).not.toContain(SENTINEL);
+		}
+	});
+});

--- a/tests/wikis/mwnProvider.test.ts
+++ b/tests/wikis/mwnProvider.test.ts
@@ -20,10 +20,16 @@ vi.mock('../../src/runtime/constants.js', () => ({
 	USER_AGENT: 'test-agent',
 }));
 
+const { mockRunExecSecret } = vi.hoisted(() => ({ mockRunExecSecret: vi.fn() }));
+vi.mock('../../src/wikis/execSecret.js', () => ({
+	runExecSecret: mockRunExecSecret,
+}));
+
 import { MwnProviderImpl } from '../../src/wikis/mwnProvider.js';
 import { WikiRegistryImpl } from '../../src/wikis/wikiRegistry.js';
 import { WikiSelectionImpl } from '../../src/wikis/wikiSelection.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
+import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.js';
 
 const sample = (name: string): WikiConfig => ({
 	sitename: name,
@@ -38,6 +44,7 @@ describe('MwnProviderImpl', () => {
 		mockGetSiteInfo.mockReset();
 		mockInit.mockReset();
 		mockGetSiteInfo.mockResolvedValue(undefined);
+		mockRunExecSecret.mockReset();
 	});
 
 	it('caches non-runtime-token mwn instances per key', async () => {
@@ -182,5 +189,75 @@ describe('MwnProviderImpl', () => {
 		await provider.get();
 		const options = mockConstructor.mock.calls[0]?.[0] as { defaultParams?: { assert?: unknown } };
 		expect(options.defaultParams?.assert).toBeUndefined();
+	});
+
+	describe('lazy exec-backed credentials', () => {
+		const execWiki = (name: string): WikiConfig => ({
+			...sample(name),
+			token: { exec: { command: 'op', args: ['read', 'x'] } },
+		});
+
+		it('runs the exec command once on first use and reuses the cached value', async () => {
+			mockRunExecSecret.mockResolvedValue('exec-token');
+			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
+			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
+			const sel = new WikiSelectionImpl('a', reg);
+			const provider = new MwnProviderImpl(reg, sel, () => undefined);
+
+			await provider.get('a');
+			await provider.get('a');
+
+			expect(mockRunExecSecret).toHaveBeenCalledOnce();
+			expect(mockInit).toHaveBeenCalledWith(
+				expect.objectContaining({ OAuth2AccessToken: 'exec-token' }),
+			);
+		});
+
+		it('never runs the exec command for a wiki that is not used', async () => {
+			mockRunExecSecret.mockResolvedValue('exec-token');
+			const reg = new WikiRegistryImpl({ a: sample('a'), b: execWiki('b') }, true);
+			const sel = new WikiSelectionImpl('a', reg);
+			const provider = new MwnProviderImpl(reg, sel, () => undefined);
+
+			await provider.get('a');
+
+			expect(mockRunExecSecret).not.toHaveBeenCalled();
+		});
+
+		it('surfaces a failing exec command as a CredentialResolutionError', async () => {
+			mockRunExecSecret.mockRejectedValue(
+				new CredentialResolutionError('Could not resolve the "token" credential for wiki "a"'),
+			);
+			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
+			const sel = new WikiSelectionImpl('a', reg);
+			const provider = new MwnProviderImpl(reg, sel, () => undefined);
+
+			await expect(provider.get('a')).rejects.toBeInstanceOf(CredentialResolutionError);
+		});
+
+		it('does not resolve config secrets when a runtime token is present', async () => {
+			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
+			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
+			const sel = new WikiSelectionImpl('a', reg);
+			const provider = new MwnProviderImpl(reg, sel, () => 'runtime-token');
+
+			await provider.get('a');
+
+			expect(mockRunExecSecret).not.toHaveBeenCalled();
+		});
+
+		it('retries a failing exec command on the next call', async () => {
+			mockRunExecSecret
+				.mockRejectedValueOnce(new CredentialResolutionError('transient'))
+				.mockResolvedValueOnce('exec-token');
+			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
+			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
+			const sel = new WikiSelectionImpl('a', reg);
+			const provider = new MwnProviderImpl(reg, sel, () => undefined);
+
+			await expect(provider.get('a')).rejects.toBeInstanceOf(CredentialResolutionError);
+			await provider.get('a');
+			expect(mockRunExecSecret).toHaveBeenCalledTimes(2);
+		});
 	});
 });


### PR DESCRIPTION
## Problem

The server resolved `{exec:…}` wiki credentials eagerly and synchronously when `config.json` loaded. Every startup ran each configured wiki's credential command (e.g. `op`, the 1Password CLI) and blocked on it; when a command exceeded the 10s timeout, the *entire* server startup crashed — even for sessions that never touched that wiki.

## Fix

Exec-backed secrets now resolve **lazily, on first use of that specific wiki**, cached for the process lifetime, and run **asynchronously** so a slow credential helper never blocks the event loop.

- Config load (`parseExecSecret`) does shape validation only — a malformed exec object still fails fast at startup; zero commands run.
- `MwnProviderImpl.create()` resolves each secret on first use via `runExecSecret`, caching the result per `(wiki, field)` (Promise cached, rejection evicted so a transient failure can retry).
- A failing or timing-out command throws `CredentialResolutionError`, classified as the `authentication` error category — surfacing as a categorized tool error when that wiki is first used, never as a startup crash. Messages carry only the command name and truncated stderr; the resolved secret and command stdout never leak.
- Only the `{exec:…}` form becomes lazy. Plain strings, `null`, and `${ENV_VAR}` substitution stay eager.
- The `WikiConfig` secret-field type widened to `string | ExecSecret | null`; a shared `isCredentialConfigured()` predicate keeps the HTTP transport's static-credential / bearer guard correct for exec-backed wikis.

## Testing

- 966 unit/integration tests pass; lint, format, and build clean.
- New tests cover the async runner, lazy resolution + caching, the bearer-guard classification, and the end-to-end credential-failure path through the dispatcher.
- Smoke-tested against the built server via the MCP Inspector CLI:
  - With a `sleep 30` exec-backed wiki configured, `tools/list` returned in **2.6s** — startup runs zero exec commands.
  - A wiki whose exec command fails returns an `authentication`-category error **only when used**, with a redacted message; the server stays up.
  - An unused exec-backed wiki's command never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)