### PR TITLE
Add per-wiki capability discovery (list-wikis, union gating)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 
 - Tool calls target a wiki named per call, defaulting to the configured default wiki, instead of a server-side selection that had to be set first.
+- Extension-gated tools (`cargo-*`, `smw-*`, `bucket-query`) and the write tools are now offered whenever *any* configured wiki supports them, instead of only when the default wiki does. A call targeting a wiki that lacks the capability returns a clear error.
 - Wiki credentials backed by an `exec` command are now fetched the first time that wiki is used, instead of when the server starts. A slow or failing credential command no longer delays startup or prevents the server from starting — the error now appears only when that wiki is used.
 
 ## [0.9.1] - 2026-05-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it.
 - Optional `wiki` argument on every tool that operates on a wiki (all except the wiki-management and OAuth tools), naming the wiki that call acts on. Accepts a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI.
 - Tool responses now report the wiki the call ran against.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | Name | Description |
 |---|---|
 | `add-wiki` | Add a wiki as an MCP resource from its URL. Disabled when `allowWikiManagement` is `false`. |
+| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it. |
 | `remove-wiki` | Remove a wiki resource. Disabled when `allowWikiManagement` is `false` or fewer than two wikis are configured. |
 
 #### OAuth

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). |
 | `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and hide flags (up to 50 per call, paginated via `continue`). |
 | `get-revision` | Fetch a specific revision of a page. |
+| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
 | `search-page` | Search wiki page titles and contents. |
 | `search-page-by-prefix` | Search page titles by prefix. |
@@ -43,7 +44,6 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | Name | Description |
 |---|---|
 | `add-wiki` | Add a wiki as an MCP resource from its URL. Disabled when `allowWikiManagement` is `false`. |
-| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it. |
 | `remove-wiki` | Remove a wiki resource. Disabled when `allowWikiManagement` is `false` or fewer than two wikis are configured. |
 
 #### OAuth

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -14,6 +14,7 @@ import {
 } from './instrument.js';
 import { acquireToken } from '../auth/acquireToken.js';
 import { structuredResult } from '../results/response.js';
+import { checkWikiCapability } from './wikiCapability.js';
 
 // Tools that operate on server-local state (the wiki registry, the OAuth token
 // store) rather than a wiki's API. They must not be blocked by an OAuth gate
@@ -49,6 +50,10 @@ export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext =
 				return ctx.format.invalidInput(
 					`Wiki "${resolvedKey}" not found. Configured wikis: ${configured.join(', ')}`,
 				);
+			}
+			const guardError = await checkWikiCapability(tool.name, resolvedKey, ctx);
+			if (guardError) {
+				return guardError;
 			}
 		}
 

--- a/src/runtime/reconcile.ts
+++ b/src/runtime/reconcile.ts
@@ -1,7 +1,6 @@
 import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { WikiConfig } from '../config/loadConfig.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
-import type { ActiveWiki } from '../wikis/activeWiki.js';
 import type { ExtensionDetector } from '../wikis/extensionDetector.js';
 import type { ExtensionPack } from '../tools/extensions/types.js';
 
@@ -9,15 +8,13 @@ export type Reconcile = () => Promise<void>;
 
 export interface ReconcileDeps {
 	readonly wikiRegistry: WikiRegistry;
-	readonly activeWiki: ActiveWiki;
 	readonly transport: 'http' | 'stdio';
 	readonly extensions: ExtensionDetector;
 	readonly extensionPacks: readonly ExtensionPack[];
 }
 
 export interface ReconcileContext {
-	readonly activeWikiKey: string;
-	readonly activeWiki: Readonly<WikiConfig>;
+	readonly allWikis: Readonly<Record<string, WikiConfig>>;
 	readonly wikiCount: number;
 	readonly allowManagement: boolean;
 	readonly transport: 'http' | 'stdio';
@@ -47,7 +44,10 @@ const STATIC_RULES: readonly ToolGatingRule[] = [
 	{
 		name: 'read-only',
 		affects: WRITE_TOOL_NAMES,
-		isAllowed: (c) => !c.activeWiki.readOnly,
+		// Union gating: write tools stay offered if ANY configured wiki is
+		// writable. The per-call capability guard rejects a write to a
+		// read-only wiki.
+		isAllowed: (c) => Object.values(c.allWikis).some((w) => w.readOnly !== true),
 	},
 	{
 		name: 'stdio-only',
@@ -70,16 +70,23 @@ function buildExtensionRules(packs: readonly ExtensionPack[]): readonly ToolGati
 	return packs.map((pack) => ({
 		name: `${pack.id}-extension`,
 		affects: pack.tools.map((t) => t.name),
-		isAllowed: (c) => c.extensions.hasAny(c.activeWikiKey, pack.extensionNames),
+		// Union gating: the pack's tools are offered if ANY configured wiki has
+		// the extension. The per-call capability guard rejects a call to a wiki
+		// that lacks it.
+		isAllowed: async (c) => {
+			const results = await Promise.all(
+				Object.keys(c.allWikis).map((key) => c.extensions.hasAny(key, pack.extensionNames)),
+			);
+			return results.some((r) => r);
+		},
 	}));
 }
 
 function buildContext(deps: ReconcileDeps): ReconcileContext {
-	const { key, config } = deps.activeWiki.get();
+	const allWikis = deps.wikiRegistry.getAll();
 	return {
-		activeWikiKey: key,
-		activeWiki: config,
-		wikiCount: Object.keys(deps.wikiRegistry.getAll()).length,
+		allWikis,
+		wikiCount: Object.keys(allWikis).length,
 		allowManagement: deps.wikiRegistry.isManagementAllowed(),
 		transport: deps.transport,
 		extensions: deps.extensions,

--- a/src/runtime/reconcile.ts
+++ b/src/runtime/reconcile.ts
@@ -3,6 +3,7 @@ import type { WikiConfig } from '../config/loadConfig.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
 import type { ExtensionDetector } from '../wikis/extensionDetector.js';
 import type { ExtensionPack } from '../tools/extensions/types.js';
+import { WRITE_TOOL_NAMES } from './wikiCapability.js';
 
 export type Reconcile = () => Promise<void>;
 
@@ -26,17 +27,6 @@ export interface ToolGatingRule {
 	readonly affects: readonly string[];
 	readonly isAllowed: (ctx: ReconcileContext) => boolean | Promise<boolean>;
 }
-
-const WRITE_TOOL_NAMES: readonly string[] = [
-	'create-page',
-	'update-page',
-	'delete-page',
-	'undelete-page',
-	'upload-file',
-	'upload-file-from-url',
-	'update-file',
-	'update-file-from-url',
-];
 
 const STDIO_ONLY_TOOLS: readonly string[] = ['oauth-status', 'oauth-logout'];
 

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -1,0 +1,62 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolContext } from './context.js';
+import type { ExtensionPack } from '../tools/extensions/types.js';
+import { extensionPacks } from '../tools/extensions/index.js';
+
+// The wiki-mutating tools. Shared by reconcile's read-only rule and the
+// per-call capability guard.
+export const WRITE_TOOL_NAMES: readonly string[] = [
+	'create-page',
+	'update-page',
+	'delete-page',
+	'undelete-page',
+	'upload-file',
+	'upload-file-from-url',
+	'update-file',
+	'update-file-from-url',
+];
+
+const WRITE_TOOL_SET: ReadonlySet<string> = new Set(WRITE_TOOL_NAMES);
+
+// toolName -> the extension pack that provides it.
+const PACK_BY_TOOL: ReadonlyMap<string, ExtensionPack> = ((): ReadonlyMap<
+	string,
+	ExtensionPack
+> => {
+	const map = new Map<string, ExtensionPack>();
+	for (const pack of extensionPacks) {
+		for (const tool of pack.tools) {
+			map.set(tool.name, pack);
+		}
+	}
+	return map;
+})();
+
+/**
+ * Verifies a wiki-scoped tool can run against the resolved wiki. Returns an
+ * error CallToolResult to short-circuit dispatch, or undefined when the call
+ * may proceed. Non-extension, non-write tools always return undefined.
+ */
+export async function checkWikiCapability(
+	toolName: string,
+	wikiKey: string,
+	ctx: ToolContext,
+): Promise<CallToolResult | undefined> {
+	const pack = PACK_BY_TOOL.get(toolName);
+	if (pack) {
+		const present = await ctx.extensions.hasAny(wikiKey, pack.extensionNames);
+		if (!present) {
+			return ctx.format.invalidInput(
+				`The ${pack.extensionNames[0]} extension is not installed on wiki "${wikiKey}". ` +
+					'Use list-wikis to see which wikis support it.',
+			);
+		}
+	}
+	if (WRITE_TOOL_SET.has(toolName)) {
+		const config = ctx.wikis.get(wikiKey);
+		if (config?.readOnly === true) {
+			return ctx.format.permissionDenied(`Wiki "${wikiKey}" is configured read-only.`);
+		}
+	}
+	return undefined;
+}

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -46,10 +46,14 @@ export async function checkWikiCapability(
 	if (pack) {
 		const present = await ctx.extensions.hasAny(wikiKey, pack.extensionNames);
 		if (!present) {
-			return ctx.format.invalidInput(
-				`The ${pack.extensionNames[0]} extension is not installed on wiki "${wikiKey}". ` +
-					'Use list-wikis to see which wikis support it.',
-			);
+			// hasAny is false both when the extension is absent and when the
+			// probe failed; inspect() (same cache entry) tells them apart so the
+			// error doesn't claim "not installed" for a wiki that is merely down.
+			const { reachable } = await ctx.extensions.inspect(wikiKey);
+			const reason = reachable
+				? `The ${pack.extensionNames[0]} extension is not installed on wiki "${wikiKey}".`
+				: `Wiki "${wikiKey}" could not be reached to check for the ${pack.extensionNames[0]} extension.`;
+			return ctx.format.invalidInput(`${reason} Use list-wikis to see which wikis support it.`);
 		}
 	}
 	if (WRITE_TOOL_SET.has(toolName)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,7 +62,6 @@ export const createServer = async (ctx: ToolContext): Promise<McpServer> => {
 	const reconcile = async (): Promise<void> => {
 		await reconcileTools(tools, {
 			wikiRegistry: ctx.wikis,
-			activeWiki: ctx.activeWiki,
 			transport: ctx.transport,
 			extensions: ctx.extensions,
 			extensionPacks,

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ const serverInfo = createRequire(import.meta.url)('../server.json') as {
 
 const SERVER_NAME: string = 'mediawiki-mcp-server';
 
-const SERVER_INSTRUCTIONS: string = `Tools and resources for working with one or more MediaWiki wikis. Each configured wiki appears as an \`mcp://wikis/{wikiKey}\` resource. Every tool that operates on a wiki accepts an optional \`wiki\` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (or its \`mcp://wikis/{wikiKey}\` URI). Omit it to use the configured default wiki. There is no stateful "current wiki": each call targets exactly the wiki it names, and every response reports the wiki it ran against.
+const SERVER_INSTRUCTIONS: string = `Tools and resources for working with one or more MediaWiki wikis. Each configured wiki appears as an \`mcp://wikis/{wikiKey}\` resource. Every tool that operates on a wiki accepts an optional \`wiki\` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (or its \`mcp://wikis/{wikiKey}\` URI). Omit it to use the configured default wiki. There is no stateful "current wiki": each call targets exactly the wiki it names, and every response reports the wiki it ran against. Call \`list-wikis\` to discover the configured wikis, their keys, and which extension tools each one supports.
 
 Writes, deletes, and uploads use the caller's \`Authorization: Bearer\` token when present, falling back to credentials configured on the targeted wiki.
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { comparePages } from './compare-pages.js';
 import { getFile } from './get-file.js';
 import { getRevision } from './get-revision.js';
 import { getCategoryMembers } from './get-category-members.js';
+import { listWikis } from './list-wikis.js';
 import { extensionPacks } from './extensions/index.js';
 import { createPage } from './create-page.js';
 import { updatePage } from './update-page.js';
@@ -50,6 +51,7 @@ const standardTools: Tool<any>[] = [
 	getFile,
 	getRevision,
 	getCategoryMembers,
+	listWikis,
 	createPage,
 	updatePage,
 	deletePage,

--- a/src/tools/list-wikis.ts
+++ b/src/tools/list-wikis.ts
@@ -1,0 +1,60 @@
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../runtime/tool.js';
+import type { ToolContext } from '../runtime/context.js';
+import { extensionPacks } from './extensions/index.js';
+
+interface WikiSummary {
+	key: string;
+	sitename: string;
+	server: string;
+	readOnly: boolean;
+	isDefault: boolean;
+	reachable: boolean;
+	// Tool names from every extension pack the wiki supports; order is not significant.
+	extensionTools: string[];
+}
+
+export const listWikis: Tool<Record<string, never>> = {
+	name: 'list-wikis',
+	description:
+		'Lists every configured wiki: its key (pass as the `wiki` argument to other tools), sitename, server URL, whether it is read-only or the default, whether it is currently reachable, and which extension-gated tools (cargo-*, smw-*, bucket-query) work on it. Use to discover the configured wikis, their keys, and which extension tools each supports.',
+	inputSchema: {},
+	annotations: {
+		title: 'List wikis',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	wikiScoped: false,
+	failureVerb: 'list wikis',
+
+	async handle(_args, ctx: ToolContext): Promise<CallToolResult> {
+		const defaultKey = ctx.activeWiki.getDefaultKey();
+		const all = ctx.wikis.getAll();
+		const wikis: WikiSummary[] = await Promise.all(
+			Object.keys(all).map(async (key): Promise<WikiSummary> => {
+				const config = all[key];
+				const { reachable, extensions } = await ctx.extensions.inspect(key);
+				const extensionTools: string[] = [];
+				for (const pack of extensionPacks) {
+					if (pack.extensionNames.some((name) => extensions.has(name))) {
+						for (const tool of pack.tools) {
+							extensionTools.push(tool.name);
+						}
+					}
+				}
+				return {
+					key,
+					sitename: config.sitename,
+					server: config.server,
+					readOnly: config.readOnly === true,
+					isDefault: key === defaultKey,
+					reachable,
+					extensionTools,
+				};
+			}),
+		);
+		return ctx.format.ok({ wikis });
+	},
+};

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -10,6 +10,7 @@ async function fetchCore(
 		params?: Record<string, string>;
 		headers?: Record<string, string>;
 		method?: string;
+		signal?: AbortSignal;
 	},
 ): Promise<Response> {
 	let url = baseUrl;
@@ -43,6 +44,7 @@ async function fetchCore(
 			method: options?.method || 'GET',
 			redirect: 'manual',
 			agent,
+			signal: options?.signal,
 		});
 
 		if (response.status < 300 || response.status >= 400) {
@@ -73,10 +75,15 @@ async function fetchCore(
 	return finalResponse;
 }
 
-export async function makeApiRequest<T>(url: string, params?: Record<string, string>): Promise<T> {
+export async function makeApiRequest<T>(
+	url: string,
+	params?: Record<string, string>,
+	options?: { signal?: AbortSignal },
+): Promise<T> {
 	const response = await fetchCore(url, {
 		params,
 		headers: { Accept: 'application/json' },
+		signal: options?.signal,
 	});
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- HTTP response body; trusted JSON envelope at this boundary
 	return (await response.json()) as T;

--- a/src/wikis/extensionDetector.ts
+++ b/src/wikis/extensionDetector.ts
@@ -6,6 +6,15 @@ import { logger } from '../runtime/logger.js';
 const TTL_SUCCESS_MS = 60 * 60 * 1000; // 1 hour
 const TTL_FAILURE_MS = 60 * 1000; // 60 seconds
 
+// Bound the siteinfo probe so a TCP-level stall on an unreachable wiki fails
+// fast instead of hanging forever. This matters because the probe fans out
+// across EVERY configured wiki — startup reconcile() probes them all, and the
+// list-wikis tool re-probes them all on each call. Without a timeout, one
+// blackholed wiki would hang every list-wikis call and leave extension tools
+// permanently un-reconciled. A timed-out probe aborts the fetch with an abort
+// error, which lands in probe()'s catch and resolves as a `failed` entry.
+const PROBE_TIMEOUT_MS = 5_000;
+
 export interface ExtensionDetector {
 	has(wikiKey: string, extensionName: string): Promise<boolean>;
 	/**
@@ -106,12 +115,16 @@ export class ExtensionDetectorImpl implements ExtensionDetector {
 
 		const apiUrl = `${config.server}${config.scriptpath}/api.php`;
 		try {
-			const data = await makeApiRequest<ExtensionsResponse>(apiUrl, {
-				action: 'query',
-				meta: 'siteinfo',
-				siprop: 'extensions',
-				format: 'json',
-			});
+			const data = await makeApiRequest<ExtensionsResponse>(
+				apiUrl,
+				{
+					action: 'query',
+					meta: 'siteinfo',
+					siprop: 'extensions',
+					format: 'json',
+				},
+				{ signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) },
+			);
 			const list = data.query?.extensions;
 			if (!Array.isArray(list)) {
 				throw new Error('Malformed siteinfo extensions response');

--- a/src/wikis/extensionDetector.ts
+++ b/src/wikis/extensionDetector.ts
@@ -14,6 +14,12 @@ export interface ExtensionDetector {
 	 * `LIBRARIAN` on wiki.gg-hosted wikis (Helldivers, Terraria, Ark, etc.).
 	 */
 	hasAny(wikiKey: string, extensionNames: readonly string[]): Promise<boolean>;
+	/**
+	 * Per-wiki snapshot for capability reporting. `reachable` is false when the
+	 * siteinfo probe failed, in which case `extensions` is empty. Shares the
+	 * same probe cache as has()/hasAny().
+	 */
+	inspect(wikiKey: string): Promise<{ reachable: boolean; extensions: ReadonlySet<string> }>;
 	invalidate(wikiKey: string): void;
 }
 
@@ -53,6 +59,16 @@ export class ExtensionDetectorImpl implements ExtensionDetector {
 			}
 		}
 		return false;
+	}
+
+	public async inspect(
+		wikiKey: string,
+	): Promise<{ reachable: boolean; extensions: ReadonlySet<string> }> {
+		const entry = await this.resolveEntry(wikiKey);
+		if (entry.kind === 'failed') {
+			return { reachable: false, extensions: new Set() };
+		}
+		return { reachable: true, extensions: entry.extensions };
 	}
 
 	public invalidate(wikiKey: string): void {

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -54,6 +54,7 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 		extensions: {
 			has: throws('extensions.has') as never,
 			hasAny: throws('extensions.hasAny') as never,
+			inspect: throws('extensions.inspect') as never,
 			invalidate: throws('extensions.invalidate') as never,
 		},
 		sections: { list: throws('sections.list') as never },

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -53,7 +53,10 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 		},
 		extensions: {
 			has: throws('extensions.has') as never,
-			hasAny: throws('extensions.hasAny') as never,
+			// The dispatch() capability guard calls hasAny for extension-pack
+			// tools; default to "present" so plain tool tests aren't blocked.
+			// Tests that exercise the guard override this explicitly.
+			hasAny: (async () => true) as never,
 			inspect: throws('extensions.inspect') as never,
 			invalidate: throws('extensions.invalidate') as never,
 		},

--- a/tests/runtime/dispatch.wiki.test.ts
+++ b/tests/runtime/dispatch.wiki.test.ts
@@ -4,6 +4,7 @@ import { dispatch } from '../../src/runtime/dispatcher.js';
 import type { Tool } from '../../src/runtime/tool.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { getRequestWiki } from '../../src/transport/requestContext.js';
+import { updatePage } from '../../src/tools/update-page.js';
 
 // A minimal wiki-scoped tool that reports the wiki it ran against.
 const probe: Tool<Record<string, never>> = {
@@ -112,5 +113,33 @@ describe('dispatch wiki echo', () => {
 		};
 		const result = await dispatch(mgmt, ctx)({} as never);
 		expect((result.structuredContent as { wiki?: unknown }).wiki).toBeUndefined();
+	});
+});
+
+describe('dispatch capability guard', () => {
+	it('blocks a write tool dispatched against a read-only wiki', async () => {
+		const roConfig = {
+			sitename: 'T',
+			server: 'https://t',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+			readOnly: true,
+		};
+		const ctx = fakeContext({
+			wikis: {
+				getAll: () => ({ 'test-wiki': roConfig }) as never,
+				get: ((k: string) => (k === 'test-wiki' ? roConfig : undefined)) as never,
+				add: (() => {}) as never,
+				remove: (() => {}) as never,
+				isManagementAllowed: () => true,
+			},
+			activeWiki: {
+				get: () => ({ key: 'test-wiki', config: roConfig as never }),
+				getDefaultKey: () => 'test-wiki',
+			},
+		});
+		const result = await dispatch(updatePage, ctx)({ title: 'X', source: 'y' } as never);
+		expect(result.isError).toBe(true);
+		expect(JSON.stringify(result.content)).toContain('read-only');
 	});
 });

--- a/tests/runtime/dispatch.wiki.test.ts
+++ b/tests/runtime/dispatch.wiki.test.ts
@@ -5,6 +5,7 @@ import type { Tool } from '../../src/runtime/tool.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { getRequestWiki } from '../../src/transport/requestContext.js';
 import { updatePage } from '../../src/tools/update-page.js';
+import { cargoQuery } from '../../src/tools/extensions/cargo/cargo-query.js';
 
 // A minimal wiki-scoped tool that reports the wiki it ran against.
 const probe: Tool<Record<string, never>> = {
@@ -141,5 +142,38 @@ describe('dispatch capability guard', () => {
 		const result = await dispatch(updatePage, ctx)({ title: 'X', source: 'y' } as never);
 		expect(result.isError).toBe(true);
 		expect(JSON.stringify(result.content)).toContain('read-only');
+	});
+
+	it('blocks an extension tool dispatched against a wiki lacking the extension', async () => {
+		const config = {
+			sitename: 'T',
+			server: 'https://t',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+		};
+		const ctx = fakeContext({
+			wikis: {
+				getAll: () => ({ 'test-wiki': config }) as never,
+				get: ((k: string) => (k === 'test-wiki' ? config : undefined)) as never,
+				add: (() => {}) as never,
+				remove: (() => {}) as never,
+				isManagementAllowed: () => true,
+			},
+			activeWiki: {
+				get: () => ({ key: 'test-wiki', config: config as never }),
+				getDefaultKey: () => 'test-wiki',
+			},
+			extensions: {
+				has: (async () => false) as never,
+				hasAny: (async () => false) as never,
+				inspect: (async () => ({ reachable: true, extensions: new Set() })) as never,
+				invalidate: (() => {}) as never,
+			},
+		});
+		// The guard fires before the handler, so the only possible failure here
+		// is the capability guard's "not installed" — not a schema/handler error.
+		const result = await dispatch(cargoQuery, ctx)({ tables: 'Items' } as never);
+		expect(result.isError).toBe(true);
+		expect(JSON.stringify(result.content)).toContain('not installed');
 	});
 });

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -101,6 +101,7 @@ function makeFakeDetector(answers: Record<string, boolean> = {}): ExtensionDetec
 		hasAny: vi.fn(async (wikiKey: string, names: readonly string[]) =>
 			names.some((name) => answers[`${wikiKey}:${name}`] ?? false),
 		),
+		inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 		invalidate: vi.fn(),
 	};
 }
@@ -652,6 +653,7 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 		const detector: ExtensionDetector = {
 			has: vi.fn(async () => false),
 			hasAny: hasAnySpy,
+			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
 		const { registry, activeWiki } = makeMocks({
@@ -726,6 +728,7 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 		const detector: ExtensionDetector = {
 			has: vi.fn(async () => false),
 			hasAny: hasAnySpy,
+			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
 		const { registry, activeWiki } = makeMocks({
@@ -804,6 +807,7 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 		const detector: ExtensionDetector = {
 			has: vi.fn(async () => false),
 			hasAny: hasAnySpy,
+			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
 		const { registry, activeWiki } = makeMocks({

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -62,6 +62,21 @@ function makeToolMap(initiallyEnabled: boolean): {
 	return { tools, mocks };
 }
 
+function makeToolMapWithExtensions(initiallyEnabled: boolean): {
+	tools: Map<string, RegisteredTool>;
+	mocks: Map<string, MockTool>;
+} {
+	const { tools, mocks } = makeToolMap(initiallyEnabled);
+	for (const pack of ALL_PACKS) {
+		for (const t of pack.tools) {
+			const mock = makeMockTool(initiallyEnabled);
+			mocks.set(t.name, mock);
+			tools.set(t.name, mock as unknown as RegisteredTool);
+		}
+	}
+	return { tools, mocks };
+}
+
 const baseWiki: WikiConfig = {
 	sitename: 'Test',
 	server: 'https://test.wiki',
@@ -133,14 +148,13 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('disables every write tool when the active wiki is readOnly', async () => {
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -154,14 +168,13 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('does not touch non-write tools', async () => {
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -175,14 +188,13 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 	it('enables every write tool when the active wiki is not readOnly', async () => {
 		const { tools, mocks } = makeToolMap(false);
 		const wiki = { ...baseWiki, readOnly: false };
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -195,14 +207,13 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 
 	it('treats missing readOnly as non-readOnly', async () => {
 		const { tools, mocks } = makeToolMap(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -218,7 +229,6 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 		const m1 = makeMocks({ activeWikiConfig: wiki, wikis: { a: wiki }, allowManagement: true });
 		await reconcileTools(tools, {
 			wikiRegistry: m1.registry,
-			activeWiki: m1.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -230,7 +240,6 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 		const m2 = makeMocks({ activeWikiConfig: wiki, wikis: { a: wiki }, allowManagement: true });
 		await reconcileTools(tools, {
 			wikiRegistry: m2.registry,
-			activeWiki: m2.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -245,7 +254,7 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 		const { tools, mocks } = makeToolMap(true);
 		tools.delete('upload-file');
 		const wiki = { ...baseWiki, readOnly: true };
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
@@ -253,7 +262,6 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 		await expect(
 			reconcileTools(tools, {
 				wikiRegistry: registry,
-				activeWiki: activeWiki,
 				transport: 'stdio',
 				extensions: makeFakeDetector(),
 				extensionPacks: ALL_PACKS,
@@ -271,14 +279,13 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 describe('reconcileTools — applyWikiSetRule', () => {
 	it('disables add-wiki and remove-wiki when count is 1 and management is disallowed', async () => {
 		const { tools, mocks } = makeToolMap(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: false,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -290,14 +297,13 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('enables add-wiki only when count is 1 and management is allowed', async () => {
 		const { tools, mocks } = makeToolMap(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -308,14 +314,13 @@ describe('reconcileTools — applyWikiSetRule', () => {
 
 	it('enables add-wiki and remove-wiki when count is 2 and management is allowed', async () => {
 		const { tools, mocks } = makeToolMap(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki, b: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -334,7 +339,6 @@ describe('reconcileTools — applyWikiSetRule', () => {
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: m1.registry,
-			activeWiki: m1.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -348,7 +352,6 @@ describe('reconcileTools — applyWikiSetRule', () => {
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: m2.registry,
-			activeWiki: m2.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -365,7 +368,6 @@ describe('reconcileTools — applyWikiSetRule', () => {
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: m1.registry,
-			activeWiki: m1.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -379,7 +381,6 @@ describe('reconcileTools — applyWikiSetRule', () => {
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: m2.registry,
-			activeWiki: m2.activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -391,14 +392,13 @@ describe('reconcileTools — applyWikiSetRule', () => {
 describe('reconcileTools — applyTransportRule', () => {
 	it('hides oauth-* tools on HTTP transport', async () => {
 		const { tools, mocks } = makeToolMap(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'http',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -411,14 +411,13 @@ describe('reconcileTools — applyTransportRule', () => {
 
 	it('shows oauth-* tools on stdio transport', async () => {
 		const { tools, mocks } = makeToolMap(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -431,14 +430,13 @@ describe('reconcileTools — applyTransportRule', () => {
 
 	it('defaults to stdio when transport is omitted', async () => {
 		const { tools, mocks } = makeToolMap(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -450,14 +448,13 @@ describe('reconcileTools — applyTransportRule', () => {
 
 	it('does not touch non-oauth tools when applying transport rule', async () => {
 		const { tools, mocks } = makeToolMap(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'http',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -474,14 +471,13 @@ describe('reconcileTools — AND semantics across rules', () => {
 		// Force read-only=true (disables write tools) AND wikiCount=1 (disables remove-wiki).
 		const { tools, mocks } = makeToolMap(true);
 		const wiki = { ...baseWiki, readOnly: true };
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: wiki,
 			wikis: { a: wiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector(),
 			extensionPacks: ALL_PACKS,
@@ -496,8 +492,7 @@ describe('reconcileTools — AND semantics across rules', () => {
 
 	it('resolves multiple rule predicates concurrently, not serially', async () => {
 		const ctx: ReconcileContext = {
-			activeWikiKey: 'a',
-			activeWiki: baseWiki,
+			allWikis: { a: baseWiki },
 			wikiCount: 1,
 			allowManagement: true,
 			transport: 'stdio',
@@ -531,8 +526,7 @@ describe('reconcileTools — AND semantics across rules', () => {
 
 describe('computeDesiredEnabledState — AND semantics for a single tool affected by multiple rules', () => {
 	const baseCtx: ReconcileContext = {
-		activeWikiKey: 'a',
-		activeWiki: baseWiki,
+		allWikis: { a: baseWiki },
 		wikiCount: 1,
 		allowManagement: true,
 		transport: 'stdio',
@@ -612,14 +606,13 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 
 	it('disables both SMW tools when the detector resolves false', async () => {
 		const { tools, mocks } = makeToolMapWithSmw(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
 			extensionPacks: ALL_PACKS,
@@ -631,14 +624,13 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 
 	it('enables both SMW tools when the detector resolves true', async () => {
 		const { tools, mocks } = makeToolMapWithSmw(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:SemanticMediaWiki': true }),
 			extensionPacks: ALL_PACKS,
@@ -656,14 +648,13 @@ describe('reconcileTools — applySmwExtensionRule', () => {
 			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: detector,
 			extensionPacks: ALL_PACKS,
@@ -689,14 +680,13 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 
 	it('disables bucket-query when the detector resolves false', async () => {
 		const { tools, mocks } = makeToolMapWithBucket(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
 			extensionPacks: ALL_PACKS,
@@ -707,14 +697,13 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 
 	it('enables bucket-query when the detector resolves true', async () => {
 		const { tools, mocks } = makeToolMapWithBucket(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:Bucket': true }),
 			extensionPacks: ALL_PACKS,
@@ -731,14 +720,13 @@ describe('reconcileTools — applyBucketExtensionRule', () => {
 			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: detector,
 			extensionPacks: ALL_PACKS,
@@ -764,14 +752,13 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 
 	it('disables all Cargo tools when the detector resolves false', async () => {
 		const { tools, mocks } = makeToolMapWithCargo(true);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({}),
 			extensionPacks: ALL_PACKS,
@@ -784,14 +771,13 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 
 	it('enables all Cargo tools when the detector resolves true', async () => {
 		const { tools, mocks } = makeToolMapWithCargo(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:Cargo': true }),
 			extensionPacks: ALL_PACKS,
@@ -810,14 +796,13 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 			inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 			invalidate: vi.fn(),
 		};
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: detector,
 			extensionPacks: ALL_PACKS,
@@ -827,14 +812,13 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 
 	it('enables all Cargo tools on a wiki.gg-rebranded LIBRARIAN install', async () => {
 		const { tools, mocks } = makeToolMapWithCargo(false);
-		const { registry, activeWiki } = makeMocks({
+		const { registry } = makeMocks({
 			activeWikiConfig: baseWiki,
 			wikis: { a: baseWiki },
 			allowManagement: true,
 		});
 		await reconcileTools(tools, {
 			wikiRegistry: registry,
-			activeWiki: activeWiki,
 			transport: 'stdio',
 			extensions: makeFakeDetector({ 'a:LIBRARIAN': true }),
 			extensionPacks: ALL_PACKS,
@@ -842,5 +826,79 @@ describe('reconcileTools — applyCargoExtensionRule', () => {
 		expect(mocks.get('cargo-list-tables')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('cargo-describe-table')!.enable).toHaveBeenCalledTimes(1);
 		expect(mocks.get('cargo-query')!.enable).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('reconcileTools — union gating', () => {
+	it('enables a pack when only a non-default wiki has the extension', async () => {
+		const { tools, mocks } = makeToolMapWithExtensions(false);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { def: baseWiki, other: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector({ 'other:Cargo': true }),
+			extensionPacks: ALL_PACKS,
+		});
+		for (const name of ['cargo-query', 'cargo-list-tables', 'cargo-describe-table']) {
+			expect(mocks.get(name)!.enable).toHaveBeenCalled();
+		}
+	});
+
+	it('keeps a pack disabled when no wiki has the extension', async () => {
+		const { tools, mocks } = makeToolMapWithExtensions(false);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { def: baseWiki, other: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector({}),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('cargo-query')!.enable).not.toHaveBeenCalled();
+	});
+
+	it('keeps write tools enabled when only a non-default wiki is writable', async () => {
+		const { tools, mocks } = makeToolMap(true);
+		const roWiki = { ...baseWiki, readOnly: true };
+		const { registry } = makeMocks({
+			activeWikiConfig: roWiki,
+			wikis: { def: roWiki, other: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		for (const name of WRITE_TOOL_NAMES) {
+			expect(mocks.get(name)!.disable).not.toHaveBeenCalled();
+		}
+	});
+
+	it('disables write tools only when every wiki is read-only', async () => {
+		const { tools, mocks } = makeToolMap(true);
+		const roWiki = { ...baseWiki, readOnly: true };
+		const { registry } = makeMocks({
+			activeWikiConfig: roWiki,
+			wikis: { def: roWiki, other: roWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		for (const name of WRITE_TOOL_NAMES) {
+			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
+		}
 	});
 });

--- a/tests/runtime/wikiCapability.test.ts
+++ b/tests/runtime/wikiCapability.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { checkWikiCapability } from '../../src/runtime/wikiCapability.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+
+const rwWiki = {
+	sitename: 'X',
+	server: 'https://x',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+} as never;
+const roWiki = { ...rwWiki, readOnly: true } as never;
+
+function ctx(hasExt: boolean, wikiConfig: unknown) {
+	return fakeContext({
+		wikis: {
+			getAll: () => ({ w: wikiConfig }) as never,
+			get: (() => wikiConfig) as never,
+			add: (() => {}) as never,
+			remove: (() => {}) as never,
+			isManagementAllowed: () => true,
+		},
+		extensions: {
+			has: (async () => hasExt) as never,
+			hasAny: (async () => hasExt) as never,
+			invalidate: (() => {}) as never,
+			inspect: (async () => ({ reachable: true, extensions: new Set<string>() })) as never,
+		},
+	});
+}
+
+describe('checkWikiCapability', () => {
+	it('rejects an extension tool when the wiki lacks the extension', async () => {
+		const result = await checkWikiCapability('cargo-query', 'w', ctx(false, rwWiki));
+		expect(result?.isError).toBe(true);
+		expect(JSON.stringify(result?.content)).toContain('not installed');
+	});
+
+	it('allows an extension tool when the wiki has the extension', async () => {
+		expect(await checkWikiCapability('cargo-query', 'w', ctx(true, rwWiki))).toBeUndefined();
+	});
+
+	it('rejects a write tool against a read-only wiki', async () => {
+		const result = await checkWikiCapability('update-page', 'w', ctx(true, roWiki));
+		expect(result?.isError).toBe(true);
+		expect(JSON.stringify(result?.content)).toContain('read-only');
+	});
+
+	it('allows a write tool against a writable wiki', async () => {
+		expect(await checkWikiCapability('update-page', 'w', ctx(true, rwWiki))).toBeUndefined();
+	});
+
+	it('returns undefined for a plain read tool', async () => {
+		expect(await checkWikiCapability('get-page', 'w', ctx(false, rwWiki))).toBeUndefined();
+	});
+});

--- a/tests/runtime/wikiCapability.test.ts
+++ b/tests/runtime/wikiCapability.test.ts
@@ -10,7 +10,7 @@ const rwWiki = {
 } as never;
 const roWiki = { ...rwWiki, readOnly: true } as never;
 
-function ctx(hasExt: boolean, wikiConfig: unknown) {
+function ctx(hasExt: boolean, wikiConfig: unknown, reachable = true) {
 	return fakeContext({
 		wikis: {
 			getAll: () => ({ w: wikiConfig }) as never,
@@ -23,7 +23,7 @@ function ctx(hasExt: boolean, wikiConfig: unknown) {
 			has: (async () => hasExt) as never,
 			hasAny: (async () => hasExt) as never,
 			invalidate: (() => {}) as never,
-			inspect: (async () => ({ reachable: true, extensions: new Set<string>() })) as never,
+			inspect: (async () => ({ reachable, extensions: new Set<string>() })) as never,
 		},
 	});
 }
@@ -33,6 +33,14 @@ describe('checkWikiCapability', () => {
 		const result = await checkWikiCapability('cargo-query', 'w', ctx(false, rwWiki));
 		expect(result?.isError).toBe(true);
 		expect(JSON.stringify(result?.content)).toContain('not installed');
+	});
+
+	it('reports an unreachable wiki rather than claiming the extension is missing', async () => {
+		const result = await checkWikiCapability('cargo-query', 'w', ctx(false, rwWiki, false));
+		expect(result?.isError).toBe(true);
+		const text = JSON.stringify(result?.content);
+		expect(text).toContain('could not be reached');
+		expect(text).not.toContain('not installed');
 	});
 
 	it('allows an extension tool when the wiki has the extension', async () => {

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -73,7 +73,6 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 	const reconcile = () =>
 		reconcileTools(tools, {
 			wikiRegistry: wikiRegistryMock,
-			activeWiki: activeWikiMock,
 			transport: 'stdio',
 			extensions: fakeDetector,
 			extensionPacks,
@@ -198,7 +197,9 @@ describe('registerAllTools — per-wiki readOnly', () => {
 		}
 	});
 
-	it('omits write tools when the default wiki is readOnly', async () => {
+	it('keeps write tools listed when only a non-default wiki is writeable', async () => {
+		// Union gating: write tools stay offered while ANY configured wiki is
+		// writeable, even if the default wiki is read-only.
 		wikiStore.current = wikiB;
 		const { client } = await connectClientAndServer();
 
@@ -206,22 +207,47 @@ describe('registerAllTools — per-wiki readOnly', () => {
 		const names = tools.map((t) => t.name);
 
 		for (const w of WRITE_TOOLS) {
-			expect(names).not.toContain(w);
+			expect(names).toContain(w);
 		}
 		expect(names).toContain('get-page');
 	});
 
-	it('rejects a write tool call with a disabled error when the default wiki is readOnly', async () => {
+	it('omits write tools when every configured wiki is readOnly', async () => {
+		const originalByKey = wikiStore.byKey;
+		wikiStore.byKey = { b: wikiB };
 		wikiStore.current = wikiB;
-		const { client } = await connectClientAndServer();
+		try {
+			const { client } = await connectClientAndServer();
 
-		const result = await client.callTool({
-			name: 'create-page',
-			arguments: { title: 'Test', source: 'test' },
-		});
+			const { tools } = await client.listTools();
+			const names = tools.map((t) => t.name);
 
-		expect(result.isError).toBe(true);
-		const content = result.content as Array<{ type: string; text: string }>;
-		expect(content[0].text).toMatch(/Tool create-page disabled/);
+			for (const w of WRITE_TOOLS) {
+				expect(names).not.toContain(w);
+			}
+			expect(names).toContain('get-page');
+		} finally {
+			wikiStore.byKey = originalByKey;
+		}
+	});
+
+	it('rejects a write tool call with a disabled error when every configured wiki is readOnly', async () => {
+		const originalByKey = wikiStore.byKey;
+		wikiStore.byKey = { b: wikiB };
+		wikiStore.current = wikiB;
+		try {
+			const { client } = await connectClientAndServer();
+
+			const result = await client.callTool({
+				name: 'create-page',
+				arguments: { title: 'Test', source: 'test' },
+			});
+
+			expect(result.isError).toBe(true);
+			const content = result.content as Array<{ type: string; text: string }>;
+			expect(content[0].text).toMatch(/Tool create-page disabled/);
+		} finally {
+			wikiStore.byKey = originalByKey;
+		}
 	});
 });

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -67,6 +67,7 @@ async function connectClientAndServer(): Promise<{ client: Client; server: McpSe
 	const fakeDetector: ExtensionDetector = {
 		has: vi.fn(async () => false),
 		hasAny: vi.fn(async () => false),
+		inspect: vi.fn(async () => ({ reachable: true, extensions: new Set<string>() })),
 		invalidate: vi.fn(),
 	};
 	const reconcile = () =>

--- a/tests/tools/list-wikis.test.ts
+++ b/tests/tools/list-wikis.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { dispatch } from '../../src/runtime/dispatcher.js';
+import { listWikis } from '../../src/tools/list-wikis.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+
+const wikiConfig = {
+	sitename: 'Test',
+	server: 'https://test.wiki',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+} as never;
+
+function ctxWith(extByWiki: Record<string, Set<string>>, unreachable: Set<string> = new Set()) {
+	const wikis = { 'test-wiki': wikiConfig, 'cargo.wiki': wikiConfig };
+	return fakeContext({
+		wikis: {
+			getAll: () => wikis as never,
+			get: ((k: string) =>
+				Object.hasOwn(wikis, k) ? wikis[k as keyof typeof wikis] : undefined) as never,
+			add: (() => {}) as never,
+			remove: (() => {}) as never,
+			isManagementAllowed: () => true,
+		},
+		activeWiki: {
+			get: () => ({ key: 'test-wiki', config: wikiConfig }),
+			getDefaultKey: () => 'test-wiki',
+		},
+		extensions: {
+			has: (async () => false) as never,
+			hasAny: (async () => false) as never,
+			invalidate: (() => {}) as never,
+			inspect: (async (k: string) => ({
+				reachable: !unreachable.has(k),
+				extensions: extByWiki[k] ?? new Set<string>(),
+			})) as never,
+		},
+	});
+}
+
+function wikisOf(result: CallToolResult): Array<Record<string, unknown>> {
+	return (result.structuredContent as { wikis: Array<Record<string, unknown>> }).wikis;
+}
+
+describe('list-wikis', () => {
+	it('returns every configured wiki with key, isDefault, readOnly, reachable', async () => {
+		const ctx = ctxWith({});
+		const result = await dispatch(listWikis, ctx)({} as never);
+		const wikis = wikisOf(result);
+		expect(wikis.map((w) => w.key).sort((a, b) => String(a).localeCompare(String(b)))).toEqual([
+			'cargo.wiki',
+			'test-wiki',
+		]);
+		const def = wikis.find((w) => w.key === 'test-wiki')!;
+		expect(def.isDefault).toBe(true);
+		expect(wikis.find((w) => w.key === 'cargo.wiki')!.isDefault).toBe(false);
+		expect(def.reachable).toBe(true);
+		expect(def).toMatchObject({ sitename: 'Test', server: 'https://test.wiki' });
+	});
+
+	it('lists the extension tools of packs the wiki has', async () => {
+		const ctx = ctxWith({ 'cargo.wiki': new Set(['Cargo']) });
+		const result = await dispatch(listWikis, ctx)({} as never);
+		const cargo = wikisOf(result).find((w) => w.key === 'cargo.wiki')!;
+		expect(cargo.extensionTools).toContain('cargo-query');
+		const def = wikisOf(result).find((w) => w.key === 'test-wiki')!;
+		expect(def.extensionTools).toEqual([]);
+	});
+
+	it('reports reachable=false with no extension tools for an unreachable wiki', async () => {
+		const ctx = ctxWith({}, new Set(['cargo.wiki']));
+		const result = await dispatch(listWikis, ctx)({} as never);
+		const cargo = wikisOf(result).find((w) => w.key === 'cargo.wiki')!;
+		expect(cargo.reachable).toBe(false);
+		expect(cargo.extensionTools).toEqual([]);
+	});
+});

--- a/tests/wikis/extensionDetector.test.ts
+++ b/tests/wikis/extensionDetector.test.ts
@@ -218,4 +218,38 @@ describe('ExtensionDetectorImpl', () => {
 			expect(vi.mocked(makeApiRequest)).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	it('inspect returns reachable=true with the detected extension set', async () => {
+		vi.mocked(makeApiRequest).mockResolvedValueOnce({
+			query: { extensions: [{ name: 'Cargo' }, { name: 'OAuth' }] },
+		});
+		const clock = fakeClock();
+		const detector = new ExtensionDetectorImpl(makeRegistry({ a: baseWiki }), clock.now);
+
+		const result = await detector.inspect('a');
+		expect(result.reachable).toBe(true);
+		expect([...result.extensions].sort()).toEqual(['Cargo', 'OAuth']);
+	});
+
+	it('inspect returns reachable=false with an empty set when the probe fails', async () => {
+		vi.mocked(makeApiRequest).mockRejectedValueOnce(new Error('network down'));
+		const clock = fakeClock();
+		const detector = new ExtensionDetectorImpl(makeRegistry({ a: baseWiki }), clock.now);
+
+		const result = await detector.inspect('a');
+		expect(result.reachable).toBe(false);
+		expect(result.extensions.size).toBe(0);
+	});
+
+	it('inspect reuses the cache — no second HTTP request after has()', async () => {
+		vi.mocked(makeApiRequest).mockResolvedValueOnce({
+			query: { extensions: [{ name: 'Cargo' }] },
+		});
+		const clock = fakeClock();
+		const detector = new ExtensionDetectorImpl(makeRegistry({ a: baseWiki }), clock.now);
+
+		await detector.has('a', 'Cargo');
+		await detector.inspect('a');
+		expect(vi.mocked(makeApiRequest)).toHaveBeenCalledTimes(1);
+	});
 });

--- a/tests/wikis/extensionDetector.test.ts
+++ b/tests/wikis/extensionDetector.test.ts
@@ -149,7 +149,24 @@ describe('ExtensionDetectorImpl', () => {
 				siprop: 'extensions',
 				format: 'json',
 			}),
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
+	});
+
+	it('treats an aborted/timed-out probe as a probe failure', async () => {
+		// AbortSignal.timeout surfaces as a rejection (DOMException / Error
+		// named 'TimeoutError' or 'AbortError') — it must land in probe()'s
+		// catch and resolve as a `failed` entry, exactly like any other failure.
+		const abortError = new Error('The operation was aborted');
+		abortError.name = 'TimeoutError';
+		vi.mocked(makeApiRequest).mockRejectedValueOnce(abortError);
+		const clock = fakeClock();
+		const detector = new ExtensionDetectorImpl(makeRegistry({ a: baseWiki }), clock.now);
+
+		expect(await detector.has('a', 'SemanticMediaWiki')).toBe(false);
+		const result = await detector.inspect('a');
+		expect(result.reachable).toBe(false);
+		expect(result.extensions.size).toBe(0);
 	});
 
 	it('returns false when the wiki key is unknown', async () => {


### PR DESCRIPTION
## Problem

PR #365 replaced the stateful "current wiki" with a per-call `wiki` argument.
That removed the only thing that made `tools/list` reflect a specific wiki:
`reconcile()` used to re-run on every `set-wiki` switch, so the extension-gated
tools (`cargo-*`, `smw-*`, `bucket-query`) appeared or disappeared to match the
selected wiki.

Post-#365, `reconcile()` runs once at startup against `config.defaultWiki`
only:

- A multi-wiki install where a **non-default** wiki has an extension but the
  default does not has that pack's tools **hidden entirely and unreachable**,
  even though they would work fine against that other wiki.
- The `read-only` rule has the identical regression — write tools are gated on
  the default wiki's `readOnly` flag.
- The LLM has no model-reachable way to discover which wikis exist, their keys,
  or their capabilities — that information lives only in the
  `mcp://wikis/{wikiKey}` resources, which many MCP clients don't surface to
  the model.

