### PR TITLE
Lengthen exec-secret timeout and signpost retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 
 - The `list-wikis` tool is now hidden when only a single wiki is configured, where it has nothing to list and every call already defaults to that wiki. It appears once a second wiki is configured or added.
+- The timeout for an `exec`-backed credential command was raised from 10 to 30 seconds, giving an interactive unlock (such as a 1Password prompt) time to be approved. If the command still times out, the error now explains that approving the prompt and retrying re-runs it.
 
 ## [0.10.0] - 2026-05-30
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,9 +79,9 @@ Secret fields can also run an external command and use its output as the secret.
 }
 ```
 
-The command runs the first time that wiki is used — not at startup — directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 10-second timeout applies, and the result is cached for the lifetime of the server process.
+The command runs the first time that wiki is used — not at startup — directly without a shell, with `args` passed exactly as given. Its trimmed stdout becomes the secret value. A 30-second timeout applies — long enough for an interactive unlock such as a 1Password prompt — and the result is cached for the lifetime of the server process.
 
-If the command fails, times out, or prints nothing, the wiki cannot be used and tool calls against it return an authentication error identifying the wiki and field. Other wikis, and server startup, are unaffected. The secret value itself is never logged.
+If the command fails, times out, or prints nothing, the wiki cannot be used and tool calls against it return an authentication error identifying the wiki and field. Other wikis, and server startup, are unaffected. When a timeout was caused by a slow interactive unlock, approve the prompt and retry — the command re-runs on the next call against that wiki. The secret value itself is never logged.
 
 Any CLI that prints a credential to stdout works: 1Password's `op`, `pass`, `secret-tool`, Bitwarden's `bw`, HashiCorp Vault, or a custom script.
 

--- a/src/wikis/execSecret.ts
+++ b/src/wikis/execSecret.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import type { ExecSecret } from '../config/loadConfig.js';
 import { CredentialResolutionError } from '../errors/credentialResolutionError.js';
 
-const TIMEOUT_MS = 10_000;
+const TIMEOUT_MS = 30_000;
 const STDERR_LIMIT = 200;
 
 function failureMessage(err: unknown, stderr: string, command: string, descriptor: string): string {
@@ -15,7 +15,7 @@ function failureMessage(err: unknown, stderr: string, command: string, descripto
 			return `Could not resolve ${descriptor}: command "${command}" not found`;
 		}
 		if (killed === true || signal === 'SIGTERM' || code === 'ETIMEDOUT') {
-			return `Could not resolve ${descriptor}: command "${command}" timed out after 10s`;
+			return `Could not resolve ${descriptor}: command "${command}" timed out after ${TIMEOUT_MS / 1000}s. If it prompts for interactive approval (e.g. a 1Password unlock), approve the prompt and retry — the command re-runs on the next attempt.`;
 		}
 		if (typeof code === 'number' && code !== 0) {
 			return `Could not resolve ${descriptor}: command "${command}" exited with status ${code}. stderr: ${stderr.slice(0, STDERR_LIMIT)}`;

--- a/tests/wikis/execSecret.test.ts
+++ b/tests/wikis/execSecret.test.ts
@@ -63,7 +63,19 @@ describe('runExecSecret', () => {
 		});
 		await expect(
 			runExecSecret({ exec: { command: 'slow', args: [] } }, descriptor),
-		).rejects.toThrow('timed out after 10s');
+		).rejects.toThrow('timed out after 30s');
+	});
+
+	it('tells the caller to approve and retry on timeout', async () => {
+		mockExecFile((cb) => {
+			const e = new Error('timed out') as Error & { killed?: boolean; signal?: string };
+			e.killed = true;
+			e.signal = 'SIGTERM';
+			cb(e, '', '');
+		});
+		await expect(
+			runExecSecret({ exec: { command: 'slow', args: [] } }, descriptor),
+		).rejects.toThrow('approve the prompt and retry');
 	});
 
 	it('throws CredentialResolutionError on non-zero exit with truncated stderr', async () => {


### PR DESCRIPTION
## Problem

A wiki credential backed by `{ "exec": { "command": "op", ... } }` is resolved lazily on the first authenticated tool call, which can trigger an interactive 1Password unlock. The previous **10-second** timeout was too short for a human to notice and approve the prompt, so the first auth'd call failed with `command "op" timed out after 10s`. The opaque error gave no hint that simply retrying — after approving the prompt — would work, so it tended to escalate to a full MCP server reconnect.

## Fix

- Raise the exec-secret command timeout from **10s → 30s** (`src/wikis/execSecret.ts`), giving an interactive unlock time to be approved.
- Reword the timeout error to signpost the recovery: *approve the prompt and retry — the command re-runs on the next attempt.* The server already evicts a failed credential resolution (`src/wikis/mwnProvider.ts`), so a retry after approval re-runs the command and succeeds — no reconnect needed.
- The seconds in the message are derived from the timeout constant, so they can't drift from it.

Hardcoded deliberately — no config knob or env var. The "right" timeout for an interactive unlock is effectively unbounded (it includes human reaction time), so the value can't be tuned to correctness; the retry signpost is what makes it reliable. A per-secret `timeoutMs` could be added later if a mixed-backend use case appears — that's a backward-compatible addition, so deferring costs nothing.

## Tests / smoke

- TDD: updated `tests/wikis/execSecret.test.ts` for the new duration and added a signpost assertion (watched both fail before changing the code). Full suite: **1083 passing**.
- Smoke: `npm run build` (tsgo) clean; exercised the compiled `runExecSecret` directly — success path returns the secret, failure path returns the expected "not found" error.

## Docs

- `docs/configuration.md`: 30s, plus a note that a timed-out interactive unlock can be approved and retried.
- `CHANGELOG.md`: entry under `[Unreleased] / Changed`.

Not a new tool or env var, so no README / `server.json` changes.

## Review notes (minor, non-blocking)

Code review flagged two cosmetic items, left as-is: the two timeout tests share identical setup (could consolidate into one), and `TIMEOUT_MS / 1000` would render a fraction if the constant ever became a non-multiple of 1000 (`30_000` is exact today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
