### PR TITLE
Add get-file-data tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`; non-image files error and point to `get-file`.
+- `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`. Images and files MediaWiki can rasterize (SVG, PDF, DjVu) come back as an image; non-renderable types (audio, video, binaries) error and point to `get-file`.
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`; non-image files error and point to `get-file`.
+- `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
+
 ### Changed
 
 - The `list-wikis` tool is now hidden when only a single wiki is configured, where it has nothing to list and every call already defaults to that wiki. It appears once a second wiki is configured or added.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `compare-pages` | Diff two versions of a wiki page by revision, title, or supplied wikitext. |
 | `get-category-members` | List members of a category (up to 500 per call, paginated via `continueFrom`). |
 | `get-file` | Fetch a file page. |
-| `get-file-data` | Fetch a file's image bytes inline (base64) for visual analysis — for clients that can't reach the wiki host. Returns a scaled rendition (set `width`); non-image types error. For metadata or a download URL, use `get-file`. |
+| `get-file-data` | Fetch a file's image bytes inline (base64) for visual analysis — for clients that can't reach the wiki host. Returns a scaled rendition (set `width`); non-renderable types (audio, video, binaries) error. For metadata or a download URL, use `get-file`. |
 | `get-links-here` | List pages that reference a wiki page — pages that link to it, embed it as a template, or display it as a file (select via `type`), including pages that reach it through a redirect. Up to 500 per call, paginated via `continueFrom`. |
 | `get-page` | Fetch a wiki page. |
 | `get-page-history` | List recent revisions of a wiki page. |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `compare-pages` | Diff two versions of a wiki page by revision, title, or supplied wikitext. |
 | `get-category-members` | List members of a category (up to 500 per call, paginated via `continueFrom`). |
 | `get-file` | Fetch a file page. |
+| `get-file-data` | Fetch a file's image bytes inline (base64) for visual analysis — for clients that can't reach the wiki host. Returns a scaled rendition (set `width`); non-image types error. For metadata or a download URL, use `get-file`. |
 | `get-links-here` | List pages that reference a wiki page — pages that link to it, embed it as a template, or display it as a file (select via `type`), including pages that reach it through a redirect. Up to 500 per call, paginated via `continueFrom`. |
 | `get-page` | Fetch a wiki page. |
 | `get-page-history` | List recent revisions of a wiki page. |
@@ -95,6 +96,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `CONFIG` | Path to your configuration file | `config.json` |
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. See [docs/deployment.md — Shape 2](docs/deployment.md#shape-2--single-wiki-per-user-oauth2-bearer-passthrough). | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs). Tune to the target LLM client's tool-response budget. | `50000` |
+| `MCP_FILE_DATA_MAX_BYTES` | Hard cap on the base64-encoded size of a `get-file-data` response. A transport/safety backstop; tune the actual size per call with the tool's `width`. Over-cap calls error rather than truncate. | `1000000` |
 | `MCP_LOG_LEVEL` | Minimum severity for logger output. One of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, or `silent`. | `debug` |
 | `MCP_OAUTH_CREDENTIALS_FILE` | Override the default credentials store path. Default: `~/.config/mediawiki-mcp/credentials.json` (Linux/macOS) or `%APPDATA%\mediawiki-mcp\credentials.json` (Windows). | `unset` |
 | `MCP_OAUTH_NO_BROWSER` | Set to `1` to skip launching a browser during the OAuth flow; the auth URL is logged to stderr instead. Useful in headless environments. | `unset` |

--- a/server.json
+++ b/server.json
@@ -34,6 +34,12 @@
           "default": "50000"
         },
         {
+          "name": "MCP_FILE_DATA_MAX_BYTES",
+          "description": "Hard cap on the base64-encoded size of a get-file-data response. A transport/safety backstop; callers tune actual size with the tool's width parameter. Over-cap responses error rather than truncate.",
+          "format": "number",
+          "default": "1000000"
+        },
+        {
           "name": "MCP_LOG_LEVEL",
           "description": "Minimum severity for logger output (stderr telemetry and sendLoggingMessage broadcast). Invalid values fail loudly on first log call.",
           "choices": [
@@ -124,6 +130,12 @@
           "description": "Byte cap for content bodies (wikitext, rendered HTML, diffs) returned by get-page, get-pages, parse-wikitext, and compare-pages. Oversized bodies are truncated with a trailing marker.",
           "format": "number",
           "default": "50000"
+        },
+        {
+          "name": "MCP_FILE_DATA_MAX_BYTES",
+          "description": "Hard cap on the base64-encoded size of a get-file-data response. A transport/safety backstop; callers tune actual size with the tool's width parameter. Over-cap responses error rather than truncate.",
+          "format": "number",
+          "default": "1000000"
         },
         {
           "name": "MCP_LOG_LEVEL",

--- a/src/tools/get-file-data.ts
+++ b/src/tools/get-file-data.ts
@@ -60,7 +60,7 @@ export const getFileData: Tool<typeof inputSchema> = {
 		idempotentHint: true,
 		openWorldHint: true,
 	} as ToolAnnotations,
-	failureVerb: 'retrieve file data',
+	failureVerb: 'fetch the file image',
 	target: (a) => a.title,
 
 	async handle({ title, width, format }, ctx: ToolContext): Promise<CallToolResult> {
@@ -121,11 +121,31 @@ export const getFileData: Tool<typeof inputSchema> = {
 		// maxRedirects caps the hop COUNT only; it does NOT address-validate redirect
 		// targets. Accepted for v1 given the wiki-derived URL; a host-scoped guard
 		// relaxation is a documented future hardening.
+		//
+		// rawRequest skips mwn.applyAuthentication, so the OAuth2 bearer is injected
+		// manually — but only when the file is same-origin as the wiki API, so the
+		// token is never leaked to a different-host file host (e.g. a foreign-repo
+		// CDN). Bot-password cookies flow via mwn's axios interceptor regardless.
+		const fetchHeaders: Record<string, string> = {};
+		if (
+			mwn.usingOAuth2 &&
+			typeof mwn.options.OAuth2AccessToken === 'string' &&
+			typeof mwn.options.apiUrl === 'string'
+		) {
+			try {
+				if (new URL(fetchUrl).origin === new URL(mwn.options.apiUrl).origin) {
+					fetchHeaders.Authorization = `Bearer ${mwn.options.OAuth2AccessToken}`;
+				}
+			} catch {
+				// Unparseable URL — skip bearer injection; the fetch surfaces any error.
+			}
+		}
 		const axiosResponse = await mwn.rawRequest({
 			url: fetchUrl,
 			method: 'GET',
 			responseType: 'arraybuffer',
 			maxRedirects: MAX_REDIRECTS,
+			headers: fetchHeaders,
 		});
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios arraybuffer body at this boundary
 		const buffer = Buffer.from(axiosResponse.data as ArrayBuffer);

--- a/src/tools/get-file-data.ts
+++ b/src/tools/get-file-data.ts
@@ -1,0 +1,183 @@
+import { z } from 'zod';
+import type {
+	CallToolResult,
+	ToolAnnotations,
+	ImageContent,
+	TextContent,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { ApiPage, ImageInfo } from 'mwn';
+import type { Tool } from '../runtime/tool.js';
+import type { ToolContext } from '../runtime/context.js';
+
+const DEFAULT_IMAGE_WIDTH = 1024;
+const DEFAULT_TEXT_WIDTH = 512;
+const MAX_WIDTH = 1568;
+const DEFAULT_FILE_DATA_MAX_BYTES = 1_000_000;
+const MAX_REDIRECTS = 5;
+
+// Operator-owned transport/safety backstop on the encoded payload size. Distinct
+// from MCP_CONTENT_MAX_BYTES (a text-body cap) — binary can't be truncated, so
+// over-cap is a hard error, not a trailing marker.
+function resolveFileDataMaxBytes(): number {
+	const raw = process.env.MCP_FILE_DATA_MAX_BYTES;
+	if (raw === undefined || raw === '') {
+		return DEFAULT_FILE_DATA_MAX_BYTES;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return DEFAULT_FILE_DATA_MAX_BYTES;
+	}
+	return parsed;
+}
+
+const inputSchema = {
+	title: z.string().describe('File title (with or without the "File:" prefix)'),
+	width: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe(
+			'Pixel width of the scaled rendition. A quality/detail knob: in image mode the model caps image tokens regardless of size, so larger mainly means more detail. Defaults to 1024 (512 when format is "text"); values above 1568 are clamped.',
+		),
+	format: z
+		.enum(['image', 'text'])
+		.default('image')
+		.describe(
+			"'image' returns a native image content block the model can view; 'text' returns the base64 as a text block, for hosts that do not forward image content to the model (base64 text costs far more tokens).",
+		),
+} as const;
+
+export const getFileData: Tool<typeof inputSchema> = {
+	name: 'get-file-data',
+	description:
+		'Fetches a wiki file server-side and returns the image inline as a content block, for clients that cannot reach the wiki host (sandboxed or network-restricted) and need the image sent to the model for visual analysis. Returns a scaled rendition sized by width. Files MediaWiki can rasterize (images, SVG, PDF, DjVu) come back as an image; other types (audio, video, arbitrary binaries) error — for those, and for metadata or a download URL, use get-file.',
+	inputSchema,
+	annotations: {
+		title: 'Get file data',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'retrieve file data',
+	target: (a) => a.title,
+
+	async handle({ title, width, format }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		const fileTitle = title.startsWith('File:') ? title : `File:${title}`;
+		const effectiveWidth = Math.min(
+			width ?? (format === 'text' ? DEFAULT_TEXT_WIDTH : DEFAULT_IMAGE_WIDTH),
+			MAX_WIDTH,
+		);
+
+		const response = await mwn.request({
+			action: 'query',
+			titles: fileTitle,
+			prop: 'imageinfo',
+			iiprop: 'url|size|mime',
+			iiurlwidth: effectiveWidth,
+			formatversion: '2',
+		});
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		const page = response.query?.pages?.[0] as ApiPage | undefined;
+		if (!page || page.missing) {
+			return ctx.format.notFound(`File "${title}" not found`);
+		}
+
+		const info: ImageInfo | undefined = page.imageinfo?.[0];
+		if (!info) {
+			return ctx.format.notFound(`No file info available for "${title}"`);
+		}
+
+		// Let MediaWiki decide renderability: a thumburl means it rasterized the
+		// file (image, SVG, PDF page, DjVu...) to an image. Otherwise only a file
+		// that is itself an image can be fetched directly (it was too small to
+		// scale). Anything else is non-renderable.
+		const thumb = info as ImageInfo & {
+			thumburl?: string;
+			thumbwidth?: number;
+			thumbheight?: number;
+		};
+		const isImageMime = typeof info.mime === 'string' && info.mime.startsWith('image/');
+		let fetchUrl: string | undefined;
+		if (typeof thumb.thumburl === 'string' && thumb.thumburl !== '') {
+			fetchUrl = thumb.thumburl;
+		} else if (isImageMime) {
+			fetchUrl = info.url;
+		}
+		if (fetchUrl === undefined) {
+			return ctx.format.invalidInput(
+				`File "${title}" (${info.mime ?? 'unknown type'}) cannot be rendered as an image. Use get-file for its download URL.`,
+			);
+		}
+
+		// Fetch via mwn (the same client that read the metadata) so auth and host
+		// trust match: any file imageinfo can describe, this can also download. The
+		// URL comes from the trusted configured wiki's own imageinfo, so — unlike a
+		// user-supplied URL (add-wiki / discovery, which go through httpFetch's
+		// assertPublicDestination guard) — it is intentionally not SSRF-guarded.
+		// maxRedirects caps the hop COUNT only; it does NOT address-validate redirect
+		// targets. Accepted for v1 given the wiki-derived URL; a host-scoped guard
+		// relaxation is a documented future hardening.
+		const axiosResponse = await mwn.rawRequest({
+			url: fetchUrl,
+			method: 'GET',
+			responseType: 'arraybuffer',
+			maxRedirects: MAX_REDIRECTS,
+		});
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios arraybuffer body at this boundary
+		const buffer = Buffer.from(axiosResponse.data as ArrayBuffer);
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios response headers at this boundary
+		const headers = (axiosResponse.headers ?? {}) as Record<string, unknown>;
+		const rawContentType = headers['content-type'];
+		const responseMime =
+			typeof rawContentType === 'string' ? rawContentType.split(';')[0]?.trim() : undefined;
+
+		// The block's mime is the fetched bytes' type (a PDF thumb is image/jpeg),
+		// falling back to the original mime for a directly-fetched image. Assert it
+		// really is an image before emitting an image block.
+		const mimeType =
+			responseMime !== undefined && responseMime.startsWith('image/')
+				? responseMime
+				: isImageMime
+					? info.mime
+					: undefined;
+		if (mimeType === undefined) {
+			return ctx.format.invalidInput(
+				`Fetched data for "${title}" is not an image (${responseMime ?? info.mime ?? 'unknown type'}). Use get-file for its download URL.`,
+			);
+		}
+
+		const base64 = buffer.toString('base64');
+		const maxBytes = resolveFileDataMaxBytes();
+		if (base64.length > maxBytes) {
+			return ctx.format.invalidInput(
+				`Encoded file data is ${base64.length} bytes, over the ${maxBytes}-byte limit (MCP_FILE_DATA_MAX_BYTES). Request a smaller width.`,
+			);
+		}
+
+		const wikiKey = ctx.activeWiki.get().key;
+		const renderedWidth = thumb.thumbwidth ?? info.width;
+		const renderedHeight = thumb.thumbheight ?? info.height;
+		const dims =
+			renderedWidth !== undefined && renderedHeight !== undefined
+				? `${renderedWidth}×${renderedHeight}`
+				: 'unknown size';
+		const sizeKb = Math.max(1, Math.round(base64.length / 1024));
+		const caption: TextContent = {
+			type: 'text',
+			text: `File: ${page.title} • Wiki: ${wikiKey} • Type: ${mimeType} • Returned ${dims}, ${sizeKb} KB encoded`,
+		};
+		const payload: ImageContent | TextContent =
+			format === 'text'
+				? { type: 'text', text: base64 }
+				: { type: 'image', data: base64, mimeType };
+
+		// No structuredContent: the dispatcher echoes the wiki key by re-wrapping a
+		// plain-object structuredContent into a single text block, which would drop
+		// the image block. The wiki key is in the caption instead.
+		return { content: [caption, payload] };
+	},
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import { searchPageByPrefix } from './search-page-by-prefix.js';
 import { parseWikitext } from './parse-wikitext.js';
 import { comparePages } from './compare-pages.js';
 import { getFile } from './get-file.js';
+import { getFileData } from './get-file-data.js';
 import { getRevision } from './get-revision.js';
 import { getSiteInfo } from './get-site-info.js';
 import { getCategoryMembers } from './get-category-members.js';
@@ -52,6 +53,7 @@ const standardTools: Tool<any>[] = [
 	parseWikitext,
 	comparePages,
 	getFile,
+	getFileData,
 	getRevision,
 	getSiteInfo,
 	getCategoryMembers,

--- a/tests/tools/get-file-data.test.ts
+++ b/tests/tools/get-file-data.test.ts
@@ -74,6 +74,36 @@ describe('get-file-data', () => {
 		);
 	});
 
+	it('attaches the OAuth2 bearer when the file is same-origin as the wiki API', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		mock.usingOAuth2 = true;
+		mock.options = { apiUrl: 'https://test.wiki/w/api.php', OAuth2AccessToken: 'secret-token' };
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		expect(mock.rawRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				headers: expect.objectContaining({ Authorization: 'Bearer secret-token' }),
+			}),
+		);
+	});
+
+	it('does not leak the bearer to a different-origin file host', async () => {
+		const mock = mwnWith({
+			...IMAGE_INFO,
+			thumburl: 'https://cdn.example.org/thumb/example.png/1024px-example.png',
+		});
+		mock.usingOAuth2 = true;
+		mock.options = { apiUrl: 'https://test.wiki/w/api.php', OAuth2AccessToken: 'secret-token' };
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		const firstCallArg = mock.rawRequest.mock.calls[0][0] as { headers?: Record<string, string> };
+		expect(firstCallArg.headers?.Authorization).toBeUndefined();
+	});
+
 	it('preserves the image block through the dispatcher (no structuredContent clobber)', async () => {
 		const mock = mwnWith(IMAGE_INFO);
 		const ctx = fakeContext({ mwn: async () => mock as never });

--- a/tests/tools/get-file-data.test.ts
+++ b/tests/tools/get-file-data.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ImageContent, TextContent } from '@modelcontextprotocol/sdk/types.js';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+import { getFileData } from '../../src/tools/get-file-data.js';
+import { dispatch } from '../../src/runtime/dispatcher.js';
+import { assertStructuredError } from '../helpers/structuredResult.js';
+
+// Build an action=query&prop=imageinfo response. `info` is the imageinfo[0]
+// object; pass `missing: true` for a missing-page response.
+function imageinfoResponse(
+	info: Record<string, unknown>,
+	opts: { missing?: boolean } = {},
+): unknown {
+	return {
+		query: {
+			pages: [
+				opts.missing
+					? { title: 'File:Missing.png', missing: true }
+					: { title: 'File:Example.png', imageinfo: [info] },
+			],
+		},
+	};
+}
+
+const IMAGE_INFO = {
+	url: 'https://test.wiki/images/example.png',
+	descriptionurl: 'https://test.wiki/wiki/File:Example.png',
+	size: 12345,
+	width: 800,
+	height: 600,
+	mime: 'image/png',
+	thumburl: 'https://test.wiki/images/thumb/example.png/1024px-example.png',
+	thumbwidth: 1024,
+	thumbheight: 768,
+};
+
+const FAKE_BYTES = Buffer.from('fake-image-bytes');
+
+function mwnWith(info: Record<string, unknown>, opts: { missing?: boolean } = {}) {
+	return createMockMwn({
+		request: vi.fn().mockResolvedValue(imageinfoResponse(info, opts)),
+		rawRequest: vi.fn().mockResolvedValue({
+			data: FAKE_BYTES,
+			headers: { 'content-type': 'image/png' },
+		}),
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('get-file-data', () => {
+	it('returns an image content block for a renderable image', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		expect(result.isError).toBeFalsy();
+		expect(result.content).toHaveLength(2);
+		const caption = result.content[0] as TextContent;
+		const payload = result.content[1] as ImageContent;
+		expect(caption.type).toBe('text');
+		expect(caption.text).toContain('test-wiki');
+		expect(caption.text).toContain('image/png');
+		expect(caption.text).toContain('1024×768');
+		expect(payload.type).toBe('image');
+		expect(payload.mimeType).toBe('image/png');
+		expect(payload.data).toBe(FAKE_BYTES.toString('base64'));
+		expect(mock.rawRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ url: IMAGE_INFO.thumburl, responseType: 'arraybuffer' }),
+		);
+	});
+
+	it('preserves the image block through the dispatcher (no structuredContent clobber)', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await dispatch(
+			getFileData,
+			ctx,
+		)({
+			title: 'Example.png',
+			format: 'image',
+		});
+
+		expect(result.isError).toBeFalsy();
+		expect(result.content).toHaveLength(2);
+		expect(result.content[0].type).toBe('text');
+		const payload = result.content[1] as ImageContent;
+		expect(payload.type).toBe('image');
+		expect(payload.data).toBe(FAKE_BYTES.toString('base64'));
+		// Dispatcher resolved the default wiki; the caption carries it (there is no
+		// structuredContent for the wiki-echo to re-wrap, so the image block survives).
+		expect((result.content[0] as TextContent).text).toContain('test-wiki');
+	});
+
+	it('falls back to the original mime when the response has no content-type', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		mock.rawRequest = vi.fn().mockResolvedValue({ data: FAKE_BYTES, headers: {} });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		expect(result.isError).toBeFalsy();
+		const payload = result.content[1] as ImageContent;
+		expect(payload.type).toBe('image');
+		expect(payload.mimeType).toBe('image/png');
+	});
+
+	it('rejects when fetched bytes are not an image and the original is non-image', async () => {
+		// A PDF with a thumburl, but the fetch returned an HTML error page.
+		const mock = mwnWith({
+			url: 'https://test.wiki/images/doc.pdf',
+			size: 99999,
+			mime: 'application/pdf',
+			thumburl: 'https://test.wiki/images/thumb/doc.pdf/1024px-doc.pdf.jpg',
+			thumbwidth: 1024,
+			thumbheight: 1320,
+		});
+		mock.rawRequest = vi.fn().mockResolvedValue({
+			data: Buffer.from('<html>error</html>'),
+			headers: { 'content-type': 'text/html' },
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Doc.pdf', format: 'image' }, ctx);
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('get-file');
+	});
+
+	it('defaults width to 1024 in image mode and passes it to iiurlwidth', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		expect(mock.request).toHaveBeenCalledWith(expect.objectContaining({ iiurlwidth: 1024 }));
+	});
+
+	it('clamps width to 1568', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await getFileData.handle({ title: 'Example.png', width: 5000, format: 'image' }, ctx);
+
+		expect(mock.request).toHaveBeenCalledWith(expect.objectContaining({ iiurlwidth: 1568 }));
+	});
+
+	it('returns base64 in a text block when format is text', async () => {
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Example.png', format: 'text' }, ctx);
+
+		expect(result.isError).toBeFalsy();
+		const payload = result.content[1] as TextContent;
+		expect(payload.type).toBe('text');
+		expect(payload.text).toBe(FAKE_BYTES.toString('base64'));
+		expect(mock.request).toHaveBeenCalledWith(expect.objectContaining({ iiurlwidth: 512 }));
+	});
+
+	it('renders a non-image file via its thumburl', async () => {
+		const mock = mwnWith({
+			url: 'https://test.wiki/images/doc.pdf',
+			size: 99999,
+			mime: 'application/pdf',
+			thumburl: 'https://test.wiki/images/thumb/doc.pdf/1024px-doc.pdf.jpg',
+			thumbwidth: 1024,
+			thumbheight: 1320,
+		});
+		mock.rawRequest = vi.fn().mockResolvedValue({
+			data: FAKE_BYTES,
+			headers: { 'content-type': 'image/jpeg' },
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Doc.pdf', format: 'image' }, ctx);
+
+		expect(result.isError).toBeFalsy();
+		const payload = result.content[1] as ImageContent;
+		expect(payload.type).toBe('image');
+		expect(payload.mimeType).toBe('image/jpeg');
+	});
+
+	it('rejects a non-renderable file with invalid_input pointing to get-file', async () => {
+		const mock = mwnWith({
+			url: 'https://test.wiki/images/sound.ogg',
+			size: 4242,
+			mime: 'audio/ogg',
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Sound.ogg', format: 'image' }, ctx);
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('get-file');
+		expect(mock.rawRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects an over-cap payload with invalid_input mentioning width', async () => {
+		vi.stubEnv('MCP_FILE_DATA_MAX_BYTES', '4');
+		const mock = mwnWith(IMAGE_INFO);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Example.png', format: 'image' }, ctx);
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message.toLowerCase()).toContain('width');
+	});
+
+	it('returns not_found for a missing file', async () => {
+		const mock = mwnWith({}, { missing: true });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getFileData.handle({ title: 'Missing.png', format: 'image' }, ctx);
+
+		const envelope = assertStructuredError(result, 'not_found');
+		expect(envelope.message).toContain('not found');
+	});
+
+	it('classifies upstream API failure via the dispatcher', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockRejectedValue(new Error('API error')),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await dispatch(
+			getFileData,
+			ctx,
+		)({
+			title: 'Example.png',
+			format: 'image',
+		});
+
+		const envelope = assertStructuredError(result, 'upstream_failure');
+		expect(envelope.message).toContain('API error');
+	});
+});


### PR DESCRIPTION
## Summary

Adds `get-file-data`, a read tool that fetches a wiki file server-side and returns it inline as a native MCP image content block (or base64 text via `format='text'`), so clients that can't reach the wiki host — sandboxed or network-restricted agents — can still get an image to the model for visual analysis. Complements `get-file` (which still returns metadata + download URLs).

- **Renderability is delegated to MediaWiki:** anything it can rasterize (images, SVG, PDF, DjVu) is returned as an image via `iiurlwidth`; non-renderable types (audio, video, binaries) return `invalid_input` pointing to `get-file`.
- **Cost ownership:** `width` is the consumer's quality knob (default 1024 image / 512 text, clamped 1568). `MCP_FILE_DATA_MAX_BYTES` (default 1 MB) is an operator-owned transport backstop; over-cap is a hard error (binary can't be truncated). The caption reports encoded size so a token-conscious client can self-regulate.
- **Auth/privacy:** bytes are fetched via `mwn` for auth parity, so it works on private/self-hosted wikis; the OAuth2 bearer is injected only when the file is same-origin as the API (leak-safe), and bot-password cookies flow automatically.
- Returns `content: [caption, imageBlock]` with no `structuredContent` so the dispatcher's wiki-echo can't clobber the image block.

Closes #385.

## Test plan

- [x] 14 unit tests: image/text output, `width` default + clamp, PDF-via-thumburl, non-renderable → `invalid_input`, over-cap → `invalid_input`, missing → `not_found`, content-type mime fallback, same-origin bearer attach + cross-origin no-leak, and dispatcher no-clobber through `dispatch()`.
- [x] Full suite green (1097 tests); `tsgo --noEmit`, oxlint, and oxfmt all clean.
- [x] Live smoke test via the MCP Inspector CLI against Wikimedia Commons: `get-file-data title=Example.jpg width=320` returned an `image/jpeg` block with valid JPEG bytes (magic `ffd8ffe0`) and caption `File: File:Example.jpg • Wiki: commons.wikimedia.org • Type: image/jpeg • Returned 172×178, 12 KB encoded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)