## Fix

Per-wiki capability becomes **discoverable data**, the tool list reflects the
**union** of all configured wikis, and a **per-call guard** turns a wrong-wiki
call into a clear error.

- **`list-wikis` tool** — the discovery entry point. Reports every configured
  wiki's `key` (the value to pass as the `wiki` argument), `sitename`,
  `server`, `readOnly`, `isDefault`, `reachable`, and the extension tools that
  work on it.
- **Union gating** — `reconcile()` offers an extension pack's tools, and the
  write tools, if *any* configured wiki supports them — not just the default.
- **Per-call capability guard** — `dispatch()` rejects an extension tool
  targeted at a wiki without the extension (`invalid_input`) and a write tool
  targeted at a read-only wiki (`permission_denied`), with a clear message. An
  unreachable wiki is reported as unreachable, not as "extension missing".
- **Bounded extension probe** — union gating fans the extension probe out to
  every configured wiki; a 5s timeout keeps one unreachable wiki from hanging
  startup or every `list-wikis` call.

## Testing

- 1001 unit/integration tests pass; lint, format, typecheck, and build clean.
- New tests cover `inspect()`, `list-wikis`, union gating (enable/disable for
  both extension and write tools), the capability guard (extension-absent,
  unreachable, read-only, and matched calls), and the probe timeout.
- Live smoke test via the MCP Inspector CLI against a 6-wiki config:
  - `list-wikis` reported accurate per-wiki `extensionTools`, `isDefault`, and
    `reachable` — and returned promptly despite two unreachable wikis,
    confirming the probe timeout.
  - `tools/list` reflected the union: `smw-*`/`cargo-*` listed, `bucket-query`
    correctly absent (no configured wiki has Bucket).
  - The guard rejected an extension tool against a wiki without the extension
    and against an unreachable wiki, and allowed a valid combination
    (`cargo-list-tables` returned real Cargo tables).

## Builds on #365

This builds on #365 (per-call wiki targeting — `ActiveWiki`, the `wiki`
argument, the renamed `reconcile`), now merged. The branch has been rebased
onto `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
