### PR TITLE
Hide list-wikis tool in single-wiki setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- The `list-wikis` tool is now hidden when only a single wiki is configured, where it has nothing to list and every call already defaults to that wiki. It appears once a second wiki is configured or added.
+
 ## [0.10.0] - 2026-05-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-recent-changes` | List recent change events across the wiki, filterable by timestamp, namespace, user, tag, type, and hide flags (up to 50 per call, paginated via `continue`). |
 | `get-revision` | Fetch a specific revision of a page. |
 | `get-site-info` | Get a wiki's key settings: MediaWiki version, content language, title-case rules, namespaces, installed extensions, license, and (optionally) statistics. |
-| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. |
+| `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. Disabled when fewer than two wikis are configured. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
 | `search-page` | Search wiki page titles and contents. |
 | `search-page-by-prefix` | Search page titles by prefix. |

--- a/src/runtime/reconcile.ts
+++ b/src/runtime/reconcile.ts
@@ -54,6 +54,13 @@ const STATIC_RULES: readonly ToolGatingRule[] = [
 		affects: ['remove-wiki'],
 		isAllowed: (c) => c.allowManagement && c.wikiCount >= 2,
 	},
+	{
+		// Nothing to list when a single wiki is configured: every call defaults
+		// to it. Offered once a second wiki appears (reconcile re-runs on add).
+		name: 'list-wikis',
+		affects: ['list-wikis'],
+		isAllowed: (c) => c.wikiCount >= 2,
+	},
 ];
 
 function buildExtensionRules(packs: readonly ExtensionPack[]): readonly ToolGatingRule[] {

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -62,8 +62,8 @@ export async function checkWikiCapability(
 					'authentication',
 					`Wiki "${wikiKey}" requires OAuth authentication. ` +
 						"Send an Authorization: Bearer token for this wiki; see the server's " +
-						'/.well-known/oauth-protected-resource document, or list-wikis for the ' +
-						"wiki's authorization server.",
+						"/.well-known/oauth-protected-resource document for the wiki's " +
+						'authorization server.',
 				);
 			}
 		}

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -21,7 +21,7 @@ const WRITE_TOOL_NAMES = [
 ];
 
 const NON_WRITE_TOOL_NAMES = ['get-page', 'search-page'];
-const WIKI_SET_TOOL_NAMES = ['add-wiki', 'remove-wiki'];
+const WIKI_SET_TOOL_NAMES = ['add-wiki', 'remove-wiki', 'list-wikis'];
 const STDIO_ONLY_TOOL_NAMES = ['oauth-status', 'oauth-logout'];
 
 interface MockTool {
@@ -386,6 +386,116 @@ describe('reconcileTools — applyWikiSetRule', () => {
 			extensionPacks: ALL_PACKS,
 		});
 		expect(mocks.get('remove-wiki')!.enabled).toBe(false);
+	});
+});
+
+describe('reconcileTools — applyListWikisRule', () => {
+	it('disables list-wikis when only one wiki is configured', async () => {
+		const { tools, mocks } = makeToolMap(true);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki },
+			allowManagement: false,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.disable).toHaveBeenCalledTimes(1);
+		expect(mocks.get('list-wikis')!.enable).not.toHaveBeenCalled();
+	});
+
+	it('keeps list-wikis disabled with one wiki even when management is allowed', async () => {
+		const { tools, mocks } = makeToolMap(true);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.disable).toHaveBeenCalledTimes(1);
+	});
+
+	it('enables list-wikis when two or more wikis are configured, regardless of management', async () => {
+		const { tools, mocks } = makeToolMap(false);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki, b: baseWiki },
+			allowManagement: false,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.enable).toHaveBeenCalledTimes(1);
+		expect(mocks.get('list-wikis')!.disable).not.toHaveBeenCalled();
+	});
+
+	it('transitions: count 1 to 2 enables list-wikis', async () => {
+		const { tools, mocks } = makeToolMap(false);
+		const m1 = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: m1.registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.enabled).toBe(false);
+
+		const m2 = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki, b: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: m2.registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.enabled).toBe(true);
+	});
+
+	it('transitions: count 2 to 1 disables list-wikis', async () => {
+		const { tools, mocks } = makeToolMap(true);
+		const m1 = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki, b: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: m1.registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.enabled).toBe(true);
+
+		const m2 = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: m2.registry,
+			transport: 'stdio',
+			extensions: makeFakeDetector(),
+			extensionPacks: ALL_PACKS,
+		});
+		expect(mocks.get('list-wikis')!.enabled).toBe(false);
 	});
 });
 


### PR DESCRIPTION
Fixes #384.

## Problem

In a single-wiki deployment (the Docker quick-start config), the `list-wikis` tool was still offered, even though it has nothing useful to list — every call already defaults to the one configured wiki. That spends tokens on an unusable tool. As the reporter noted, the old `set-wiki` tool was hidden in the same situation.

## Change

- Gate `list-wikis` on two or more configured wikis (`src/runtime/reconcile.ts`), mirroring the historical `set-wiki` gating. Reconcile re-runs on add/remove-wiki, so the tool appears the moment a second wiki is configured and disappears when the count drops back to one.
- Drop the now-misleading `list-wikis` pointer from the OAuth-required error message (`src/runtime/wikiCapability.ts`): that message fires on HTTP for a single OAuth-only wiki — exactly the case where `list-wikis` is now hidden. The always-served `/.well-known/oauth-protected-resource` document remains as the discovery path.
- Updated the README tool table and CHANGELOG.

## Testing

- New `applyListWikisRule` cases covering count = 1 (management on and off), count ≥ 2, and both the 1→2 and 2→1 transitions.
- Full suite: 1082 tests pass; lint, format, and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)