### PR TITLE
Add get-site-info tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- `get-site-info` tool: returns a wiki's MediaWiki version, content language, title case-sensitivity, maximum page size, namespace map, installed extensions, and content license; optionally page/article/user/edit statistics.
 - `move-page` tool that renames a wiki page (and, by default, its talk page), optionally moving subpages and suppressing the redirect left at the old title.
 - `get-links-here` tool that lists the pages referencing a target page — pages that link to it, embed it as a template, or display it as a file — including pages that reach it through a redirect.
 - `list-wikis` tool reporting every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-pages` | Fetch multiple wiki pages in one call (up to 50). |
 | `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and hide flags (up to 50 per call, paginated via `continue`). |
 | `get-revision` | Fetch a specific revision of a page. |
+| `get-site-info` | Get a wiki's key settings: MediaWiki version, content language, title-case rules, namespaces, installed extensions, license, and (optionally) statistics. |
 | `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
 | `search-page` | Search wiki page titles and contents. |

--- a/src/tools/get-site-info.ts
+++ b/src/tools/get-site-info.ts
@@ -46,6 +46,32 @@ interface SiteInfoResponse {
 	};
 }
 
+interface Statistics {
+	pages: number;
+	articles: number;
+	edits: number;
+	images: number;
+	users: number;
+	activeusers: number;
+	admins: number;
+}
+
+interface StatisticsResponse {
+	query?: { statistics?: Partial<Statistics> };
+}
+
+function pickStatistics(raw: Partial<Statistics>): Statistics {
+	return {
+		pages: raw.pages ?? 0,
+		articles: raw.articles ?? 0,
+		edits: raw.edits ?? 0,
+		images: raw.images ?? 0,
+		users: raw.users ?? 0,
+		activeusers: raw.activeusers ?? 0,
+		admins: raw.admins ?? 0,
+	};
+}
+
 interface CompactGeneral {
 	sitename: string;
 	generator: string;
@@ -124,7 +150,7 @@ export const getSiteInfo: Tool<typeof inputSchema> = {
 	} as ToolAnnotations,
 	failureVerb: 'fetch site info',
 
-	async handle(_args: GetSiteInfoArgs, ctx: ToolContext): Promise<CallToolResult> {
+	async handle(args: GetSiteInfoArgs, ctx: ToolContext): Promise<CallToolResult> {
 		const { key } = ctx.activeWiki.get();
 		const mwn = await ctx.mwn();
 
@@ -158,6 +184,17 @@ export const getSiteInfo: Tool<typeof inputSchema> = {
 		};
 		if (siteInfo.license) {
 			result.license = siteInfo.license;
+		}
+
+		if (args.includeStatistics === true) {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+			const statsResponse = (await mwn.request({
+				action: 'query',
+				meta: 'siteinfo',
+				siprop: 'statistics',
+				formatversion: '2',
+			})) as StatisticsResponse;
+			result.statistics = pickStatistics(statsResponse.query?.statistics ?? {});
 		}
 
 		return ctx.format.ok(result);

--- a/src/tools/get-site-info.ts
+++ b/src/tools/get-site-info.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../runtime/tool.js';
+import type { ToolContext } from '../runtime/context.js';
+import { resolveSiteInfo } from '../wikis/siteInfo.js';
+
+const inputSchema = {
+	includeStatistics: z
+		.boolean()
+		.optional()
+		.describe(
+			'Also return live wiki statistics (page, article, edit, image, user, active-user, and admin counts). Defaults to false.',
+		),
+} as const;
+
+type GetSiteInfoArgs = z.infer<z.ZodObject<typeof inputSchema>>;
+
+interface RawGeneral {
+	sitename: string;
+	generator: string;
+	lang: string;
+	case: string;
+	readonly: boolean;
+	readonlyreason?: string;
+	maxarticlesize: number;
+}
+
+interface RawNamespace {
+	id: number;
+	name: string;
+	canonical?: string;
+	case?: string;
+	content?: boolean;
+}
+
+interface RawNamespaceAlias {
+	id: number;
+	alias: string;
+}
+
+interface SiteInfoResponse {
+	query?: {
+		general?: RawGeneral;
+		namespaces?: Record<string, RawNamespace>;
+		namespacealiases?: RawNamespaceAlias[];
+	};
+}
+
+interface CompactGeneral {
+	sitename: string;
+	generator: string;
+	lang: string;
+	case: string;
+	readonly: boolean;
+	readonlyreason?: string;
+	maxarticlesize: number;
+}
+
+interface CompactNamespace {
+	canonical: string;
+	name: string;
+	aliases?: string[];
+	content?: boolean;
+	case?: string;
+}
+
+function buildGeneral(g: RawGeneral): CompactGeneral {
+	const general: CompactGeneral = {
+		sitename: g.sitename,
+		generator: g.generator,
+		lang: g.lang,
+		case: g.case,
+		readonly: g.readonly,
+		maxarticlesize: g.maxarticlesize,
+	};
+	if (g.readonly && typeof g.readonlyreason === 'string') {
+		general.readonlyreason = g.readonlyreason;
+	}
+	return general;
+}
+
+function buildNamespaces(
+	namespaces: Record<string, RawNamespace>,
+	aliases: RawNamespaceAlias[],
+	defaultCase: string,
+): Record<string, CompactNamespace> {
+	const aliasesById = new Map<number, string[]>();
+	for (const a of aliases) {
+		const list = aliasesById.get(a.id) ?? [];
+		list.push(a.alias);
+		aliasesById.set(a.id, list);
+	}
+
+	const out: Record<string, CompactNamespace> = {};
+	for (const key of Object.keys(namespaces)) {
+		const ns = namespaces[key];
+		const entry: CompactNamespace = { canonical: ns.canonical ?? '', name: ns.name };
+		const nsAliases = aliasesById.get(ns.id);
+		if (nsAliases && nsAliases.length > 0) {
+			entry.aliases = nsAliases;
+		}
+		if (ns.content === true) {
+			entry.content = true;
+		}
+		if (typeof ns.case === 'string' && ns.case !== defaultCase) {
+			entry.case = ns.case;
+		}
+		out[key] = entry;
+	}
+	return out;
+}
+
+export const getSiteInfo: Tool<typeof inputSchema> = {
+	name: 'get-site-info',
+	description:
+		'Returns key facts about the targeted wiki from its MediaWiki siteinfo: general settings (sitename, MediaWiki version, content language, page-title case-sensitivity, live read-only state, and maxarticlesize in bytes), the namespace map with localized names and aliases, the list of installed extension names, and the content license. Set includeStatistics to also return page, article, edit, image, user, active-user, and admin counts.',
+	inputSchema,
+	annotations: {
+		title: 'Get site info',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'fetch site info',
+
+	async handle(_args: GetSiteInfoArgs, ctx: ToolContext): Promise<CallToolResult> {
+		const { key } = ctx.activeWiki.get();
+		const mwn = await ctx.mwn();
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		const response = (await mwn.request({
+			action: 'query',
+			meta: 'siteinfo',
+			siprop: 'general|namespaces|namespacealiases',
+			formatversion: '2',
+		})) as SiteInfoResponse;
+
+		const query = response.query ?? {};
+		const rawGeneral = query.general;
+		if (!rawGeneral) {
+			throw new Error('siteinfo response did not include general data');
+		}
+		const general = buildGeneral(rawGeneral);
+		const namespaces = buildNamespaces(
+			query.namespaces ?? {},
+			query.namespacealiases ?? [],
+			general.case,
+		);
+
+		const { extensions } = await ctx.extensions.inspect(key);
+		const siteInfo = await resolveSiteInfo(ctx, key);
+
+		const result: Record<string, unknown> = {
+			general,
+			namespaces,
+			extensions: [...extensions].sort(),
+		};
+		if (siteInfo.license) {
+			result.license = siteInfo.license;
+		}
+
+		return ctx.format.ok(result);
+	},
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { parseWikitext } from './parse-wikitext.js';
 import { comparePages } from './compare-pages.js';
 import { getFile } from './get-file.js';
 import { getRevision } from './get-revision.js';
+import { getSiteInfo } from './get-site-info.js';
 import { getCategoryMembers } from './get-category-members.js';
 import { getLinksHere } from './get-links-here.js';
 import { listWikis } from './list-wikis.js';
@@ -52,6 +53,7 @@ const standardTools: Tool<any>[] = [
 	comparePages,
 	getFile,
 	getRevision,
+	getSiteInfo,
 	getCategoryMembers,
 	getLinksHere,
 	listWikis,

--- a/tests/helpers/structuredResult.ts
+++ b/tests/helpers/structuredResult.ts
@@ -16,6 +16,14 @@ export function assertStructuredSuccess(result: CallToolResult): string {
 	return (result.content![0] as TextContent).text;
 }
 
+// oxlint-disable-next-line typescript/no-explicit-any -- structured payload shape is verified at runtime; any is intentional for test ergonomics
+export function assertStructuredData(result: CallToolResult): Record<string, any> {
+	expect(result.isError).toBeFalsy();
+	expect(result.structuredContent).toBeDefined();
+	// oxlint-disable-next-line typescript/no-explicit-any -- same rationale as return type
+	return result.structuredContent as Record<string, any>;
+}
+
 export function assertStructuredError(
 	result: CallToolResult,
 	category: ErrorEnvelope['category'],

--- a/tests/tools/get-site-info.test.ts
+++ b/tests/tools/get-site-info.test.ts
@@ -3,7 +3,7 @@ import { getSiteInfo } from '../../src/tools/get-site-info.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { createMockMwn } from '../helpers/mock-mwn.js';
 import { dispatch } from '../../src/runtime/dispatcher.js';
-import { assertStructuredData } from '../helpers/structuredResult.js';
+import { assertStructuredData, assertStructuredError } from '../helpers/structuredResult.js';
 import type { LicenseInfo } from '../../src/wikis/siteInfoCache.js';
 
 function siteinfoResponse(generalOverrides: Record<string, unknown> = {}) {
@@ -29,7 +29,7 @@ function siteinfoResponse(generalOverrides: Record<string, unknown> = {}) {
 
 function ctxWith(
 	request: ReturnType<typeof vi.fn>,
-	opts: { extensions?: Set<string>; license?: LicenseInfo } = {},
+	opts: { extensions?: Set<string>; license?: LicenseInfo; reachable?: boolean } = {},
 ) {
 	const mwn = createMockMwn({ request });
 	return fakeContext({
@@ -48,7 +48,7 @@ function ctxWith(
 			has: (async () => false) as never,
 			hasAny: (async () => false) as never,
 			inspect: (async () => ({
-				reachable: true,
+				reachable: opts.reachable ?? true,
 				extensions: opts.extensions ?? new Set<string>(),
 			})) as never,
 			invalidate: (() => {}) as never,
@@ -183,5 +183,23 @@ describe('get-site-info', () => {
 		});
 		expect(request).toHaveBeenCalledTimes(2);
 		expect(request.mock.calls[1][0].siprop).toBe('statistics');
+	});
+
+	it('fails with upstream_failure when the siteinfo response lacks general data', async () => {
+		const request = vi.fn().mockResolvedValue({ query: {} });
+		const ctx = ctxWith(request);
+
+		const result = await dispatch(getSiteInfo, ctx)({} as never);
+
+		assertStructuredError(result, 'upstream_failure');
+	});
+
+	it('returns empty extensions when the wiki is unreachable for extension probing', async () => {
+		const request = vi.fn().mockResolvedValue(siteinfoResponse());
+		const ctx = ctxWith(request, { reachable: false });
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.extensions).toEqual([]);
 	});
 });

--- a/tests/tools/get-site-info.test.ts
+++ b/tests/tools/get-site-info.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getSiteInfo } from '../../src/tools/get-site-info.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+import { dispatch } from '../../src/runtime/dispatcher.js';
+import { assertStructuredData } from '../helpers/structuredResult.js';
+import type { LicenseInfo } from '../../src/wikis/siteInfoCache.js';
+
+function siteinfoResponse(generalOverrides: Record<string, unknown> = {}) {
+	return {
+		query: {
+			general: {
+				sitename: 'Example',
+				generator: 'MediaWiki 1.43.0',
+				lang: 'en',
+				case: 'first-letter',
+				readonly: false,
+				maxarticlesize: 2097152,
+				...generalOverrides,
+			},
+			namespaces: {
+				0: { id: 0, name: '', canonical: '', case: 'first-letter', content: true },
+				10: { id: 10, name: 'Template', canonical: 'Template', case: 'first-letter' },
+			},
+			namespacealiases: [{ id: 10, alias: 'T' }],
+		},
+	};
+}
+
+function ctxWith(
+	request: ReturnType<typeof vi.fn>,
+	opts: { extensions?: Set<string>; license?: LicenseInfo } = {},
+) {
+	const mwn = createMockMwn({ request });
+	return fakeContext({
+		mwn: () => Promise.resolve(mwn as never),
+		// Pre-populate so resolveSiteInfo short-circuits (issues no extra request).
+		siteInfoCache: {
+			get: () => ({
+				server: 'https://example',
+				articlepath: '/wiki',
+				...(opts.license ? { license: opts.license } : {}),
+			}),
+			set: () => {},
+			delete: () => {},
+		},
+		extensions: {
+			has: (async () => false) as never,
+			hasAny: (async () => false) as never,
+			inspect: (async () => ({
+				reachable: true,
+				extensions: opts.extensions ?? new Set<string>(),
+			})) as never,
+			invalidate: (() => {}) as never,
+		},
+	});
+}
+
+describe('get-site-info', () => {
+	it('returns the curated static set', async () => {
+		const request = vi.fn().mockResolvedValue(siteinfoResponse());
+		const ctx = ctxWith(request, {
+			extensions: new Set(['VisualEditor', 'Cargo']),
+			license: { url: 'https://x/license', title: 'CC BY-SA 4.0' },
+		});
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.general).toEqual({
+			sitename: 'Example',
+			generator: 'MediaWiki 1.43.0',
+			lang: 'en',
+			case: 'first-letter',
+			readonly: false,
+			maxarticlesize: 2097152,
+		});
+		expect(data.extensions).toEqual(['Cargo', 'VisualEditor']);
+		expect(data.license).toEqual({ url: 'https://x/license', title: 'CC BY-SA 4.0' });
+	});
+
+	it('compacts namespaces: aliases attached, default content/case omitted', async () => {
+		const request = vi.fn().mockResolvedValue(siteinfoResponse());
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.namespaces['0']).toEqual({ canonical: '', name: '', content: true });
+		expect(data.namespaces['10']).toEqual({
+			canonical: 'Template',
+			name: 'Template',
+			aliases: ['T'],
+		});
+	});
+
+	it('keeps namespace case only when it differs from general.case', async () => {
+		const resp = siteinfoResponse();
+		resp.query.namespaces[10].case = 'case-sensitive';
+		const request = vi.fn().mockResolvedValue(resp);
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.namespaces['10'].case).toBe('case-sensitive');
+	});
+
+	it('includes readonlyreason only when readonly', async () => {
+		const request = vi
+			.fn()
+			.mockResolvedValue(siteinfoResponse({ readonly: true, readonlyreason: 'maintenance' }));
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.general.readonly).toBe(true);
+		expect(data.general.readonlyreason).toBe('maintenance');
+	});
+
+	it('omits license when resolveSiteInfo returns none', async () => {
+		const request = vi.fn().mockResolvedValue(siteinfoResponse());
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.license).toBeUndefined();
+	});
+
+	it('accumulates multiple aliases for the same namespace id', async () => {
+		const resp = siteinfoResponse();
+		resp.query.namespacealiases = [
+			{ id: 10, alias: 'T' },
+			{ id: 10, alias: 'Tpl' },
+		];
+		const request = vi.fn().mockResolvedValue(resp);
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.namespaces['10'].aliases).toEqual(['T', 'Tpl']);
+	});
+});

--- a/tests/tools/get-site-info.test.ts
+++ b/tests/tools/get-site-info.test.ts
@@ -137,4 +137,51 @@ describe('get-site-info', () => {
 
 		expect(data.namespaces['10'].aliases).toEqual(['T', 'Tpl']);
 	});
+
+	it('omits statistics by default and makes one siteinfo request', async () => {
+		const request = vi.fn().mockResolvedValue(siteinfoResponse());
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(getSiteInfo, ctx)({} as never));
+
+		expect(data.statistics).toBeUndefined();
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(request.mock.calls[0][0].siprop).not.toContain('statistics');
+	});
+
+	it('fetches statistics live when includeStatistics is true', async () => {
+		const request = vi
+			.fn()
+			.mockResolvedValueOnce(siteinfoResponse())
+			.mockResolvedValueOnce({
+				query: {
+					statistics: {
+						pages: 10,
+						articles: 4,
+						edits: 99,
+						images: 2,
+						users: 7,
+						activeusers: 3,
+						admins: 1,
+					},
+				},
+			});
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(
+			await dispatch(getSiteInfo, ctx)({ includeStatistics: true } as never),
+		);
+
+		expect(data.statistics).toEqual({
+			pages: 10,
+			articles: 4,
+			edits: 99,
+			images: 2,
+			users: 7,
+			activeusers: 3,
+			admins: 1,
+		});
+		expect(request).toHaveBeenCalledTimes(2);
+		expect(request.mock.calls[1][0].siprop).toBe('statistics');
+	});
 });


### PR DESCRIPTION
## Summary

Adds a read-only `get-site-info` MCP tool that returns a curated, agent-correctness subset of a wiki's MediaWiki `meta=siteinfo`:

- **`general`** — sitename, MediaWiki version, content language, page-title case-sensitivity, live read-only state (with reason when set), and `maxarticlesize` (bytes).
- **`namespaces`** — compact per-id map: canonical + localized name, aliases, and `content`/`case` only when they carry non-default information.
- **`extensions`** — installed extension names (reusing the existing per-wiki extension probe).
- **`license`** — content license, reusing `resolveSiteInfo`.
- **`statistics`** — opt-in via `includeStatistics`; fetched in a separate request so the static payload stays cacheable.

The data was already fetched-and-discarded internally; this exposes the parts an agent needs to construct valid titles/namespaces and reason about capabilities, without dumping the full siteinfo blob.

Per repo policy, the README tool table and CHANGELOG `[Unreleased]` are updated.

## Test Plan

- [x] `npm test` — full suite green (1077 passing)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Unit tests cover: curated static set; namespace compaction (aliases, default content/case omission, differing case, multi-alias accumulation); `readonlyreason` only when readonly; license present/absent; statistics opt-in vs default request count; missing-`general` → `upstream_failure`; unreachable wiki → empty extensions