### PR TITLE
Multi-wiki OAuth discovery on the HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it.
 - Optional `wiki` argument on every tool that operates on a wiki (all except the wiki-management and OAuth tools), naming the wiki that call acts on. Accepts a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI.
 - Tool responses now report the wiki the call ran against.
+- `MCP_SESSION_IDLE_TIMEOUT` env var (default `1800` seconds) closes HTTP sessions that have been idle for the configured window. Any request resets the timer; setting it to `0` disables expiry.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Tool calls target a wiki named per call, defaulting to the configured default wiki, instead of a server-side selection that had to be set first.
 - Extension-gated tools (`cargo-*`, `smw-*`, `bucket-query`) and the write tools are now offered whenever *any* configured wiki supports them, instead of only when the default wiki does. A call targeting a wiki that lacks the capability returns a clear error.
 - Wiki credentials backed by an `exec` command are now fetched the first time that wiki is used, instead of when the server starts. A slow or failing credential command no longer delays startup or prevents the server from starting — the error now appears only when that wiki is used.
+- The HTTP transport's OAuth discovery now covers every configured wiki: the `/.well-known/oauth-protected-resource` document advertises every OAuth wiki's authorization server, and a tokenless client is challenged only when no configured wiki is usable without a token — a deployment that mixes OAuth and non-OAuth wikis still serves tokenless clients.
+- An HTTP client may now send a different `Authorization: Bearer` token per request, so one session can work with wikis on different authorization servers. A call targeting an OAuth wiki with no usable token returns a clear authentication error.
 
 ## [0.9.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it.
+- `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server.
 - Optional `wiki` argument on every tool that operates on a wiki (all except the wiki-management and OAuth tools), naming the wiki that call acts on. Accepts a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI.
 - Tool responses now report the wiki the call ran against.
 - `MCP_SESSION_IDLE_TIMEOUT` env var (default `1800` seconds) closes HTTP sessions that have been idle for the configured window. Any request resets the timer; setting it to `0` disables expiry.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). |
 | `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and hide flags (up to 50 per call, paginated via `continue`). |
 | `get-revision` | Fetch a specific revision of a page. |
-| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, and which extension-gated tools work on it. |
+| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
 | `search-page` | Search wiki page titles and contents. |
 | `search-page-by-prefix` | Search page titles by prefix. |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `MCP_PUBLIC_URL` | Override the request-derived public URL used in OAuth protected-resource discovery. Useful for reverse-proxy setups that rewrite the `Host` header. | `unset` |
 | `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings like `512kb` or `1mb`. Oversize requests get a JSON-RPC 413. | `1mb` |
 | `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
+| `MCP_SESSION_IDLE_TIMEOUT` | Seconds an HTTP session may sit idle before it is closed and removed (StreamableHTTP transport). Any request resets the timer. `0` disables expiry. | `1800` |
 | `MCP_SHUTDOWN_GRACE_MS` | Maximum ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT`. See [docs/operations.md — Graceful shutdown](docs/operations.md#graceful-shutdown). | `10000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,7 +183,13 @@ If your wiki doesn't have an OAuth consumer set up, omit `oauth2ClientId`. Stati
 
 #### HTTP transport behaviour
 
-When you run the HTTP transport with at least one OAuth-enabled wiki, the server publishes `/.well-known/oauth-protected-resource` so OAuth-aware MCP clients (Claude Desktop, mcp-remote, Claude Code) can discover the wiki and run the consent flow themselves. Bearer-less requests get `401` with a `WWW-Authenticate` header pointing at the discovery document. Wikis without `oauth2ClientId` are unaffected.
+When you run the HTTP transport with at least one OAuth-enabled wiki, the server publishes `/.well-known/oauth-protected-resource` so OAuth-aware MCP clients (Claude Desktop, mcp-remote, Claude Code) can discover the wikis and run the consent flow themselves. The discovery document lists the authorization server of every OAuth-configured wiki, so a client can pick the one it needs. Wikis without `oauth2ClientId` are unaffected.
+
+A bearer-less request gets `401` with a `WWW-Authenticate` header pointing at the discovery document only when no configured wiki is usable without a token. A deployment that mixes OAuth and non-OAuth wikis still lets tokenless clients connect and use the wikis that don't require authentication.
+
+An HTTP client sends the `Authorization: Bearer` token appropriate to each call's target wiki. There is no per-session bearer pin: one session can carry tokens for wikis on different authorization servers, with a different token per request. The MCP session id is the session capability, so run the HTTP transport behind TLS. Idle sessions are closed after `MCP_SESSION_IDLE_TIMEOUT`, bounding how long a leaked session id stays usable.
+
+Use `list-wikis` to retrieve the wiki-to-authorization-server mapping — it reports each OAuth wiki's `authorizationServer`.
 
 If `MCP_ALLOW_STATIC_FALLBACK=true` and the wiki has static credentials, bearer-less requests fall back to those credentials instead of returning 401. Use this only if you specifically want a hybrid where OAuth-aware clients sign in per user but unauthenticated callers still get service through a shared identity.
 

