### PR TITLE
Add get-links-here tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 
 - `move-page` tool that renames a wiki page (and, by default, its talk page), optionally moving subpages and suppressing the redirect left at the old title.
+- `get-links-here` tool that lists the pages referencing a target page — pages that link to it, embed it as a template, or display it as a file — including pages that reach it through a redirect.
 - `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server.
 - Optional `wiki` argument on every tool that operates on a wiki (all except the wiki-management and OAuth tools), naming the wiki that call acts on. Accepts a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI.
 - Tool responses now report the wiki the call ran against.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `compare-pages` | Diff two versions of a wiki page by revision, title, or supplied wikitext. |
 | `get-category-members` | List members of a category (up to 500 per call, paginated via `continueFrom`). |
 | `get-file` | Fetch a file page. |
+| `get-links-here` | List pages that reference a wiki page — pages that link to it, embed it as a template, or display it as a file (select via `type`), including pages that reach it through a redirect. Up to 500 per call, paginated via `continueFrom`. |
 | `get-page` | Fetch a wiki page. |
 | `get-page-history` | List recent revisions of a wiki page. |
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). |

--- a/src/tools/get-links-here.ts
+++ b/src/tools/get-links-here.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../runtime/tool.js';
+import type { ToolContext } from '../runtime/context.js';
+import type { TruncationInfo } from '../results/truncation.js';
+
+export enum LinkType {
+	wikilinks = 'wikilinks',
+	transclusions = 'transclusions',
+	fileusage = 'fileusage',
+}
+
+export enum RedirectFilter {
+	all = 'all',
+	redirects = 'redirects',
+	nonredirects = 'nonredirects',
+}
+
+// Each relationship maps to a MediaWiki list module, its parameter prefix, and
+// whether that module supports redirect expansion (embeddedin does not).
+const MODULES = {
+	[LinkType.wikilinks]: { list: 'backlinks', prefix: 'bl', canExpand: true },
+	[LinkType.transclusions]: { list: 'embeddedin', prefix: 'ei', canExpand: false },
+	[LinkType.fileusage]: { list: 'imageusage', prefix: 'iu', canExpand: true },
+} as const;
+
+// MediaWiki halves the per-level limit when redirect expansion is enabled, so a
+// requested 500 would exceed the ceiling. Clamp what we send in that case.
+const EXPANDED_LIMIT_CAP = 250;
+
+interface ApiLink {
+	pageid: number;
+	ns: number;
+	title: string;
+	redirect?: boolean;
+	redirlinks?: ApiLink[];
+}
+
+const inputSchema = {
+	title: z
+		.string()
+		.describe(
+			'Wiki page title to find references to (the link target). A File title when type is fileusage.',
+		),
+	type: z
+		.nativeEnum(LinkType)
+		.default(LinkType.wikilinks)
+		.describe(
+			'Inbound relationship to list: wikilinks (pages that link to the target), transclusions (pages that embed it), or fileusage (pages that display it)',
+		),
+	namespaces: z
+		.array(z.number().int().nonnegative())
+		.optional()
+		.describe('Namespace IDs to filter the referencing pages by'),
+	filter: z
+		.nativeEnum(RedirectFilter)
+		.default(RedirectFilter.all)
+		.describe('Filter the referencing pages by redirect status'),
+	expandRedirects: z
+		.boolean()
+		.default(true)
+		.describe(
+			'When a referencing page is a redirect to the target, also return the pages that link through it. Applies to wikilinks and fileusage only.',
+		),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(500)
+		.optional()
+		.describe('Maximum referencing pages to return (1..500)'),
+	continueFrom: z
+		.string()
+		.optional()
+		.describe('Opaque continuation token from the previous response; omit on first call'),
+} as const;
+
+export const getLinksHere: Tool<typeof inputSchema> = {
+	name: 'get-links-here',
+	description:
+		"Lists pages that reference a target wiki page, returning each referencing page's title, page ID, namespace ID, and whether it is a redirect. The type parameter selects the relationship — wikilinks (pages that link to the target), transclusions (pages that embed it, such as a template), or fileusage (pages that display it, for File pages) — one relationship per call. With expandRedirects, a referencing redirect also yields the pages that link through it (wikilinks and fileusage only), each tagged with the via redirect. Filter by namespace ID or by redirect status. For members of a category, use get-category-members; for full-text content search, use search-page. Returns up to 500 per call; paginate with continueFrom.",
+	inputSchema,
+	annotations: {
+		title: 'Get links here',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'retrieve links',
+	target: (a) => a.title,
+
+	async handle(
+		{ title, type, namespaces, filter, expandRedirects, limit, continueFrom },
+		ctx: ToolContext,
+	): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		const { list, prefix, canExpand } = MODULES[type];
+		const doExpand = canExpand && expandRedirects;
+
+		const params: Record<string, string | number | boolean> = {
+			action: 'query',
+			list,
+			[`${prefix}title`]: title,
+			formatversion: '2',
+		};
+		if (namespaces && namespaces.length > 0) {
+			params[`${prefix}namespace`] = namespaces.join('|');
+		}
+		if (filter !== RedirectFilter.all) {
+			params[`${prefix}filterredir`] = filter;
+		}
+		// With expansion on, MediaWiki halves the per-level cap to 250; clamp so a
+		// requested 500 doesn't get rejected.
+		const requested = limit ?? 500;
+		params[`${prefix}limit`] = doExpand ? Math.min(requested, EXPANDED_LIMIT_CAP) : requested;
+		if (doExpand) {
+			params[`${prefix}redirect`] = true;
+		}
+		if (continueFrom) {
+			params[`${prefix}continue`] = continueFrom;
+		}
+
+		const response = await mwn.request(params);
+		// A nonexistent target is a valid query (red links point to not-yet-created
+		// titles); the list modules return an empty array rather than erroring.
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		const raw: ApiLink[] = (response.query?.[list] ?? []) as ApiLink[];
+
+		// Flatten one level: each redirect entry's redirlinks become indirect
+		// entries tagged with the via redirect that mediates them. Transclusions
+		// never carry redirlinks, so this is a no-op there.
+		const links = raw.flatMap((entry) => {
+			const base = {
+				title: entry.title,
+				pageId: entry.pageid,
+				namespace: entry.ns,
+				redirect: entry.redirect ?? false,
+			};
+			const indirect = (entry.redirlinks ?? []).map((child) => ({
+				title: child.title,
+				pageId: child.pageid,
+				namespace: child.ns,
+				redirect: child.redirect ?? false,
+				via: entry.title,
+			}));
+			return [base, ...indirect];
+		});
+
+		const nextCursor: string | undefined = response.continue?.[`${prefix}continue`];
+		const truncation: TruncationInfo | null = nextCursor
+			? {
+					reason: 'more-available',
+					returnedCount: links.length,
+					itemNoun: 'links',
+					toolName: 'get-links-here',
+					continueWith: { param: 'continueFrom', value: nextCursor },
+				}
+			: null;
+
+		return ctx.format.ok({
+			links,
+			...(truncation !== null ? { truncation } : {}),
+		});
+	},
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { comparePages } from './compare-pages.js';
 import { getFile } from './get-file.js';
 import { getRevision } from './get-revision.js';
 import { getCategoryMembers } from './get-category-members.js';
+import { getLinksHere } from './get-links-here.js';
 import { listWikis } from './list-wikis.js';
 import { extensionPacks } from './extensions/index.js';
 import { createPage } from './create-page.js';
@@ -52,6 +53,7 @@ const standardTools: Tool<any>[] = [
 	getFile,
 	getRevision,
 	getCategoryMembers,
+	getLinksHere,
 	listWikis,
 	createPage,
 	updatePage,

--- a/tests/tools/get-links-here.test.ts
+++ b/tests/tools/get-links-here.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+import { getLinksHere, LinkType, RedirectFilter } from '../../src/tools/get-links-here.js';
+import { dispatch } from '../../src/runtime/dispatcher.js';
+import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
+
+// The SDK applies zod defaults in production; a direct handle() call does not,
+// and handle()'s arg type (zod output) makes defaulted fields required. This
+// helper supplies resolved defaults so each test overrides only what it tests.
+function args(
+	overrides: Partial<Parameters<typeof getLinksHere.handle>[0]> = {},
+): Parameters<typeof getLinksHere.handle>[0] {
+	return {
+		title: 'Foo',
+		type: LinkType.wikilinks,
+		filter: RedirectFilter.all,
+		expandRedirects: true,
+		...overrides,
+	} as Parameters<typeof getLinksHere.handle>[0];
+}
+
+describe('get-links-here', () => {
+	it('queries list=backlinks with bltitle for wikilinks', async () => {
+		const mock = createMockMwn({
+			request: vi
+				.fn()
+				.mockResolvedValue({ query: { backlinks: [{ pageid: 1, ns: 0, title: 'A' }] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ title: 'Target', expandRedirects: false }), ctx);
+
+		expect(mock.request.mock.calls[0][0]).toMatchObject({
+			action: 'query',
+			list: 'backlinks',
+			bltitle: 'Target',
+			formatversion: '2',
+		});
+	});
+
+	it('routes type=transclusions to list=embeddedin', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { embeddedin: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ title: 'Tmpl', type: LinkType.transclusions }), ctx);
+
+		expect(mock.request.mock.calls[0][0]).toMatchObject({ list: 'embeddedin', eititle: 'Tmpl' });
+	});
+
+	it('routes type=fileusage to list=imageusage', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { imageusage: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(
+			args({ title: 'File:Bar.png', type: LinkType.fileusage, expandRedirects: false }),
+			ctx,
+		);
+
+		expect(mock.request.mock.calls[0][0]).toMatchObject({
+			list: 'imageusage',
+			iutitle: 'File:Bar.png',
+		});
+	});
+
+	it('forwards namespaces and a non-all filter with the module prefix', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(
+			args({ namespaces: [0, 6], filter: RedirectFilter.redirects, expandRedirects: false }),
+			ctx,
+		);
+
+		expect(mock.request.mock.calls[0][0]).toMatchObject({
+			blnamespace: '0|6',
+			blfilterredir: 'redirects',
+		});
+	});
+
+	it('omits filterredir when filter is all', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ filter: RedirectFilter.all, expandRedirects: false }), ctx);
+
+		expect(mock.request.mock.calls[0][0]).not.toHaveProperty('blfilterredir');
+	});
+
+	it('flattens redirlinks into indirect entries tagged with via when expandRedirects is on', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: {
+					backlinks: [
+						{ pageid: 1, ns: 0, title: 'Direct' },
+						{
+							pageid: 2,
+							ns: 0,
+							title: 'Old Name',
+							redirect: true,
+							redirlinks: [{ pageid: 3, ns: 0, title: 'Via Old Name' }],
+						},
+					],
+				},
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getLinksHere.handle(args({ expandRedirects: true }), ctx);
+
+		expect(mock.request.mock.calls[0][0]).toMatchObject({ blredirect: true });
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('Title: Direct');
+		expect(text).toContain('Title: Old Name');
+		expect(text).toContain('Redirect: true');
+		expect(text).toContain('Title: Via Old Name');
+		expect(text).toContain('Via: Old Name');
+	});
+
+	it('sends no redirect param for transclusions and yields no indirect entries', async () => {
+		const mock = createMockMwn({
+			request: vi
+				.fn()
+				.mockResolvedValue({ query: { embeddedin: [{ pageid: 1, ns: 0, title: 'User:Bob' }] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getLinksHere.handle(
+			args({ type: LinkType.transclusions, expandRedirects: true }),
+			ctx,
+		);
+
+		expect(mock.request.mock.calls[0][0]).not.toHaveProperty('eiredirect');
+		const text = assertStructuredSuccess(result);
+		expect(text).not.toContain('Via:');
+	});
+
+	it('clamps the per-level limit to 250 when expandRedirects is on', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ limit: 500, expandRedirects: true }), ctx);
+
+		expect(mock.request.mock.calls[0][0].bllimit).toBe(250);
+	});
+
+	it('sends the full requested limit when expansion is off', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ limit: 500, expandRedirects: false }), ctx);
+
+		expect(mock.request.mock.calls[0][0].bllimit).toBe(500);
+	});
+
+	it('forwards continueFrom as the module continue param', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getLinksHere.handle(args({ continueFrom: '0|999', expandRedirects: false }), ctx);
+
+		expect(mock.request.mock.calls[0][0].blcontinue).toBe('0|999');
+	});
+
+	it('attaches a more-available truncation with the continueFrom cursor', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: { backlinks: [{ pageid: 1, ns: 0, title: 'A' }] },
+				continue: { blcontinue: '0|123' },
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getLinksHere.handle(args({ expandRedirects: false }), ctx);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('Truncation:');
+		expect(text).toContain('  Reason: more-available');
+		expect(text).toContain('  Item noun: links');
+		expect(text).toContain('  Tool name: get-links-here');
+		expect(text).toContain('    Param: continueFrom');
+		expect(text).toContain('    Value: 0|123');
+	});
+
+	it('returns an empty list without error when the target has no references', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { backlinks: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getLinksHere.handle(
+			args({ title: 'Nonexistent', expandRedirects: false }),
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).not.toContain('Truncation:');
+		expect(text).not.toContain('Title:');
+	});
+
+	it('surfaces upstream errors as isError via the dispatcher', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockRejectedValue(new Error('API boom')),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await dispatch(getLinksHere, ctx)(args());
+
+		const envelope = assertStructuredError(result, 'upstream_failure');
+		expect(envelope.message).toContain('API boom');
+	});
+});


### PR DESCRIPTION
## Summary

Adds a read-only `get-links-here` tool that lists the pages **referencing** a target wiki page — the inbound link graph — for impact analysis before a move/delete or a widely-used template edit.

- One tool, with a `type` parameter selecting the relationship (one per call): `wikilinks` (`list=backlinks`), `transclusions` (`list=embeddedin`), `fileusage` (`list=imageusage`). Modelled on `Special:WhatLinksHere` and mirrors `get-category-members`.
- `expandRedirects` (default on; wikilinks & fileusage only — `embeddedin` has no redirect expansion) flattens a referencing redirect's through-links into the result, each tagged with a `via` field naming the mediating redirect. One hop deep (matching MediaWiki).
- `namespaces` and `filter` (all / redirects / nonredirects) filters; 500/call with opaque `continueFrom` pagination. Per-level limit is clamped to 250 when expanding, since MediaWiki halves it.
- A non-existent target returns an empty list (red links are valid), not an error — a deliberate divergence from `get-page-history`.
- Updates `README.md` (Page reads table) and `CHANGELOG.md` (`[Unreleased]`).

## Test plan

- [x] **Unit tests** — `tests/tools/get-links-here.test.ts`, 13 cases covering type routing ×3, namespace/filter forwarding, `filter=all` suppression, redirect flatten + `via`, transclusions no-op (no `*redirect` param, no `via`), limit clamp both ways, `continueFrom` forwarding, truncation cursor, empty result, dispatcher error path. Full suite: **1053 passed**; `build` / `lint` / `fmt:check` clean.
- [x] **Live smoke test** (MCP Inspector CLI against en.wikipedia.org):
  - `wikilinks` / `transclusions` / `fileusage` each route to the correct module and return correctly-shaped, paginated results.
  - Redirect expansion verified deterministically — `get-links-here(title="United Kingdom", filter=redirects, expandRedirects=true)` surfaced 12 `via`-tagged indirect entries against real data.

## Review notes (minor, non-blocking)

A reviewer rated this *ready to merge* with two minor, optional nits left for discussion:
1. The description's "up to 500 per call" is slightly imprecise when `expandRedirects` is on (the top level is then 250 + flattened redirlinks). The sibling `get-category-members` uses the same flat phrasing.
2. `filter=nonredirects` + `expandRedirects=true` is a vacuous-but-harmless combination (nothing to expand once redirects are filtered out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)