--- a/server.json
+++ b/server.json
@@ -72,6 +72,12 @@
           "description": "Override the request-derived public URL used in the protected-resource discovery doc and WWW-Authenticate header. Set this when running behind a proxy that rewrites the request Host."
         },
         {
+          "name": "MCP_SESSION_IDLE_TIMEOUT",
+          "description": "Seconds an HTTP session may sit idle before it is closed and removed on the StreamableHTTP transport. Any request resets the timer. Set to 0 to disable expiry.",
+          "format": "number",
+          "default": "1800"
+        },
+        {
           "name": "MCP_SHUTDOWN_GRACE_MS",
           "description": "Maximum milliseconds to wait for in-flight /mcp calls to drain on SIGTERM/SIGINT before exiting. Capped at 600000.",
           "format": "number",
@@ -156,6 +162,12 @@
         {
           "name": "MCP_PUBLIC_URL",
           "description": "Override the request-derived public URL used in the protected-resource discovery doc and WWW-Authenticate header. Set this when running behind a proxy that rewrites the request Host."
+        },
+        {
+          "name": "MCP_SESSION_IDLE_TIMEOUT",
+          "description": "Seconds an HTTP session may sit idle before it is closed and removed on the StreamableHTTP transport. Any request resets the timer. Set to 0 to disable expiry.",
+          "format": "number",
+          "default": "1800"
         },
         {
           "name": "MCP_SHUTDOWN_GRACE_MS",

--- a/src/auth/protectedResource.ts
+++ b/src/auth/protectedResource.ts
@@ -6,8 +6,7 @@ const RESOURCE_DOCUMENTATION =
 
 export interface ProtectedResourceInput {
 	wikis: Record<string, { oauth2ClientId?: string | null }>;
-	defaultWiki: string;
-	metadata: AsMetadata;
+	metadatas: readonly AsMetadata[];
 	requestHost: string | undefined;
 	requestProto: 'http' | 'https' | undefined;
 }
@@ -51,21 +50,23 @@ export function resolvePublicBase(
 export function buildProtectedResource(
 	input: ProtectedResourceInput,
 ): ProtectedResourceDoc | undefined {
-	if (!anyWikiHasOAuth(input.wikis)) {
+	if (!anyWikiHasOAuth(input.wikis) || input.metadatas.length === 0) {
 		return undefined;
 	}
 
 	const resource = resolvePublicBase(input.requestHost, input.requestProto);
+	const issuers = [...new Set(input.metadatas.map((m) => m.issuer))];
+	const scopes = [...new Set(input.metadatas.flatMap((m) => m.scopes_supported ?? []))];
 
 	const doc: ProtectedResourceDoc = {
 		resource,
-		authorization_servers: [input.metadata.issuer],
+		authorization_servers: issuers,
 		bearer_methods_supported: ['header'],
 		resource_documentation: RESOURCE_DOCUMENTATION,
 	};
 
-	if (Array.isArray(input.metadata.scopes_supported)) {
-		doc.scopes_supported = input.metadata.scopes_supported;
+	if (scopes.length > 0) {
+		doc.scopes_supported = scopes;
 	}
 
 	return doc;

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -138,7 +138,8 @@ export function emitToolCall<TArgs>(opts: EmitToolCallOptions<TArgs>): void {
 		data.target = targetValue;
 	}
 	if (opts.sessionId !== undefined) {
-		data.session_id = opts.sessionId.replace(/-/g, '').slice(0, 12);
+		const hex = createHash('sha256').update(opts.sessionId).digest('hex');
+		data.session_id = `sha256:${hex.slice(0, 12)}`;
 	}
 	if (opts.upstreamStatus !== undefined) {
 		data.upstream_status = opts.upstreamStatus;

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -3,7 +3,7 @@ import type { ToolContext } from './context.js';
 import type { ExtensionPack } from '../tools/extensions/types.js';
 import { extensionPacks } from '../tools/extensions/index.js';
 import { getRuntimeToken } from '../transport/requestContext.js';
-import { isCredentialConfigured } from '../config/loadConfig.js';
+import { hasStaticCredentials } from '../transport/bearerGuard.js';
 
 // The wiki-mutating tools. Shared by reconcile's read-only rule and the
 // per-call capability guard.
@@ -47,14 +47,15 @@ export async function checkWikiCapability(
 	// HTTP transport: a call to an OAuth-only wiki with no usable token can only
 	// fail downstream with an opaque error. Reject it up front with discovery
 	// guidance. (On stdio the dispatcher's acquireToken gate drives OAuth, so
-	// this never fires there.)
+	// this never fires there.) On HTTP a wiki with static credentials only
+	// coexists with a running server when MCP_ALLOW_STATIC_FALLBACK is set —
+	// the startup bearer guard (evaluateBearerGuard) blocks startup otherwise —
+	// so this guard need not re-consult that env var.
 	if (ctx.transport === 'http') {
 		const cfg = ctx.wikis.get(wikiKey);
 		if (cfg) {
 			const oauthOnly = typeof cfg.oauth2ClientId === 'string' && cfg.oauth2ClientId.trim() !== '';
-			const hasStatic =
-				isCredentialConfigured(cfg.token) ||
-				(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
+			const hasStatic = hasStaticCredentials(cfg);
 			if (oauthOnly && !hasStatic && getRuntimeToken() === undefined) {
 				return ctx.format.error(
 					'authentication',

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -2,6 +2,8 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolContext } from './context.js';
 import type { ExtensionPack } from '../tools/extensions/types.js';
 import { extensionPacks } from '../tools/extensions/index.js';
+import { getRuntimeToken } from '../transport/requestContext.js';
+import { isCredentialConfigured } from '../config/loadConfig.js';
 
 // The wiki-mutating tools. Shared by reconcile's read-only rule and the
 // per-call capability guard.
@@ -42,6 +44,28 @@ export async function checkWikiCapability(
 	wikiKey: string,
 	ctx: ToolContext,
 ): Promise<CallToolResult | undefined> {
+	// HTTP transport: a call to an OAuth-only wiki with no usable token can only
+	// fail downstream with an opaque error. Reject it up front with discovery
+	// guidance. (On stdio the dispatcher's acquireToken gate drives OAuth, so
+	// this never fires there.)
+	if (ctx.transport === 'http') {
+		const cfg = ctx.wikis.get(wikiKey);
+		if (cfg) {
+			const oauthOnly = typeof cfg.oauth2ClientId === 'string' && cfg.oauth2ClientId.trim() !== '';
+			const hasStatic =
+				isCredentialConfigured(cfg.token) ||
+				(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
+			if (oauthOnly && !hasStatic && getRuntimeToken() === undefined) {
+				return ctx.format.error(
+					'authentication',
+					`Wiki "${wikiKey}" requires OAuth authentication. ` +
+						"Send an Authorization: Bearer token for this wiki; see the server's " +
+						'/.well-known/oauth-protected-resource document, or list-wikis for the ' +
+						"wiki's authorization server.",
+				);
+			}
+		}
+	}
 	const pack = PACK_BY_TOOL.get(toolName);
 	if (pack) {
 		const present = await ctx.extensions.hasAny(wikiKey, pack.extensionNames);

--- a/src/tools/list-wikis.ts
+++ b/src/tools/list-wikis.ts
@@ -2,6 +2,7 @@ import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext } from '../runtime/context.js';
 import { extensionPacks } from './extensions/index.js';
+import { fetchMetadata } from '../auth/metadata.js';
 
 interface WikiSummary {
 	key: string;
@@ -12,6 +13,8 @@ interface WikiSummary {
 	reachable: boolean;
 	// Tool names from every extension pack the wiki supports; order is not significant.
 	extensionTools: string[];
+	// AS issuer for an OAuth-configured wiki; absent otherwise.
+	authorizationServer?: string;
 }
 
 export const listWikis: Tool<Record<string, never>> = {
@@ -44,6 +47,18 @@ export const listWikis: Tool<Record<string, never>> = {
 						}
 					}
 				}
+				let authorizationServer: string | undefined;
+				if (typeof config.oauth2ClientId === 'string' && config.oauth2ClientId.trim() !== '') {
+					try {
+						const md = await fetchMetadata(key, {
+							server: config.server,
+							scriptpath: config.scriptpath,
+						});
+						authorizationServer = md.issuer;
+					} catch {
+						// Metadata unavailable — leave authorizationServer absent.
+					}
+				}
 				return {
 					key,
 					sitename: config.sitename,
@@ -52,6 +67,7 @@ export const listWikis: Tool<Record<string, never>> = {
 					isDefault: key === defaultKey,
 					reachable,
 					extensionTools,
+					...(authorizationServer !== undefined ? { authorizationServer } : {}),
 				};
 			}),
 		);

--- a/src/transport/httpConfig.ts
+++ b/src/transport/httpConfig.ts
@@ -4,6 +4,7 @@ export interface HttpConfig {
 	allowedHosts: string[] | undefined;
 	allowedOrigins: string[] | undefined;
 	maxRequestBody: string;
+	sessionIdleTimeoutMs: number;
 	warnings: string[];
 }
 
@@ -13,6 +14,7 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 3000;
 const MAX_PORT = 65535;
 const DEFAULT_MAX_REQUEST_BODY = '1mb';
+const DEFAULT_SESSION_IDLE_TIMEOUT_S = 1800;
 
 // Mirrors body-parser's size grammar: optional decimal number followed by an
 // optional unit (bytes if omitted). Validating at startup prevents body-parser
@@ -38,6 +40,19 @@ function resolvePort(): number {
 		return DEFAULT_PORT;
 	}
 	return parsed;
+}
+
+function resolveSessionIdleTimeoutMs(): number {
+	const raw = process.env.MCP_SESSION_IDLE_TIMEOUT;
+	if (raw === undefined || raw.trim() === '') {
+		return DEFAULT_SESSION_IDLE_TIMEOUT_S * 1000;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	// 0 disables expiry; negative or non-numeric → default.
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return DEFAULT_SESSION_IDLE_TIMEOUT_S * 1000;
+	}
+	return parsed * 1000;
 }
 
 function resolveAllowedHosts(): string[] | undefined {
@@ -113,6 +128,7 @@ export function resolveHttpConfig(): HttpConfig {
 		allowedHosts: resolveAllowedHosts(),
 		allowedOrigins: resolveAllowedOrigins(host, port),
 		maxRequestBody: body.value,
+		sessionIdleTimeoutMs: resolveSessionIdleTimeoutMs(),
 		warnings,
 	};
 }

--- a/src/transport/httpConfig.ts
+++ b/src/transport/httpConfig.ts
@@ -15,6 +15,10 @@ const DEFAULT_PORT = 3000;
 const MAX_PORT = 65535;
 const DEFAULT_MAX_REQUEST_BODY = '1mb';
 const DEFAULT_SESSION_IDLE_TIMEOUT_S = 1800;
+// setTimeout clamps delays above its 32-bit signed ceiling to 1ms, which would
+// expire every session almost immediately. Cap the resolved value at that
+// ceiling so a large MCP_SESSION_IDLE_TIMEOUT stays a long-but-valid delay.
+const MAX_SESSION_IDLE_TIMEOUT_MS = 2147483647;
 
 // Mirrors body-parser's size grammar: optional decimal number followed by an
 // optional unit (bytes if omitted). Validating at startup prevents body-parser
@@ -47,12 +51,18 @@ function resolveSessionIdleTimeoutMs(): number {
 	if (raw === undefined || raw.trim() === '') {
 		return DEFAULT_SESSION_IDLE_TIMEOUT_S * 1000;
 	}
-	const parsed = Number.parseInt(raw, 10);
-	// 0 disables expiry; negative or non-numeric → default.
-	if (!Number.isFinite(parsed) || parsed < 0) {
+	// Strict parse: require a plain run of digits so trailing garbage ('300abc')
+	// and scientific notation ('1e9') — both of which Number.parseInt silently
+	// truncates to a wrong value — fall back to the default instead. 0 disables
+	// expiry. Number.isInteger guards the (practically unreachable) overflow case.
+	const trimmed = raw.trim();
+	const seconds = Number(trimmed);
+	if (!/^\d+$/.test(trimmed) || !Number.isInteger(seconds)) {
 		return DEFAULT_SESSION_IDLE_TIMEOUT_S * 1000;
 	}
-	return parsed * 1000;
+	// Clamp to setTimeout's ceiling so an over-large value stays a valid delay
+	// instead of being clamped to 1ms by Node.
+	return Math.min(seconds * 1000, MAX_SESSION_IDLE_TIMEOUT_MS);
 }
 
 function resolveAllowedHosts(): string[] | undefined {

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -30,7 +30,7 @@ import { isCredentialConfigured, loadConfigFromFile } from '../config/loadConfig
 import type { MwnProvider } from '../wikis/mwnProvider.js';
 import type { ActiveWiki } from '../wikis/activeWiki.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
-import { fetchMetadata } from '../auth/metadata.js';
+import { fetchMetadata, type AsMetadata } from '../auth/metadata.js';
 import { buildProtectedResource, resolvePublicBase } from '../auth/protectedResource.js';
 import { createAppState } from '../wikis/state.js';
 import { createServer } from '../server.js';
@@ -130,32 +130,33 @@ function sendSessionBearerMismatch(res: Response): void {
 
 export function createOAuthProtectedResourceHandler(deps: {
 	wikiRegistry: WikiRegistry;
-	activeWiki: ActiveWiki;
 }): RequestHandler {
 	return async (req, res, next) => {
 		try {
 			const wikis = deps.wikiRegistry.getAll();
-			const oauthEnabled = Object.values(wikis).some(
-				(w) => typeof w.oauth2ClientId === 'string' && w.oauth2ClientId.trim() !== '',
+			const oauthWikis = Object.entries(wikis).filter(
+				([, w]) => typeof w.oauth2ClientId === 'string' && w.oauth2ClientId.trim() !== '',
 			);
-			if (!oauthEnabled) {
+			if (oauthWikis.length === 0) {
 				res.status(404).end();
 				return;
 			}
-			const defaultKey = deps.activeWiki.getDefaultKey();
-			const defaultCfg = wikis[defaultKey];
-			if (!defaultCfg) {
-				res.status(404).end();
-				return;
-			}
-			let metadata;
-			try {
-				metadata = await fetchMetadata(defaultKey, {
-					server: defaultCfg.server,
-					scriptpath: defaultCfg.scriptpath,
+			const settled = await Promise.allSettled(
+				oauthWikis.map(([key, cfg]) =>
+					fetchMetadata(key, { server: cfg.server, scriptpath: cfg.scriptpath }),
+				),
+			);
+			const metadatas = settled
+				.filter((r): r is PromiseFulfilledResult<AsMetadata> => r.status === 'fulfilled')
+				.map((r) => r.value);
+			if (metadatas.length === 0) {
+				const reasons = settled
+					.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+					.map((r) => String(r.reason));
+				logger.warning('OAuth protected-resource discovery failed for all wikis', {
+					reasons,
 				});
-			} catch (err) {
-				res.status(503).json({ error: 'discovery_failed', detail: String(err) });
+				res.status(503).json({ error: 'discovery_failed' });
 				return;
 			}
 			const protoHeader = req.headers['x-forwarded-proto'];
@@ -164,8 +165,7 @@ export function createOAuthProtectedResourceHandler(deps: {
 				proto === 'https' || proto === 'http' ? proto : req.secure ? 'https' : 'http';
 			const doc = buildProtectedResource({
 				wikis,
-				defaultWiki: defaultKey,
-				metadata,
+				metadatas,
 				requestHost: req.headers.host ?? undefined,
 				requestProto,
 			});
@@ -498,7 +498,6 @@ app.get(
 	'/.well-known/oauth-protected-resource',
 	createOAuthProtectedResourceHandler({
 		wikiRegistry: state.wikiRegistry,
-		activeWiki: state.activeWiki,
 	}),
 );
 

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import express, {
 	type ErrorRequestHandler,
 	type RequestHandler,
@@ -55,27 +55,6 @@ export function extractBearerToken(req: Request): string | undefined {
 	return token || undefined;
 }
 
-// Separate from any token value so "no bearer" and "empty string" cannot collide.
-const NO_BEARER_SENTINEL = ' no-bearer';
-
-export function hashBearer(token: string | undefined): string {
-	const input = token === undefined ? NO_BEARER_SENTINEL : `t:${token}`;
-	return createHash('sha256').update(input).digest('hex');
-}
-
-export function verifySessionBearer(storedHash: string, token: string | undefined): boolean {
-	// Buffer.from(..., 'hex') silently drops non-hex characters and
-	// truncates on odd length, so malformed input yields a short or
-	// empty buffer rather than throwing — the length check below
-	// rejects it before timingSafeEqual runs.
-	const a = Buffer.from(storedHash, 'hex');
-	const b = Buffer.from(hashBearer(token), 'hex');
-	if (a.length === 0 || a.length !== b.length) {
-		return false;
-	}
-	return timingSafeEqual(a, b);
-}
-
 export function resolveMcpHostValidation(
 	host: string,
 	allowedHosts: string[] | undefined,
@@ -96,10 +75,7 @@ export function resolveMcpHostValidation(
 	return undefined;
 }
 
-export type SessionEntry = {
-	readonly transport: StreamableHTTPServerTransport;
-	readonly bearerHash: string;
-};
+export type SessionEntry = { readonly transport: StreamableHTTPServerTransport };
 
 export type SessionRegistry = { [sessionId: string]: SessionEntry };
 
@@ -118,18 +94,6 @@ export function createInFlightCounter(): InFlightCounter {
 		next();
 	};
 	return { middleware, count: () => n };
-}
-
-function sendSessionBearerMismatch(res: Response): void {
-	res.status(401).json({
-		jsonrpc: '2.0',
-		error: {
-			code: -32001,
-			message:
-				'Unauthorized: session bearer does not match the token that initialized this session',
-		},
-		id: null,
-	});
 }
 
 export function createOAuthProtectedResourceHandler(deps: {
@@ -242,14 +206,8 @@ export function createMcpPostHandler(
 		let transport: StreamableHTTPServerTransport;
 
 		if (sessionId && sessions[sessionId]) {
-			const entry = sessions[sessionId];
-			if (!verifySessionBearer(entry.bearerHash, bearer)) {
-				sendSessionBearerMismatch(res);
-				return;
-			}
-			transport = entry.transport;
+			transport = sessions[sessionId].transport;
 		} else if (!sessionId && isInitializeRequest(req.body)) {
-			const initialBearerHash = hashBearer(bearer);
 			transport = new StreamableHTTPServerTransport({
 				sessionIdGenerator: () => randomUUID(),
 				// The SDK transport's Origin check is gated behind this flag.
@@ -259,7 +217,7 @@ export function createMcpPostHandler(
 				enableDnsRebindingProtection: allowedOrigins !== undefined,
 				allowedOrigins,
 				onsessioninitialized: (newSessionId) => {
-					sessions[newSessionId] = { transport, bearerHash: initialBearerHash };
+					sessions[newSessionId] = { transport };
 				},
 			});
 
@@ -299,11 +257,15 @@ export function createSessionRequestHandler(sessions: SessionRegistry): RequestH
 		}
 
 		const entry = sessions[sessionId];
+		// The session id (a 122-bit randomUUID) is itself the session capability:
+		// possession of a valid one authorizes GET/DELETE, with no bearer check.
+		// That is safe because every POST self-authenticates with its own per-
+		// request bearer (results return on that POST's own HTTP response), and
+		// the standalone GET SSE stream carries only global, non-client-specific
+		// notifications — so a session id alone grants nothing sensitive.
+		// The bearer is still extracted to thread into withRequestContext for
+		// consistency with the POST path.
 		const bearer = extractBearerToken(req);
-		if (!verifySessionBearer(entry.bearerHash, bearer)) {
-			sendSessionBearerMismatch(res);
-			return;
-		}
 		await withRequestContext(bearer, sessionId, () => entry.transport.handleRequest(req, res));
 	};
 }

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -74,6 +74,7 @@ export function resolveMcpHostValidation(
 export type SessionEntry = {
 	readonly transport: StreamableHTTPServerTransport;
 	idleTimer?: ReturnType<typeof setTimeout>;
+	activeRequests: number;
 };
 
 export type SessionRegistry = { [sessionId: string]: SessionEntry };
@@ -95,10 +96,27 @@ export function createInFlightCounter(): InFlightCounter {
 	return { middleware, count: () => n };
 }
 
-// Resets a session's idle timer. When the timeout elapses with no activity the
-// transport is closed; its onclose handler removes the registry entry. A
-// timeout of 0 disables expiry.
-export function touchSession(
+// Marks a session as having an in-flight request or open response stream:
+// increments the active-request count and cancels any pending idle expiry.
+// Pair every call with markSessionIdle on the response's 'close' event.
+export function markSessionActive(sessions: SessionRegistry, sessionId: string): void {
+	const entry = sessions[sessionId];
+	if (!entry) {
+		return;
+	}
+	entry.activeRequests += 1;
+	if (entry.idleTimer) {
+		clearTimeout(entry.idleTimer);
+		entry.idleTimer = undefined;
+	}
+}
+
+// Marks one request/stream finished. When the session has no remaining
+// in-flight requests, arms the idle-expiry timer; when it elapses the transport
+// is closed and its onclose handler removes the registry entry. A timeout of 0
+// disables expiry. Because this runs on response 'close', a long-lived GET SSE
+// stream keeps the session active for as long as the client holds it open.
+export function markSessionIdle(
 	sessions: SessionRegistry,
 	sessionId: string,
 	idleTimeoutMs: number,
@@ -107,11 +125,12 @@ export function touchSession(
 	if (!entry) {
 		return;
 	}
+	entry.activeRequests = Math.max(0, entry.activeRequests - 1);
+	if (entry.activeRequests > 0 || idleTimeoutMs <= 0) {
+		return;
+	}
 	if (entry.idleTimer) {
 		clearTimeout(entry.idleTimer);
-	}
-	if (idleTimeoutMs <= 0) {
-		return;
 	}
 	entry.idleTimer = setTimeout(() => {
 		void sessions[sessionId]?.transport.close();
@@ -229,7 +248,9 @@ export function createMcpPostHandler(
 
 		if (sessionId && sessions[sessionId]) {
 			transport = sessions[sessionId].transport;
-			touchSession(sessions, sessionId, idleTimeoutMs);
+			// Existing session: the registry entry already exists, so count this
+			// request now and release it when the response closes.
+			markSessionActive(sessions, sessionId);
 		} else if (!sessionId && isInitializeRequest(req.body)) {
 			transport = new StreamableHTTPServerTransport({
 				sessionIdGenerator: () => randomUUID(),
@@ -239,9 +260,13 @@ export function createMcpPostHandler(
 				// _allowedHosts is undefined, regardless of the flag).
 				enableDnsRebindingProtection: allowedOrigins !== undefined,
 				allowedOrigins,
+				// onsessioninitialized fires during handleRequest below — the only
+				// point where the registry entry and transport.sessionId both
+				// exist. Seed activeRequests to 1 so the init POST counts as
+				// in-flight; the res.on('close') handler registered after
+				// handleRequest releases it.
 				onsessioninitialized: (newSessionId) => {
-					sessions[newSessionId] = { transport };
-					touchSession(sessions, newSessionId, idleTimeoutMs);
+					sessions[newSessionId] = { transport, activeRequests: 1 };
 				},
 			});
 
@@ -269,6 +294,17 @@ export function createMcpPostHandler(
 			return;
 		}
 
+		// Release the in-flight count when this response closes. transport.sessionId
+		// is populated by now for both branches (set synchronously during
+		// handleRequest for a new session). Registered before handleRequest so the
+		// 'close' listener is in place even if the response finishes synchronously.
+		res.on('close', () => {
+			const sid = transport.sessionId;
+			if (sid) {
+				markSessionIdle(sessions, sid, idleTimeoutMs);
+			}
+		});
+
 		await withRequestContext(bearer, transport.sessionId, () =>
 			transport.handleRequest(req, res, req.body),
 		);
@@ -286,7 +322,10 @@ export function createSessionRequestHandler(
 			res.status(400).send('Invalid or missing session ID');
 			return;
 		}
-		touchSession(sessions, sessionId, idleTimeoutMs);
+		// A held-open GET SSE stream stays counted as active until it closes, so
+		// markSessionIdle (and the idle timer) won't run while a client holds it.
+		markSessionActive(sessions, sessionId);
+		res.on('close', () => markSessionIdle(sessions, sessionId, idleTimeoutMs));
 
 		const entry = sessions[sessionId];
 		// The session id (a 122-bit randomUUID) is itself the session capability:

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -26,7 +26,11 @@ import {
 import { withRequestContext } from './requestContext.js';
 
 export { withRequestContext } from './requestContext.js';
-import { isCredentialConfigured, loadConfigFromFile } from '../config/loadConfig.js';
+import {
+	isCredentialConfigured,
+	loadConfigFromFile,
+	type WikiConfig,
+} from '../config/loadConfig.js';
 import type { MwnProvider } from '../wikis/mwnProvider.js';
 import type { ActiveWiki } from '../wikis/activeWiki.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
@@ -180,9 +184,21 @@ export function createOAuthProtectedResourceHandler(deps: {
 	};
 }
 
+// A wiki needs auth when it is OAuth-only with no usable static fallback.
+function wikiNeedsAuth(cfg: WikiConfig, fallbackAllowed: boolean): boolean {
+	const oauthOnly = typeof cfg.oauth2ClientId === 'string' && cfg.oauth2ClientId.trim() !== '';
+	if (!oauthOnly) {
+		return false;
+	}
+	const hasStatic =
+		isCredentialConfigured(cfg.token) ||
+		(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
+	return !(hasStatic && fallbackAllowed);
+}
+
 export interface McpPostHandlerOptions {
 	allowedOrigins?: string[];
-	activeWiki?: ActiveWiki;
+	wikiRegistry?: WikiRegistry;
 }
 
 export function createMcpPostHandler(
@@ -190,20 +206,17 @@ export function createMcpPostHandler(
 	createServerFn: () => ReturnType<typeof createServer>,
 	options: McpPostHandlerOptions = {},
 ): RequestHandler {
-	const { allowedOrigins, activeWiki } = options;
+	const { allowedOrigins, wikiRegistry } = options;
 	return async (req, res) => {
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Express headers are string|string[]|undefined; MCP transport sends a single header
 		const sessionId = req.headers['mcp-session-id'] as string | undefined;
 		const bearer = extractBearerToken(req);
 
-		if (!bearer && activeWiki) {
-			const cfg = activeWiki.get().config;
-			const oauthOnly = typeof cfg.oauth2ClientId === 'string' && cfg.oauth2ClientId.trim() !== '';
-			const hasStatic =
-				isCredentialConfigured(cfg.token) ||
-				(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
+		if (!bearer && wikiRegistry) {
+			const all = Object.values(wikiRegistry.getAll());
 			const fallbackAllowed = process.env.MCP_ALLOW_STATIC_FALLBACK === 'true';
-			if (oauthOnly && !(hasStatic && fallbackAllowed)) {
+			const allNeedAuth = all.length > 0 && all.every((cfg) => wikiNeedsAuth(cfg, fallbackAllowed));
+			if (allNeedAuth) {
 				const protoHeader = req.headers['x-forwarded-proto'];
 				const proto =
 					typeof protoHeader === 'string' ? protoHeader.split(',')[0]?.trim() : undefined;
@@ -484,7 +497,7 @@ app.post(
 	'/mcp',
 	createMcpPostHandler(sessions, () => createServer(ctx), {
 		allowedOrigins,
-		activeWiki: state.activeWiki,
+		wikiRegistry: state.wikiRegistry,
 	}),
 );
 app.get('/mcp', sessionRequestHandler);

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -75,7 +75,10 @@ export function resolveMcpHostValidation(
 	return undefined;
 }
 
-export type SessionEntry = { readonly transport: StreamableHTTPServerTransport };
+export type SessionEntry = {
+	readonly transport: StreamableHTTPServerTransport;
+	idleTimer?: ReturnType<typeof setTimeout>;
+};
 
 export type SessionRegistry = { [sessionId: string]: SessionEntry };
 
@@ -94,6 +97,30 @@ export function createInFlightCounter(): InFlightCounter {
 		next();
 	};
 	return { middleware, count: () => n };
+}
+
+// Resets a session's idle timer. When the timeout elapses with no activity the
+// transport is closed; its onclose handler removes the registry entry. A
+// timeout of 0 disables expiry.
+export function touchSession(
+	sessions: SessionRegistry,
+	sessionId: string,
+	idleTimeoutMs: number,
+): void {
+	const entry = sessions[sessionId];
+	if (!entry) {
+		return;
+	}
+	if (entry.idleTimer) {
+		clearTimeout(entry.idleTimer);
+	}
+	if (idleTimeoutMs <= 0) {
+		return;
+	}
+	entry.idleTimer = setTimeout(() => {
+		void sessions[sessionId]?.transport.close();
+	}, idleTimeoutMs);
+	entry.idleTimer.unref();
 }
 
 export function createOAuthProtectedResourceHandler(deps: {
@@ -163,6 +190,7 @@ function wikiNeedsAuth(cfg: WikiConfig, fallbackAllowed: boolean): boolean {
 export interface McpPostHandlerOptions {
 	allowedOrigins?: string[];
 	wikiRegistry?: WikiRegistry;
+	idleTimeoutMs?: number;
 }
 
 export function createMcpPostHandler(
@@ -170,7 +198,7 @@ export function createMcpPostHandler(
 	createServerFn: () => ReturnType<typeof createServer>,
 	options: McpPostHandlerOptions = {},
 ): RequestHandler {
-	const { allowedOrigins, wikiRegistry } = options;
+	const { allowedOrigins, wikiRegistry, idleTimeoutMs = 0 } = options;
 	return async (req, res) => {
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Express headers are string|string[]|undefined; MCP transport sends a single header
 		const sessionId = req.headers['mcp-session-id'] as string | undefined;
@@ -207,6 +235,7 @@ export function createMcpPostHandler(
 
 		if (sessionId && sessions[sessionId]) {
 			transport = sessions[sessionId].transport;
+			touchSession(sessions, sessionId, idleTimeoutMs);
 		} else if (!sessionId && isInitializeRequest(req.body)) {
 			transport = new StreamableHTTPServerTransport({
 				sessionIdGenerator: () => randomUUID(),
@@ -218,11 +247,16 @@ export function createMcpPostHandler(
 				allowedOrigins,
 				onsessioninitialized: (newSessionId) => {
 					sessions[newSessionId] = { transport };
+					touchSession(sessions, newSessionId, idleTimeoutMs);
 				},
 			});
 
 			transport.onclose = () => {
 				if (transport.sessionId) {
+					const entry = sessions[transport.sessionId];
+					if (entry?.idleTimer) {
+						clearTimeout(entry.idleTimer);
+					}
 					delete sessions[transport.sessionId];
 				}
 			};
@@ -247,7 +281,10 @@ export function createMcpPostHandler(
 	};
 }
 
-export function createSessionRequestHandler(sessions: SessionRegistry): RequestHandler {
+export function createSessionRequestHandler(
+	sessions: SessionRegistry,
+	idleTimeoutMs = 0,
+): RequestHandler {
 	return async (req, res) => {
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Express headers are string|string[]|undefined; MCP transport sends a single header
 		const sessionId = req.headers['mcp-session-id'] as string | undefined;
@@ -255,6 +292,7 @@ export function createSessionRequestHandler(sessions: SessionRegistry): RequestH
 			res.status(400).send('Invalid or missing session ID');
 			return;
 		}
+		touchSession(sessions, sessionId, idleTimeoutMs);
 
 		const entry = sessions[sessionId];
 		// The session id (a 122-bit randomUUID) is itself the session capability:
@@ -396,7 +434,8 @@ export function mountReadyEndpoint(
 // independent — placed after for visual grouping with the HTTP setup.
 const config = loadConfigFromFile();
 const state = createAppState(config);
-const { host, port, allowedHosts, allowedOrigins, maxRequestBody, warnings } = resolveHttpConfig();
+const { host, port, allowedHosts, allowedOrigins, maxRequestBody, sessionIdleTimeoutMs, warnings } =
+	resolveHttpConfig();
 const guard = evaluateBearerGuard(state.wikiRegistry.getAll(), process.env);
 if (guard.kind === 'block') {
 	logger.error(
@@ -449,7 +488,7 @@ if ((host === '0.0.0.0' || host === '::') && !allowedOrigins) {
 }
 
 const sessions: SessionRegistry = {};
-const sessionRequestHandler = createSessionRequestHandler(sessions);
+const sessionRequestHandler = createSessionRequestHandler(sessions, sessionIdleTimeoutMs);
 const ctx = createToolContext({ logger, state, transport: 'http' });
 
 const inFlight = createInFlightCounter();
@@ -460,6 +499,7 @@ app.post(
 	createMcpPostHandler(sessions, () => createServer(ctx), {
 		allowedOrigins,
 		wikiRegistry: state.wikiRegistry,
+		idleTimeoutMs: sessionIdleTimeoutMs,
 	}),
 );
 app.get('/mcp', sessionRequestHandler);

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -13,7 +13,7 @@ import {
 } from '@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { evaluateBearerGuard } from './bearerGuard.js';
+import { evaluateBearerGuard, hasStaticCredentials } from './bearerGuard.js';
 import { LOCALHOST_HOSTS, resolveHttpConfig } from './httpConfig.js';
 import { logger } from '../runtime/logger.js';
 import {
@@ -26,11 +26,7 @@ import {
 import { withRequestContext } from './requestContext.js';
 
 export { withRequestContext } from './requestContext.js';
-import {
-	isCredentialConfigured,
-	loadConfigFromFile,
-	type WikiConfig,
-} from '../config/loadConfig.js';
+import { loadConfigFromFile, type WikiConfig } from '../config/loadConfig.js';
 import type { MwnProvider } from '../wikis/mwnProvider.js';
 import type { ActiveWiki } from '../wikis/activeWiki.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
@@ -181,9 +177,7 @@ function wikiNeedsAuth(cfg: WikiConfig, fallbackAllowed: boolean): boolean {
 	if (!oauthOnly) {
 		return false;
 	}
-	const hasStatic =
-		isCredentialConfigured(cfg.token) ||
-		(isCredentialConfigured(cfg.username) && isCredentialConfigured(cfg.password));
+	const hasStatic = hasStaticCredentials(cfg);
 	return !(hasStatic && fallbackAllowed);
 }
 

--- a/tests/auth/protectedResource.test.ts
+++ b/tests/auth/protectedResource.test.ts
@@ -22,8 +22,7 @@ const metadataWithScopes: AsMetadata = {
 function makeInput(overrides: Partial<ProtectedResourceInput> = {}): ProtectedResourceInput {
 	return {
 		wikis: { mywiki: { oauth2ClientId: 'client-abc' } },
-		defaultWiki: 'mywiki',
-		metadata: baseMetadata,
+		metadatas: [baseMetadata],
 		requestHost: 'mcp.example.org',
 		requestProto: 'https',
 		...overrides,
@@ -118,7 +117,7 @@ describe('buildProtectedResource', () => {
 	});
 
 	it('includes scopes_supported when AS metadata declares it', () => {
-		const result = buildProtectedResource(makeInput({ metadata: metadataWithScopes }));
+		const result = buildProtectedResource(makeInput({ metadatas: [metadataWithScopes] }));
 		expect(result?.scopes_supported).toEqual(['basic', 'editpage']);
 	});
 
@@ -139,5 +138,51 @@ describe('buildProtectedResource', () => {
 			}),
 		);
 		expect(result).toBeDefined();
+	});
+
+	it('lists every distinct issuer across multiple authorization servers', () => {
+		const doc = buildProtectedResource({
+			wikis: { a: { oauth2ClientId: 'ca' }, b: { oauth2ClientId: 'cb' } },
+			metadatas: [
+				{
+					issuer: 'https://a.example',
+					authorization_endpoint: 'x',
+					token_endpoint: 'y',
+					source: 'well-known',
+					synthesized: false,
+					scopes_supported: ['read'],
+				},
+				{
+					issuer: 'https://b.example',
+					authorization_endpoint: 'x',
+					token_endpoint: 'y',
+					source: 'well-known',
+					synthesized: false,
+					scopes_supported: ['write'],
+				},
+				{
+					issuer: 'https://a.example',
+					authorization_endpoint: 'x',
+					token_endpoint: 'y',
+					source: 'well-known',
+					synthesized: false,
+				},
+			],
+			requestHost: 'mcp.example',
+			requestProto: 'https',
+		});
+		expect(doc?.authorization_servers).toEqual(['https://a.example', 'https://b.example']);
+		expect(doc?.scopes_supported?.sort()).toEqual(['read', 'write']);
+	});
+
+	it('returns undefined when no metadata resolved', () => {
+		expect(
+			buildProtectedResource({
+				wikis: { a: { oauth2ClientId: 'ca' } },
+				metadatas: [],
+				requestHost: 'mcp.example',
+				requestProto: 'https',
+			}),
+		).toBeUndefined();
 	});
 });

--- a/tests/runtime/dispatch.oauth.test.ts
+++ b/tests/runtime/dispatch.oauth.test.ts
@@ -140,7 +140,7 @@ describe('dispatch OAuth integration', () => {
 		expect(vi.mocked(openMod)).not.toHaveBeenCalled();
 	});
 
-	it('http + oauth2ClientId: does not call acquireToken / open', async () => {
+	it('http + oauth2ClientId with no token: capability guard rejects, no acquireToken / open', async () => {
 		fakeAs = await startFakeAs();
 		vi.mocked(openMod).mockImplementation(
 			fakeBrowserDriver(fakeAs.url, 'consent') as typeof openMod,
@@ -158,10 +158,11 @@ describe('dispatch OAuth integration', () => {
 		);
 
 		const result = await dispatch(tokenCaptureTool, ctx)({});
-		expect(result.isError).toBeUndefined();
-		// HTTP transport: no token acquired, getRuntimeToken() returns undefined
-		const text = (result.content[0] as { text: string }).text;
-		expect(text).toBe('');
+		// HTTP transport: an OAuth-only wiki with no usable token is rejected
+		// up front by the capability guard with an authentication error; the
+		// dispatcher never reaches the OAuth gate, so open() is never called.
+		expect(result.isError).toBe(true);
+		expect(JSON.stringify(result.content)).toContain('requires OAuth');
 		expect(vi.mocked(openMod)).not.toHaveBeenCalled();
 	});
 

--- a/tests/runtime/dispatch.wiki.test.ts
+++ b/tests/runtime/dispatch.wiki.test.ts
@@ -5,6 +5,7 @@ import type { Tool } from '../../src/runtime/tool.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { getRequestWiki } from '../../src/transport/requestContext.js';
 import { updatePage } from '../../src/tools/update-page.js';
+import { getPage } from '../../src/tools/get-page.js';
 import { cargoQuery } from '../../src/tools/extensions/cargo/cargo-query.js';
 
 // A minimal wiki-scoped tool that reports the wiki it ran against.
@@ -175,5 +176,32 @@ describe('dispatch capability guard', () => {
 		const result = await dispatch(cargoQuery, ctx)({ tables: 'Items' } as never);
 		expect(result.isError).toBe(true);
 		expect(JSON.stringify(result.content)).toContain('not installed');
+	});
+
+	it('blocks an HTTP call to an OAuth-only wiki with no usable token', async () => {
+		const oauthConfig = {
+			sitename: 'T',
+			server: 'https://t',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+			oauth2ClientId: 'client-id',
+		};
+		const ctx = fakeContext({
+			transport: 'http',
+			wikis: {
+				getAll: () => ({ 'test-wiki': oauthConfig }) as never,
+				get: ((k: string) => (k === 'test-wiki' ? oauthConfig : undefined)) as never,
+				add: (() => {}) as never,
+				remove: (() => {}) as never,
+				isManagementAllowed: () => true,
+			},
+			activeWiki: {
+				get: () => ({ key: 'test-wiki', config: oauthConfig as never }),
+				getDefaultKey: () => 'test-wiki',
+			},
+		});
+		const result = await dispatch(getPage, ctx)({ title: 'X' } as never);
+		expect(result.isError).toBe(true);
+		expect(JSON.stringify(result.content)).toContain('requires OAuth');
 	});
 });

--- a/tests/runtime/instrument.test.ts
+++ b/tests/runtime/instrument.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
 
 vi.mock('../../src/runtime/metrics.js', () => ({
 	recordToolCall: vi.fn(),
@@ -384,7 +385,8 @@ describe('emitToolCall', () => {
 		expect(captureToolCallLine(stderrSpy).caller).toMatch(/^sha256:[0-9a-f]{12}$/);
 	});
 
-	it('normalises session_id to first 12 hex chars with dashes stripped', () => {
+	it('hashes session_id to sha256:<12 hex>', () => {
+		const sessionId = 'f4e1d2c3-b4a5-dead-beef-abcdef012345';
 		emitToolCall({
 			toolName: 'get-page',
 			target: undefined,
@@ -395,11 +397,12 @@ describe('emitToolCall', () => {
 			upstreamStatus: undefined,
 			errorMessage: undefined,
 			runtimeToken: undefined,
-			sessionId: 'f4e1d2c3-b4a5-dead-beef-abcdef012345',
+			sessionId,
 			wikiKey: 'a.example',
 		});
 
-		expect(captureToolCallLine(stderrSpy).session_id).toBe('f4e1d2c3b4a5');
+		const expected = `sha256:${createHash('sha256').update(sessionId).digest('hex').slice(0, 12)}`;
+		expect(captureToolCallLine(stderrSpy).session_id).toBe(expected);
 	});
 
 	it('omits session_id when not provided', () => {

--- a/tests/runtime/wikiCapability.test.ts
+++ b/tests/runtime/wikiCapability.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { checkWikiCapability } from '../../src/runtime/wikiCapability.js';
 import { fakeContext } from '../helpers/fakeContext.js';
+import { withRequestFields } from '../../src/transport/requestContext.js';
 
 const rwWiki = {
 	sitename: 'X',
@@ -9,9 +10,21 @@ const rwWiki = {
 	scriptpath: '/w',
 } as never;
 const roWiki = { ...rwWiki, readOnly: true } as never;
+const oauthWiki = { ...rwWiki, oauth2ClientId: 'client-id' } as never;
+const oauthWithTokenWiki = {
+	...rwWiki,
+	oauth2ClientId: 'client-id',
+	token: 'static-token',
+} as never;
 
-function ctx(hasExt: boolean, wikiConfig: unknown, reachable = true) {
+function ctx(
+	hasExt: boolean,
+	wikiConfig: unknown,
+	reachable = true,
+	transport: 'http' | 'stdio' = 'stdio',
+) {
 	return fakeContext({
+		transport,
 		wikis: {
 			getAll: () => ({ w: wikiConfig }) as never,
 			get: (() => wikiConfig) as never,
@@ -59,5 +72,53 @@ describe('checkWikiCapability', () => {
 
 	it('returns undefined for a plain read tool', async () => {
 		expect(await checkWikiCapability('get-page', 'w', ctx(false, rwWiki))).toBeUndefined();
+	});
+
+	it('rejects an HTTP call to an OAuth-only wiki with no usable token', async () => {
+		const result = await checkWikiCapability('get-page', 'w', ctx(false, oauthWiki, true, 'http'));
+		expect(result?.isError).toBe(true);
+		const raw = result?.content?.map((c) => (c as { text?: string }).text).join('') ?? '';
+		const message = (JSON.parse(raw) as { message: string }).message;
+		expect(message).toContain('requires OAuth');
+		expect(message).toContain('Wiki "w"');
+	});
+
+	it('allows an HTTP call to an OAuth-only wiki when a runtime bearer is present', async () => {
+		const result = await withRequestFields({ runtimeToken: 'tok' }, () =>
+			checkWikiCapability('get-page', 'w', ctx(false, oauthWiki, true, 'http')),
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it('allows an HTTP call to an OAuth wiki with static credentials configured', async () => {
+		const result = await checkWikiCapability(
+			'get-page',
+			'w',
+			ctx(false, oauthWithTokenWiki, true, 'http'),
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it('fires the OAuth check before the extension check', async () => {
+		// cargo-query is an extension tool, and the wiki lacks the extension; the
+		// OAuth error must surface first.
+		const result = await checkWikiCapability(
+			'cargo-query',
+			'w',
+			ctx(false, oauthWiki, true, 'http'),
+		);
+		expect(result?.isError).toBe(true);
+		expect(JSON.stringify(result?.content)).toContain('requires OAuth');
+		expect(JSON.stringify(result?.content)).not.toContain('not installed');
+	});
+
+	it('does not fire the OAuth check on the stdio transport', async () => {
+		const result = await checkWikiCapability('get-page', 'w', ctx(false, oauthWiki, true, 'stdio'));
+		expect(result).toBeUndefined();
+	});
+
+	it('does not block an HTTP call to a non-OAuth wiki', async () => {
+		const result = await checkWikiCapability('get-page', 'w', ctx(false, rwWiki, true, 'http'));
+		expect(result).toBeUndefined();
 	});
 });

--- a/tests/tools/list-wikis.test.ts
+++ b/tests/tools/list-wikis.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { dispatch } from '../../src/runtime/dispatcher.js';
 import { listWikis } from '../../src/tools/list-wikis.js';
 import { fakeContext } from '../helpers/fakeContext.js';
+
+const fetchMetadata = vi.fn();
+vi.mock('../../src/auth/metadata.js', () => ({
+	fetchMetadata: (...args: unknown[]) => fetchMetadata(...args) as unknown,
+}));
 
 const wikiConfig = {
 	sitename: 'Test',
@@ -11,13 +16,15 @@ const wikiConfig = {
 	scriptpath: '/w',
 } as never;
 
-function ctxWith(extByWiki: Record<string, Set<string>>, unreachable: Set<string> = new Set()) {
-	const wikis = { 'test-wiki': wikiConfig, 'cargo.wiki': wikiConfig };
+function ctxWith(
+	extByWiki: Record<string, Set<string>>,
+	unreachable: Set<string> = new Set(),
+	wikis: Record<string, unknown> = { 'test-wiki': wikiConfig, 'cargo.wiki': wikiConfig },
+) {
 	return fakeContext({
 		wikis: {
 			getAll: () => wikis as never,
-			get: ((k: string) =>
-				Object.hasOwn(wikis, k) ? wikis[k as keyof typeof wikis] : undefined) as never,
+			get: ((k: string) => (Object.hasOwn(wikis, k) ? wikis[k] : undefined)) as never,
 			add: (() => {}) as never,
 			remove: (() => {}) as never,
 			isManagementAllowed: () => true,
@@ -43,6 +50,10 @@ function wikisOf(result: CallToolResult): Array<Record<string, unknown>> {
 }
 
 describe('list-wikis', () => {
+	beforeEach(() => {
+		fetchMetadata.mockReset();
+	});
+
 	it('returns every configured wiki with key, isDefault, readOnly, reachable', async () => {
 		const ctx = ctxWith({});
 		const result = await dispatch(listWikis, ctx)({} as never);
@@ -73,5 +84,60 @@ describe('list-wikis', () => {
 		const cargo = wikisOf(result).find((w) => w.key === 'cargo.wiki')!;
 		expect(cargo.reachable).toBe(false);
 		expect(cargo.extensionTools).toEqual([]);
+	});
+
+	it('reports the authorization server issuer for an OAuth-configured wiki', async () => {
+		fetchMetadata.mockResolvedValue({ issuer: 'https://oauth.wiki' });
+		const ctx = ctxWith({}, new Set(), {
+			'oauth-wiki': {
+				sitename: 'OAuth',
+				server: 'https://oauth.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				oauth2ClientId: 'client-id-123',
+			},
+		});
+		const result = await dispatch(listWikis, ctx)({} as never);
+		const wiki = wikisOf(result).find((w) => w.key === 'oauth-wiki')!;
+		expect(wiki.authorizationServer).toBe('https://oauth.wiki');
+	});
+
+	it('omits authorizationServer for a non-OAuth wiki', async () => {
+		const ctx = ctxWith({}, new Set(), { 'plain-wiki': wikiConfig });
+		const result = await dispatch(listWikis, ctx)({} as never);
+		const wiki = wikisOf(result).find((w) => w.key === 'plain-wiki')!;
+		expect(wiki).not.toHaveProperty('authorizationServer');
+		expect(fetchMetadata).not.toHaveBeenCalled();
+	});
+
+	it('omits authorizationServer for a wiki whose metadata fetch fails, without failing the call', async () => {
+		fetchMetadata.mockImplementation((key: string) => {
+			if (key === 'broken-wiki') {
+				return Promise.reject(new Error('metadata unavailable'));
+			}
+			return Promise.resolve({ issuer: 'https://good.wiki' });
+		});
+		const ctx = ctxWith({}, new Set(), {
+			'good-wiki': {
+				sitename: 'Good',
+				server: 'https://good.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				oauth2ClientId: 'good-client',
+			},
+			'broken-wiki': {
+				sitename: 'Broken',
+				server: 'https://broken.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				oauth2ClientId: 'broken-client',
+			},
+		});
+		const result = await dispatch(listWikis, ctx)({} as never);
+		expect(result.isError).not.toBe(true);
+		const good = wikisOf(result).find((w) => w.key === 'good-wiki')!;
+		const broken = wikisOf(result).find((w) => w.key === 'broken-wiki')!;
+		expect(good.authorizationServer).toBe('https://good.wiki');
+		expect(broken).not.toHaveProperty('authorizationServer');
 	});
 });

--- a/tests/transport/httpConfig.test.ts
+++ b/tests/transport/httpConfig.test.ts
@@ -269,6 +269,19 @@ describe('resolveHttpConfig', () => {
 			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '-5');
 			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
 		});
+
+		it('clamps a value above the setTimeout ceiling to 2147483647ms', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '999999999999');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(2147483647);
+		});
+
+		it.each(['300abc', '1e9'])(
+			'falls back to 1800000 for the non-integer value %s (strict parsing)',
+			(value) => {
+				vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', value);
+				expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+			},
+		);
 	});
 
 	describe('warnings', () => {

--- a/tests/transport/httpConfig.test.ts
+++ b/tests/transport/httpConfig.test.ts
@@ -235,6 +235,42 @@ describe('resolveHttpConfig', () => {
 		});
 	});
 
+	describe('sessionIdleTimeoutMs', () => {
+		it('defaults to 1800000 (1800s) when MCP_SESSION_IDLE_TIMEOUT is unset', () => {
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+		});
+
+		it('defaults to 1800000 when MCP_SESSION_IDLE_TIMEOUT is empty', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+		});
+
+		it('defaults to 1800000 when MCP_SESSION_IDLE_TIMEOUT is whitespace', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '   ');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+		});
+
+		it('parses an explicit value in seconds to milliseconds', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '60');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(60000);
+		});
+
+		it('treats 0 as expiry disabled', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '0');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(0);
+		});
+
+		it('defaults to 1800000 when MCP_SESSION_IDLE_TIMEOUT is non-numeric', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', 'abc');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+		});
+
+		it('defaults to 1800000 when MCP_SESSION_IDLE_TIMEOUT is negative', () => {
+			vi.stubEnv('MCP_SESSION_IDLE_TIMEOUT', '-5');
+			expect(resolveHttpConfig().sessionIdleTimeoutMs).toBe(1800000);
+		});
+	});
+
 	describe('warnings', () => {
 		it('is empty by default', () => {
 			expect(resolveHttpConfig().warnings).toEqual([]);

--- a/tests/transport/streamableHttp.oauth.test.ts
+++ b/tests/transport/streamableHttp.oauth.test.ts
@@ -60,12 +60,12 @@ function fakeActiveWiki(key: string, cfg: Partial<WikiConfig>): ActiveWiki {
 	} as unknown as ActiveWiki;
 }
 
-function buildWellKnownApp(registry: WikiRegistry, activeWiki: ActiveWiki): Express {
+function buildWellKnownApp(registry: WikiRegistry): Express {
 	const app = express();
 	app.use(express.json());
 	app.get(
 		'/.well-known/oauth-protected-resource',
-		createOAuthProtectedResourceHandler({ wikiRegistry: registry, activeWiki: activeWiki }),
+		createOAuthProtectedResourceHandler({ wikiRegistry: registry }),
 	);
 	return app;
 }
@@ -101,8 +101,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 			oauth2ClientId: 'my-client-id',
 		};
 		const registry = fakeRegistry({ mywiki: wikiCfg });
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildWellKnownApp(registry, activeWiki);
+		const app = buildWellKnownApp(registry);
 
 		const res = await request(app).get('/.well-known/oauth-protected-resource');
 		expect(res.status).toBe(200);
@@ -120,8 +119,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 			articlepath: '/wiki',
 		};
 		const registry = fakeRegistry({ plain: wikiCfg });
-		const activeWiki = fakeActiveWiki('plain', wikiCfg);
-		const app = buildWellKnownApp(registry, activeWiki);
+		const app = buildWellKnownApp(registry);
 
 		const res = await request(app).get('/.well-known/oauth-protected-resource');
 		expect(res.status).toBe(404);
@@ -136,8 +134,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 			oauth2ClientId: '',
 		};
 		const registry = fakeRegistry({ empty: wikiCfg });
-		const activeWiki = fakeActiveWiki('empty', wikiCfg);
-		const app = buildWellKnownApp(registry, activeWiki);
+		const app = buildWellKnownApp(registry);
 
 		const res = await request(app).get('/.well-known/oauth-protected-resource');
 		expect(res.status).toBe(404);
@@ -153,8 +150,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 			oauth2ClientId: 'my-client-id',
 		};
 		const registry = fakeRegistry({ mywiki: wikiCfg });
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildWellKnownApp(registry, activeWiki);
+		const app = buildWellKnownApp(registry);
 
 		// MCP_PUBLIC_URL not set; resource is derived from host header and proto
 		const res = await request(app)
@@ -164,6 +160,95 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 		expect(res.status).toBe(200);
 		// resource should use https
 		expect(res.body.resource).toMatch(/^https:\/\/mcp\.example\.org\//);
+	});
+
+	it('lists every OAuth wiki authorization server when two wikis use different servers', async () => {
+		fakeAs = await startFakeAs();
+		const fakeAs2 = await startFakeAs();
+		try {
+			const wikiCfgA: Partial<WikiConfig> = {
+				sitename: 'WikiA',
+				server: fakeAs.url,
+				scriptpath: '/w',
+				articlepath: '/wiki',
+				oauth2ClientId: 'client-a',
+			};
+			const wikiCfgB: Partial<WikiConfig> = {
+				sitename: 'WikiB',
+				server: fakeAs2.url,
+				scriptpath: '/w',
+				articlepath: '/wiki',
+				oauth2ClientId: 'client-b',
+			};
+			const registry = fakeRegistry({ wikiA: wikiCfgA, wikiB: wikiCfgB });
+			const app = buildWellKnownApp(registry);
+
+			const res = await request(app).get('/.well-known/oauth-protected-resource');
+			expect(res.status).toBe(200);
+			expect(res.body.authorization_servers).toContain(fakeAs.url);
+			expect(res.body.authorization_servers).toContain(fakeAs2.url);
+			expect(res.body.authorization_servers).toHaveLength(2);
+		} finally {
+			await fakeAs2.close();
+		}
+	});
+
+	it('still includes a reachable wiki AS when another wiki metadata fetch rejects', async () => {
+		fakeAs = await startFakeAs();
+		// A second AS that explicitly advertises a non-S256 PKCE method makes
+		// fetchMetadata reject with MetadataError; Promise.allSettled keeps it
+		// out of the document while the reachable wiki's AS survives.
+		const badAs = await startFakeAs({
+			wellKnownBody: { code_challenge_methods_supported: ['plain'] },
+		});
+		try {
+			const reachable: Partial<WikiConfig> = {
+				sitename: 'Reachable',
+				server: fakeAs.url,
+				scriptpath: '/w',
+				articlepath: '/wiki',
+				oauth2ClientId: 'client-ok',
+			};
+			const rejecting: Partial<WikiConfig> = {
+				sitename: 'Rejecting',
+				server: badAs.url,
+				scriptpath: '/w',
+				articlepath: '/wiki',
+				oauth2ClientId: 'client-bad',
+			};
+			const registry = fakeRegistry({ reachable: reachable, rejecting: rejecting });
+			const app = buildWellKnownApp(registry);
+
+			const res = await request(app).get('/.well-known/oauth-protected-resource');
+			expect(res.status).toBe(200);
+			expect(res.body.authorization_servers).toContain(fakeAs.url);
+			expect(res.body.authorization_servers).not.toContain(badAs.url);
+		} finally {
+			await badAs.close();
+		}
+	});
+
+	it('returns 503 when every OAuth wiki metadata fetch rejects', async () => {
+		const badAs = await startFakeAs({
+			wellKnownBody: { code_challenge_methods_supported: ['plain'] },
+		});
+		try {
+			const rejecting: Partial<WikiConfig> = {
+				sitename: 'Rejecting',
+				server: badAs.url,
+				scriptpath: '/w',
+				articlepath: '/wiki',
+				oauth2ClientId: 'client-bad',
+			};
+			const registry = fakeRegistry({ rejecting: rejecting });
+			const app = buildWellKnownApp(registry);
+
+			const res = await request(app).get('/.well-known/oauth-protected-resource');
+			expect(res.status).toBe(503);
+			expect(res.body.error).toBe('discovery_failed');
+		} finally {
+			await badAs.close();
+		}
 	});
 });
 

--- a/tests/transport/streamableHttp.oauth.test.ts
+++ b/tests/transport/streamableHttp.oauth.test.ts
@@ -38,7 +38,6 @@ import {
 	type SessionRegistry,
 } from '../../src/transport/streamableHttp.js';
 import type { WikiRegistry } from '../../src/wikis/wikiRegistry.js';
-import type { ActiveWiki } from '../../src/wikis/activeWiki.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
 import { _resetMetadataCacheForTesting } from '../../src/auth/metadata.js';
 import { startFakeAs, type FakeAsHandle } from '../helpers/fakeAuthorizationServer.js';
@@ -51,13 +50,6 @@ function fakeRegistry(wikis: Record<string, Partial<WikiConfig>>): WikiRegistry 
 		remove: () => {},
 		isManagementAllowed: () => false,
 	} as unknown as WikiRegistry;
-}
-
-function fakeActiveWiki(key: string, cfg: Partial<WikiConfig>): ActiveWiki {
-	return {
-		get: () => ({ key, config: cfg as WikiConfig }),
-		getDefaultKey: () => key,
-	} as unknown as ActiveWiki;
 }
 
 function buildWellKnownApp(registry: WikiRegistry): Express {
@@ -74,11 +66,11 @@ function stubCreateServer(): McpServer {
 	return new McpServer({ name: 'oauth-test-server', version: '0.0.0' }, { capabilities: {} });
 }
 
-function buildMcpApp(activeWiki: ActiveWiki): Express {
+function buildMcpApp(registry: WikiRegistry): Express {
 	const app = express();
 	app.use(express.json());
 	const sessions: SessionRegistry = {};
-	app.post('/mcp', createMcpPostHandler(sessions, stubCreateServer, { activeWiki: activeWiki }));
+	app.post('/mcp', createMcpPostHandler(sessions, stubCreateServer, { wikiRegistry: registry }));
 	return app;
 }
 
@@ -252,7 +244,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 	});
 });
 
-describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
+describe('POST /mcp 401 short-circuit when every wiki requires auth', () => {
 	afterEach(() => {
 		delete process.env.MCP_ALLOW_STATIC_FALLBACK;
 		vi.unstubAllEnvs();
@@ -266,8 +258,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			articlepath: '/wiki',
 			oauth2ClientId: 'client-id-123',
 		};
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ mywiki: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -291,8 +282,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			scriptpath: '/w',
 			articlepath: '/wiki',
 		};
-		const activeWiki = fakeActiveWiki('plain', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ plain: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -302,8 +292,8 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 		expect(res.status).not.toBe(401);
 	});
 
-	it('does NOT return 401 when activeWiki is not provided to handler', async () => {
-		// If activeWiki is omitted entirely, the 401 check is skipped
+	it('does NOT return 401 when wikiRegistry is not provided to handler', async () => {
+		// If wikiRegistry is omitted entirely, the 401 check is skipped
 		const app = express();
 		app.use(express.json());
 		const sessions: SessionRegistry = {};
@@ -325,8 +315,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			articlepath: '/wiki',
 			oauth2ClientId: 'client-id-123',
 		};
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ mywiki: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -349,8 +338,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			oauth2ClientId: 'client-id-456',
 			token: 'static-bot-token',
 		};
-		const activeWiki = fakeActiveWiki('fallback', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ fallback: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -371,8 +359,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			username: 'bot-user',
 			password: 'bot-pass',
 		};
-		const activeWiki = fakeActiveWiki('fallback2', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ fallback2: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -391,8 +378,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			articlepath: '/wiki',
 			oauth2ClientId: 'client-id-000',
 		};
-		const activeWiki = fakeActiveWiki('oauthonly', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ oauthonly: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -410,8 +396,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			articlepath: '/wiki',
 			oauth2ClientId: 'client-id-123',
 		};
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ mywiki: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -434,8 +419,7 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 			articlepath: '/wiki',
 			oauth2ClientId: 'client-id-123',
 		};
-		const activeWiki = fakeActiveWiki('mywiki', wikiCfg);
-		const app = buildMcpApp(activeWiki);
+		const app = buildMcpApp(fakeRegistry({ mywiki: wikiCfg }));
 
 		const res = await request(app)
 			.post('/mcp')
@@ -447,5 +431,58 @@ describe('POST /mcp 401 short-circuit for OAuth-only wikis', () => {
 		const wwwAuth = res.headers['www-authenticate'] as string;
 		expect(wwwAuth).toContain('https://override.example.org/.well-known/oauth-protected-resource');
 		expect(wwwAuth).not.toContain('internal.example.org');
+	});
+
+	it('returns 401 when EVERY configured wiki is OAuth-only', async () => {
+		const wikiA: Partial<WikiConfig> = {
+			sitename: 'OAuthA',
+			server: 'https://a.example',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+			oauth2ClientId: 'client-a',
+		};
+		const wikiB: Partial<WikiConfig> = {
+			sitename: 'OAuthB',
+			server: 'https://b.example',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+			oauth2ClientId: 'client-b',
+		};
+		const app = buildMcpApp(fakeRegistry({ wikiA: wikiA, wikiB: wikiB }));
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+		expect(res.status).toBe(401);
+		expect(res.body?.error?.code).toBe(-32001);
+		const wwwAuth = res.headers['www-authenticate'];
+		expect(typeof wwwAuth).toBe('string');
+		expect(wwwAuth).toMatch(/Bearer realm="MediaWiki MCP Server"/);
+	});
+
+	it('does NOT return 401 when one wiki is OAuth-only but another needs no auth', async () => {
+		const oauthWiki: Partial<WikiConfig> = {
+			sitename: 'OAuthOnly',
+			server: 'https://oauth.example',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+			oauth2ClientId: 'client-oauth',
+		};
+		const publicWiki: Partial<WikiConfig> = {
+			sitename: 'PublicWiki',
+			server: 'https://public.example',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+		};
+		const app = buildMcpApp(fakeRegistry({ oauth: oauthWiki, public: publicWiki }));
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+		expect(res.status).not.toBe(401);
 	});
 });

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -40,6 +40,7 @@ import {
 	payloadTooLargeHandler,
 	resolveMcpHostValidation,
 	type SessionRegistry,
+	touchSession,
 	withRequestContext,
 } from '../../src/transport/streamableHttp.js';
 import { getRuntimeToken, getSessionId } from '../../src/transport/requestContext.js';
@@ -458,6 +459,83 @@ describe('withRequestContext', () => {
 			expect(getRuntimeToken()).toBeUndefined();
 			expect(getSessionId()).toBe('sess-only');
 		});
+	});
+});
+
+describe('touchSession (idle expiry)', () => {
+	function sessionWithCloseSpy(): {
+		sessions: SessionRegistry;
+		close: ReturnType<typeof vi.fn>;
+	} {
+		const sessions: SessionRegistry = {};
+		// Mirror the real transport.close() -> onclose -> delete sessions[id] chain
+		// from createMcpPostHandler, so the test exercises registry removal too.
+		const transport = {
+			onclose: undefined as (() => void) | undefined,
+		} as unknown as SessionRegistry[string]['transport'] & { onclose?: () => void };
+		const close = vi.fn(() => {
+			transport.onclose?.();
+			return Promise.resolve();
+		});
+		(transport as { close: unknown }).close = close;
+		transport.onclose = () => {
+			delete sessions['sid-1'];
+		};
+		sessions['sid-1'] = { transport };
+		return { sessions, close };
+	}
+
+	it('closes the session transport once the timeout window elapses', () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, close } = sessionWithCloseSpy();
+			touchSession(sessions, 'sid-1', 1000);
+			expect(close).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(1000);
+			expect(close).toHaveBeenCalledTimes(1);
+			expect(sessions['sid-1']).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('resets the idle timer on a subsequent touch', () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, close } = sessionWithCloseSpy();
+			touchSession(sessions, 'sid-1', 1000);
+			vi.advanceTimersByTime(600);
+			touchSession(sessions, 'sid-1', 1000);
+			vi.advanceTimersByTime(600);
+			expect(close).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(400);
+			expect(close).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('never closes the session when the timeout is 0 (expiry disabled)', () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, close } = sessionWithCloseSpy();
+			touchSession(sessions, 'sid-1', 0);
+			expect(sessions['sid-1'].idleTimer).toBeUndefined();
+			vi.advanceTimersByTime(10_000_000);
+			expect(close).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('is a no-op for an unknown session id', () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions } = sessionWithCloseSpy();
+			expect(() => touchSession(sessions, 'sid-unknown', 1000)).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -37,11 +37,9 @@ import {
 	createMcpPostHandler,
 	createSessionRequestHandler,
 	extractBearerToken,
-	hashBearer,
 	payloadTooLargeHandler,
 	resolveMcpHostValidation,
 	type SessionRegistry,
-	verifySessionBearer,
 	withRequestContext,
 } from '../../src/transport/streamableHttp.js';
 import { getRuntimeToken, getSessionId } from '../../src/transport/requestContext.js';
@@ -78,47 +76,6 @@ describe('extractBearerToken', () => {
 	it('returns undefined if the first comma-joined value is not Bearer', () => {
 		expect(extractBearerToken(req(', Bearer abc'))).toBeUndefined();
 		expect(extractBearerToken(req('Basic xyz, Bearer abc'))).toBeUndefined();
-	});
-});
-
-describe('hashBearer', () => {
-	it('returns a 64-character hex string', () => {
-		expect(hashBearer('abc123')).toMatch(/^[0-9a-f]{64}$/);
-	});
-	it('is deterministic for the same token', () => {
-		expect(hashBearer('abc123')).toBe(hashBearer('abc123'));
-	});
-	it('produces different hashes for different tokens', () => {
-		expect(hashBearer('abc123')).not.toBe(hashBearer('xyz789'));
-	});
-	it('produces a distinct hash for undefined vs a present token', () => {
-		expect(hashBearer(undefined)).not.toBe(hashBearer(''));
-		expect(hashBearer(undefined)).not.toBe(hashBearer('abc'));
-	});
-	it('is deterministic for undefined', () => {
-		expect(hashBearer(undefined)).toBe(hashBearer(undefined));
-	});
-});
-
-describe('verifySessionBearer', () => {
-	it('returns true when the presented token matches the hashed original', () => {
-		expect(verifySessionBearer(hashBearer('abc123'), 'abc123')).toBe(true);
-	});
-	it('returns false when the presented token differs from the hashed original', () => {
-		expect(verifySessionBearer(hashBearer('abc123'), 'xyz789')).toBe(false);
-	});
-	it('returns false when the hash was of a token and the request has none', () => {
-		expect(verifySessionBearer(hashBearer('abc123'), undefined)).toBe(false);
-	});
-	it('returns false when the hash was of no token and the request has one', () => {
-		expect(verifySessionBearer(hashBearer(undefined), 'abc123')).toBe(false);
-	});
-	it('returns true when both original and presented are absent', () => {
-		expect(verifySessionBearer(hashBearer(undefined), undefined)).toBe(true);
-	});
-	it('returns false for a malformed stored hash without throwing', () => {
-		expect(() => verifySessionBearer('not-a-hash', 'abc123')).not.toThrow();
-		expect(verifySessionBearer('not-a-hash', 'abc123')).toBe(false);
 	});
 });
 
@@ -190,7 +147,7 @@ describe('host validation (scoped to /mcp)', () => {
 	});
 });
 
-describe('session-bearer binding (GET/DELETE handler)', () => {
+describe('session request handler (GET/DELETE)', () => {
 	function buildApp(sessions: SessionRegistry): {
 		app: Express;
 		handleRequest: ReturnType<typeof vi.fn>;
@@ -212,11 +169,10 @@ describe('session-bearer binding (GET/DELETE handler)', () => {
 		return { app, handleRequest };
 	}
 
-	function fakeSession(bearerHash: string): SessionRegistry {
+	function fakeSession(): SessionRegistry {
 		return {
 			'sid-1': {
 				transport: {} as unknown as SessionRegistry[string]['transport'],
-				bearerHash,
 			},
 		};
 	}
@@ -228,73 +184,94 @@ describe('session-bearer binding (GET/DELETE handler)', () => {
 	});
 
 	it('returns 400 when the session id is not known', async () => {
-		const { app } = buildApp(fakeSession(hashBearer('abc')));
+		const { app } = buildApp(fakeSession());
 		const res = await request(app).get('/mcp').set('mcp-session-id', 'sid-unknown');
 		expect(res.status).toBe(400);
 	});
 
-	it('forwards to transport.handleRequest when bearer matches the bound session', async () => {
-		const sessions = fakeSession(hashBearer('abc'));
-		const { app, handleRequest } = buildApp(sessions);
-		const res = await request(app)
-			.get('/mcp')
-			.set('mcp-session-id', 'sid-1')
-			.set('Authorization', 'Bearer abc');
-		expect(res.status).toBe(204);
-		expect(handleRequest).toHaveBeenCalledTimes(1);
-	});
-
-	it('returns 401 with a JSON-RPC error when the bearer differs from the bound session', async () => {
-		const sessions = fakeSession(hashBearer('abc'));
-		const { app, handleRequest } = buildApp(sessions);
-		const res = await request(app)
-			.get('/mcp')
-			.set('mcp-session-id', 'sid-1')
-			.set('Authorization', 'Bearer different');
-		expect(res.status).toBe(401);
-		expect(res.body?.error?.message).toMatch(/session/i);
-		expect(handleRequest).not.toHaveBeenCalled();
-	});
-
-	it('returns 401 when the session was bound with a bearer but the request has none', async () => {
-		const sessions = fakeSession(hashBearer('abc'));
-		const { app, handleRequest } = buildApp(sessions);
+	it('forwards a GET to transport.handleRequest with a valid session id and no bearer', async () => {
+		const { app, handleRequest } = buildApp(fakeSession());
 		const res = await request(app).get('/mcp').set('mcp-session-id', 'sid-1');
-		expect(res.status).toBe(401);
-		expect(handleRequest).not.toHaveBeenCalled();
-	});
-
-	it('returns 401 when the session was bound without a bearer but the request now supplies one', async () => {
-		const sessions = fakeSession(hashBearer(undefined));
-		const { app, handleRequest } = buildApp(sessions);
-		const res = await request(app)
-			.get('/mcp')
-			.set('mcp-session-id', 'sid-1')
-			.set('Authorization', 'Bearer abc');
-		expect(res.status).toBe(401);
-		expect(handleRequest).not.toHaveBeenCalled();
-	});
-
-	it('forwards a DELETE when bearer matches the bound session', async () => {
-		const sessions = fakeSession(hashBearer('abc'));
-		const { app, handleRequest } = buildApp(sessions);
-		const res = await request(app)
-			.delete('/mcp')
-			.set('mcp-session-id', 'sid-1')
-			.set('Authorization', 'Bearer abc');
 		expect(res.status).toBe(204);
 		expect(handleRequest).toHaveBeenCalledTimes(1);
 	});
 
-	it('rejects a DELETE with a mismatched bearer', async () => {
-		const sessions = fakeSession(hashBearer('abc'));
-		const { app, handleRequest } = buildApp(sessions);
+	it('forwards a GET regardless of which bearer it carries', async () => {
+		const { app, handleRequest } = buildApp(fakeSession());
 		const res = await request(app)
-			.delete('/mcp')
+			.get('/mcp')
 			.set('mcp-session-id', 'sid-1')
-			.set('Authorization', 'Bearer nope');
-		expect(res.status).toBe(401);
-		expect(handleRequest).not.toHaveBeenCalled();
+			.set('Authorization', 'Bearer any-token');
+		expect(res.status).toBe(204);
+		expect(handleRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards a DELETE with a valid session id and no bearer', async () => {
+		const { app, handleRequest } = buildApp(fakeSession());
+		const res = await request(app).delete('/mcp').set('mcp-session-id', 'sid-1');
+		expect(res.status).toBe(204);
+		expect(handleRequest).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('POST to an existing session (per-request bearer)', () => {
+	function buildApp(sessions: SessionRegistry): {
+		app: Express;
+		handleRequest: ReturnType<typeof vi.fn>;
+	} {
+		const app = express();
+		app.use(express.json());
+		const handleRequest = vi.fn(
+			async (
+				_req: unknown,
+				res: { status: (n: number) => { end: () => void } },
+				_body: unknown,
+			) => {
+				res.status(202).end();
+			},
+		);
+		for (const key of Object.keys(sessions)) {
+			(
+				sessions[key].transport as unknown as { handleRequest: typeof handleRequest }
+			).handleRequest = handleRequest;
+		}
+		app.post('/mcp', createMcpPostHandler(sessions, stubCreateServer));
+		return { app, handleRequest };
+	}
+
+	function stubCreateServer(): McpServer {
+		return new McpServer({ name: 'post-test-server', version: '0.0.0' }, { capabilities: {} });
+	}
+
+	function fakeSession(): SessionRegistry {
+		return {
+			'sid-1': {
+				transport: {} as unknown as SessionRegistry[string]['transport'],
+			},
+		};
+	}
+
+	it('accepts a POST carrying a bearer that differs from the one that initialized the session', async () => {
+		const { app, handleRequest } = buildApp(fakeSession());
+		const res = await request(app)
+			.post('/mcp')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', 'Bearer a-different-token')
+			.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+		expect(res.status).not.toBe(401);
+		expect(res.status).toBe(202);
+		expect(handleRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it('accepts a POST to an existing session with no bearer at all', async () => {
+		const { app, handleRequest } = buildApp(fakeSession());
+		const res = await request(app)
+			.post('/mcp')
+			.set('mcp-session-id', 'sid-1')
+			.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+		expect(res.status).not.toBe(401);
+		expect(res.status).toBe(202);
+		expect(handleRequest).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -563,6 +563,125 @@ describe('markSessionActive / markSessionIdle (idle expiry)', () => {
 	});
 });
 
+describe('idle-counter wiring through the HTTP handlers', () => {
+	function stubCreateServer(): McpServer {
+		return new McpServer({ name: 'idle-wiring-server', version: '0.0.0' }, { capabilities: {} });
+	}
+
+	// supertest resolves its promise on the HTTP response, but the handler's
+	// markSessionIdle runs on the response's 'close' event, which can fire a
+	// tick later. Mirror the createInFlightCounter abort test's setImmediate
+	// drain so the post-close registry state is observable.
+	async function afterResponseClosed(): Promise<void> {
+		await new Promise((r) => setImmediate(r));
+	}
+
+	it('balances activeRequests back to 0 after a POST to an existing session', async () => {
+		const app = express();
+		app.use(express.json());
+		const handleRequest = vi.fn(
+			async (_req: unknown, res: { status: (n: number) => { end: () => void } }) => {
+				res.status(202).end();
+			},
+		);
+		// transport.sessionId must be populated: the POST handler's res.on('close')
+		// reads it to route markSessionIdle back to this registry entry.
+		const transport = {
+			sessionId: 'sid-1',
+			handleRequest,
+		} as unknown as SessionRegistry[string]['transport'];
+		const sessions: SessionRegistry = { 'sid-1': { transport, activeRequests: 0 } };
+		app.post('/mcp', createMcpPostHandler(sessions, stubCreateServer, { idleTimeoutMs: 0 }));
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('mcp-session-id', 'sid-1')
+			.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+		await afterResponseClosed();
+
+		expect(res.status).toBe(202);
+		// markSessionActive (+1) and the res.on('close') -> markSessionIdle (-1)
+		// balanced out — the request did not leak an in-flight count.
+		expect(sessions['sid-1'].activeRequests).toBe(0);
+	});
+
+	it('balances activeRequests back to 0 after a new-session initialize POST', async () => {
+		const app = express();
+		app.use(express.json());
+		const sessions: SessionRegistry = {};
+		app.post('/mcp', createMcpPostHandler(sessions, stubCreateServer, { idleTimeoutMs: 0 }));
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Accept', 'application/json, text/event-stream')
+			.send({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: {
+					protocolVersion: '2025-11-25',
+					capabilities: {},
+					clientInfo: { name: 'idle-wiring-client', version: '0.0.0' },
+				},
+			});
+		await afterResponseClosed();
+
+		expect(res.status).toBe(200);
+		const created = Object.keys(sessions);
+		expect(created).toHaveLength(1);
+		// onsessioninitialized seeds activeRequests: 1; the init request's
+		// res.on('close') -> markSessionIdle must decrement it back to 0
+		// rather than leaving the fresh session stuck at 1.
+		expect(sessions[created[0]].activeRequests).toBe(0);
+	});
+
+	it('balances activeRequests back to 0 after a GET to an existing session', async () => {
+		const app = express();
+		app.use(express.json());
+		const handleRequest = vi.fn(
+			async (_req: unknown, res: { status: (n: number) => { end: () => void } }) => {
+				res.status(204).end();
+			},
+		);
+		const transport = {
+			sessionId: 'sid-1',
+			handleRequest,
+		} as unknown as SessionRegistry[string]['transport'];
+		const sessions: SessionRegistry = { 'sid-1': { transport, activeRequests: 0 } };
+		app.get('/mcp', createSessionRequestHandler(sessions, 0));
+
+		const res = await request(app).get('/mcp').set('mcp-session-id', 'sid-1');
+		await afterResponseClosed();
+
+		expect(res.status).toBe(204);
+		// markSessionActive (+1) and res.on('close') -> markSessionIdle (-1)
+		// balanced out for the GET path too.
+		expect(sessions['sid-1'].activeRequests).toBe(0);
+	});
+
+	it('balances activeRequests back to 0 after a DELETE to an existing session', async () => {
+		const app = express();
+		app.use(express.json());
+		const handleRequest = vi.fn(
+			async (_req: unknown, res: { status: (n: number) => { end: () => void } }) => {
+				res.status(204).end();
+			},
+		);
+		const transport = {
+			sessionId: 'sid-1',
+			handleRequest,
+		} as unknown as SessionRegistry[string]['transport'];
+		const sessions: SessionRegistry = { 'sid-1': { transport, activeRequests: 0 } };
+		app.delete('/mcp', createSessionRequestHandler(sessions, 0));
+
+		const res = await request(app).delete('/mcp').set('mcp-session-id', 'sid-1');
+		await afterResponseClosed();
+
+		expect(res.status).toBe(204);
+		expect(sessions['sid-1'].activeRequests).toBe(0);
+	});
+});
+
 describe('createInFlightCounter', () => {
 	function buildApp(): Express {
 		const app = express();

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -37,10 +37,11 @@ import {
 	createMcpPostHandler,
 	createSessionRequestHandler,
 	extractBearerToken,
+	markSessionActive,
+	markSessionIdle,
 	payloadTooLargeHandler,
 	resolveMcpHostValidation,
 	type SessionRegistry,
-	touchSession,
 	withRequestContext,
 } from '../../src/transport/streamableHttp.js';
 import { getRuntimeToken, getSessionId } from '../../src/transport/requestContext.js';
@@ -174,6 +175,7 @@ describe('session request handler (GET/DELETE)', () => {
 		return {
 			'sid-1': {
 				transport: {} as unknown as SessionRegistry[string]['transport'],
+				activeRequests: 0,
 			},
 		};
 	}
@@ -248,6 +250,7 @@ describe('POST to an existing session (per-request bearer)', () => {
 		return {
 			'sid-1': {
 				transport: {} as unknown as SessionRegistry[string]['transport'],
+				activeRequests: 0,
 			},
 		};
 	}
@@ -462,7 +465,7 @@ describe('withRequestContext', () => {
 	});
 });
 
-describe('touchSession (idle expiry)', () => {
+describe('markSessionActive / markSessionIdle (idle expiry)', () => {
 	function sessionWithCloseSpy(): {
 		sessions: SessionRegistry;
 		close: ReturnType<typeof vi.fn>;
@@ -481,15 +484,29 @@ describe('touchSession (idle expiry)', () => {
 		transport.onclose = () => {
 			delete sessions['sid-1'];
 		};
-		sessions['sid-1'] = { transport };
+		sessions['sid-1'] = { transport, activeRequests: 0 };
 		return { sessions, close };
 	}
 
-	it('closes the session transport once the timeout window elapses', () => {
+	it('does not close while a request is active (no timer armed)', () => {
 		vi.useFakeTimers();
 		try {
 			const { sessions, close } = sessionWithCloseSpy();
-			touchSession(sessions, 'sid-1', 1000);
+			markSessionActive(sessions, 'sid-1');
+			expect(sessions['sid-1'].idleTimer).toBeUndefined();
+			vi.advanceTimersByTime(10_000);
+			expect(close).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('arms the idle timer once the request goes idle, then closes and removes the entry', () => {
+		vi.useFakeTimers();
+		try {
+			const { sessions, close } = sessionWithCloseSpy();
+			markSessionActive(sessions, 'sid-1');
+			markSessionIdle(sessions, 'sid-1', 1000);
 			expect(close).not.toHaveBeenCalled();
 			vi.advanceTimersByTime(1000);
 			expect(close).toHaveBeenCalledTimes(1);
@@ -499,27 +516,33 @@ describe('touchSession (idle expiry)', () => {
 		}
 	});
 
-	it('resets the idle timer on a subsequent touch', () => {
+	it('keeps the session alive while at least one request is still in-flight', () => {
 		vi.useFakeTimers();
 		try {
 			const { sessions, close } = sessionWithCloseSpy();
-			touchSession(sessions, 'sid-1', 1000);
-			vi.advanceTimersByTime(600);
-			touchSession(sessions, 'sid-1', 1000);
-			vi.advanceTimersByTime(600);
+			// Two concurrent requests (e.g. a held-open GET SSE stream plus a POST).
+			markSessionActive(sessions, 'sid-1');
+			markSessionActive(sessions, 'sid-1');
+			// First one finishes — still one in-flight, no timer.
+			markSessionIdle(sessions, 'sid-1', 1000);
+			expect(sessions['sid-1'].idleTimer).toBeUndefined();
+			vi.advanceTimersByTime(5000);
 			expect(close).not.toHaveBeenCalled();
-			vi.advanceTimersByTime(400);
+			// Second one finishes — now idle, timer arms and fires.
+			markSessionIdle(sessions, 'sid-1', 1000);
+			vi.advanceTimersByTime(1000);
 			expect(close).toHaveBeenCalledTimes(1);
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
-	it('never closes the session when the timeout is 0 (expiry disabled)', () => {
+	it('never arms a timer when the timeout is 0 (expiry disabled)', () => {
 		vi.useFakeTimers();
 		try {
 			const { sessions, close } = sessionWithCloseSpy();
-			touchSession(sessions, 'sid-1', 0);
+			markSessionActive(sessions, 'sid-1');
+			markSessionIdle(sessions, 'sid-1', 0);
 			expect(sessions['sid-1'].idleTimer).toBeUndefined();
 			vi.advanceTimersByTime(10_000_000);
 			expect(close).not.toHaveBeenCalled();
@@ -532,7 +555,8 @@ describe('touchSession (idle expiry)', () => {
 		vi.useFakeTimers();
 		try {
 			const { sessions } = sessionWithCloseSpy();
-			expect(() => touchSession(sessions, 'sid-unknown', 1000)).not.toThrow();
+			expect(() => markSessionActive(sessions, 'sid-unknown')).not.toThrow();
+			expect(() => markSessionIdle(sessions, 'sid-unknown', 1000)).not.toThrow();
 		} finally {
 			vi.useRealTimers();
 		}


### PR DESCRIPTION
## Summary

Makes the HTTP transport's OAuth surface aware of *every* configured wiki, not just the default one. Builds on per-call wiki targeting (#365) and per-wiki capability discovery (#366).

Previously the transport reasoned about `config.defaultWiki` alone: the `401` challenge was driven by the default wiki, the protected-resource document advertised a single authorization server, and a per-session bearer pin meant one MCP session could only ever carry one wiki's token. In a deployment of independent wikis with distinct OAuth authorization servers, a client had no standards-based way to discover the other wikis' ASes and could not span them within a session.

## What changed

- **Multi-AS protected-resource document.** `/.well-known/oauth-protected-resource` now advertises the authorization server of every OAuth-configured wiki. `scopes_supported` is the union; the endpoint `503`s only when *no* OAuth wiki's metadata resolves, still `404`s when no wiki uses OAuth.
- **All-wikis challenge policy.** The transport-level `401` + `WWW-Authenticate` challenge fires only when *every* configured wiki requires auth. A mixed deployment with a usable-without-token wiki lets a tokenless client connect.
- **Per-request bearer.** The per-session bearer pin is removed — each POST carries the token for that request's target wiki, so one session can carry per-wiki tokens for wikis on different authorization servers. The session id itself is the session capability (the MCP-spec-native model).
- **Idle session expiry.** An HTTP session with no activity for `MCP_SESSION_IDLE_TIMEOUT` seconds (default 1800; 0 disables) is closed and removed. Held-open SSE streams keep the session alive while connected.
- **Per-call OAuth guard.** A `tools/call` to an OAuth-only wiki on HTTP with no usable token now returns a clear `authentication` error naming the wiki and pointing at the discovery document, instead of a raw upstream failure.
- **`list-wikis` `authorizationServer` field.** Each OAuth wiki's entry reports its authorization-server issuer, restoring the wiki↔AS mapping that the flat `authorization_servers` array loses.

## New environment variable

`MCP_SESSION_IDLE_TIMEOUT` — HTTP session idle timeout in seconds (default `1800`, `0` disables). Documented in `README.md` and `server.json`.

## Testing

- Full suite green (1025 tests); lint, format, type-check, build all pass.
- Smoke-tested end-to-end against live HTTP servers: multi-AS document, mixed-vs-all-auth challenge policy, the `list-wikis` field, the per-call OAuth guard, idle expiry, and held-open streams surviving the idle window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)