### PR TITLE
Serialize exec-secret command runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - List responses (`get-recent-changes`, `get-page-history`, `get-links-here`, `get-category-members`, `get-pages`) now omit default and empty fields to reduce response size: boolean flags appear only when `true`, empty comments and tag lists are dropped, recent changes report the size delta without the raw old/new lengths, a category member's `type` is omitted for ordinary pages, and `get-pages` omits `requestedTitle` when it matches the resolved title. Absent flags mean `false`.
 - The `list-wikis` tool is now hidden when only a single wiki is configured, where it has nothing to list and every call already defaults to that wiki. It appears once a second wiki is configured or added.
 - The timeout for an `exec`-backed credential command was raised from 10 to 30 seconds, giving an interactive unlock (such as a 1Password prompt) time to be approved. If the command still times out, the error now explains that approving the prompt and retrying re-runs it.
+- `exec`-backed credential commands now run one at a time instead of concurrently. Resolving secrets for several wikis at once (for example when listing wikis) previously launched every command together, so an interactive unlock such as a 1Password prompt appeared once per wiki; now the first command's unlock is reused by the rest, so a single prompt covers them all.
 
 ## [0.10.0] - 2026-05-30
 

--- a/src/wikis/execSecret.ts
+++ b/src/wikis/execSecret.ts
@@ -24,6 +24,32 @@ function failureMessage(err: unknown, stderr: string, command: string, descripto
 	return `Could not resolve ${descriptor}: ${err instanceof Error ? err.message : typeof err === 'string' ? err : String(err)}`;
 }
 
+// Serialize exec-secret command runs process-wide. An interactive credential
+// helper — e.g. `op read` backed by the 1Password desktop app — prompts the
+// user to unlock on its first run; once that completes, the helper caches a
+// session that later runs reuse silently. Running them concurrently instead
+// races every run against that one unlock, so each prompts: resolving secrets
+// for N wikis at once (e.g. list-wikis fanning out over every wiki) yields N
+// dialogs. A single in-process queue collapses that to one prompt — the first
+// run unlocks, the rest reuse the warm session.
+//
+// The per-run timeout starts when execFile is invoked (on dequeue), not while
+// a run waits its turn, so a slow human unlock on the first prompt never eats
+// into a queued run's timeout budget.
+let queue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+	const run = queue.then(task);
+	// Advance the chain past this run regardless of its outcome. The rejection
+	// handler here also marks `run`'s rejection as observed, so a caller that
+	// forgets to await never triggers an unhandled-rejection warning.
+	queue = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
+
 /**
  * Run an {exec:…} credential command and return its trimmed stdout.
  *
@@ -33,29 +59,36 @@ function failureMessage(err: unknown, stderr: string, command: string, descripto
  *
  * Uses the async (callback) form of execFile so a slow command never blocks
  * the Node event loop. The child's stdin is closed immediately so a command
- * that reads stdin sees EOF instead of hanging until the timeout. Failure
- * messages carry only the command name and truncated stderr — never stdout,
- * never the resolved secret.
+ * that reads stdin sees EOF instead of hanging until the timeout. Runs are
+ * serialized process-wide (see `enqueue`) so an interactive credential helper
+ * prompts once rather than once per concurrent resolution. Failure messages
+ * carry only the command name and truncated stderr — never stdout, never the
+ * resolved secret.
  */
 export async function runExecSecret(spec: ExecSecret, descriptor: string): Promise<string> {
 	const { command, args } = spec.exec;
-	const stdout = await new Promise<string>((resolve, reject) => {
-		const child = execFile(
-			command,
-			args,
-			{ timeout: TIMEOUT_MS, encoding: 'utf-8' },
-			(err, out, errOut) => {
-				if (err) {
-					reject(
-						new CredentialResolutionError(failureMessage(err, errOut ?? '', command, descriptor)),
-					);
-					return;
-				}
-				resolve(out);
-			},
-		);
-		child.stdin?.end();
-	});
+	const stdout = await enqueue(
+		() =>
+			new Promise<string>((resolve, reject) => {
+				const child = execFile(
+					command,
+					args,
+					{ timeout: TIMEOUT_MS, encoding: 'utf-8' },
+					(err, out, errOut) => {
+						if (err) {
+							reject(
+								new CredentialResolutionError(
+									failureMessage(err, errOut ?? '', command, descriptor),
+								),
+							);
+							return;
+						}
+						resolve(out);
+					},
+				);
+				child.stdin?.end();
+			}),
+	);
 
 	const trimmed = stdout.replace(/\r?\n+$/, '');
 	if (trimmed === '') {

--- a/tests/wikis/execSecret.test.ts
+++ b/tests/wikis/execSecret.test.ts
@@ -24,6 +24,14 @@ function mockExecFile(
 	}) as unknown as typeof execFile);
 }
 
+// Flush the microtask queue plus one macrotask turn, so the serialization
+// queue in runExecSecret advances to the next run before we assert on it.
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+// NOTE: runExecSecret's serialization queue is module-global and persists
+// across the it() blocks below. These tests stay isolated only because each
+// settles every run it starts, draining the queue; a test that leaves a run
+// unsettled would leak into the next one.
 describe('runExecSecret', () => {
 	beforeEach(() => {
 		vi.mocked(execFile).mockReset();
@@ -108,6 +116,64 @@ describe('runExecSecret', () => {
 		await expect(runExecSecret({ exec: { command: 'op', args: [] } }, descriptor)).rejects.toThrow(
 			'produced no output',
 		);
+	});
+
+	it('serializes concurrent runs so the commands never overlap', async () => {
+		const pending: Array<(e: unknown, o: string, s: string) => void> = [];
+		let live = 0;
+		let maxLive = 0;
+		vi.mocked(execFile).mockImplementation(((...callArgs: unknown[]) => {
+			live++;
+			maxLive = Math.max(maxLive, live);
+			const cb = callArgs[callArgs.length - 1] as (e: unknown, o: string, s: string) => void;
+			pending.push((e, o, s) => {
+				live--;
+				cb(e, o, s);
+			});
+			return { stdin: { end: () => {} } } as unknown as ReturnType<typeof execFile>;
+		}) as unknown as typeof execFile);
+
+		const first = runExecSecret({ exec: { command: 'op', args: ['1'] } }, descriptor);
+		const second = runExecSecret({ exec: { command: 'op', args: ['2'] } }, descriptor);
+
+		// Only the first command has started; the second waits its turn.
+		await tick();
+		expect(pending.length).toBe(1);
+
+		// Completing the first lets the queue release the second.
+		pending[0](null, 'first\n', '');
+		await expect(first).resolves.toBe('first');
+		await tick();
+		expect(pending.length).toBe(2);
+
+		pending[1](null, 'second\n', '');
+		await expect(second).resolves.toBe('second');
+		expect(maxLive).toBe(1);
+	});
+
+	it('lets a failed run release the next queued run', async () => {
+		const pending: Array<(e: unknown, o: string, s: string) => void> = [];
+		vi.mocked(execFile).mockImplementation(((...callArgs: unknown[]) => {
+			pending.push(callArgs[callArgs.length - 1] as (e: unknown, o: string, s: string) => void);
+			return { stdin: { end: () => {} } } as unknown as ReturnType<typeof execFile>;
+		}) as unknown as typeof execFile);
+
+		const first = runExecSecret({ exec: { command: 'op', args: ['1'] } }, descriptor);
+		const second = runExecSecret({ exec: { command: 'op', args: ['2'] } }, descriptor);
+
+		await tick();
+		expect(pending.length).toBe(1);
+
+		const failure = new Error('failed') as Error & { code?: number };
+		failure.code = 1;
+		pending[0](failure, '', 'nope');
+		await expect(first).rejects.toBeInstanceOf(CredentialResolutionError);
+
+		// A rejected run must not stall the queue.
+		await tick();
+		expect(pending.length).toBe(2);
+		pending[1](null, 'second\n', '');
+		await expect(second).resolves.toBe('second');
 	});
 
 	it('never leaks the command stdout into a failure message', async () => {


### PR DESCRIPTION
## Problem

When several configured wikis resolve credentials via an `{exec:…}` command backed by 1Password (`op read`), the initial authentication pops the 1Password unlock dialog **once per wiki**, in a row.

Root cause is a concurrency race, not config. Tools that fan out across wikis — most visibly `list-wikis`, which does `Promise.all` over every wiki → `resolveSiteInfo` → `ctx.mwn(key)` → `resolveSecret` → `runExecSecret` — spawn all the `op` processes at roughly the same instant. None has established a 1Password session yet, so each process independently triggers an unlock prompt.

A config like 7 wikis (1 token + 4 username/password pairs via `op`) fires ~9 `op` processes concurrently → a wall of dialogs.

## Fix

Serialize `{exec:…}` credential commands through a process-wide queue in `src/wikis/execSecret.ts`, so they run one at a time. The first run's unlock establishes a 1Password session the rest reuse silently → a single prompt covers them all.

Design points:
- The per-run `execFile` timeout starts on **dequeue** (when the command actually runs), not while it waits its turn — a slow human unlock on the first prompt never burns a queued run's timeout budget.
- A failed/timed-out/rejected run **releases** the next queued run rather than stalling the queue (the chain link resolves on both fulfilment and rejection).
- An unawaited rejected run can't raise an unhandled-rejection warning (the chain link's rejection handler observes it).
- All existing behavior is preserved (trimmed stdout, empty-output error, ENOENT/timeout/non-zero classification, never leaking stdout or the secret into error messages, the per-`(wiki,field)` secret cache).

`runExecSecret` is the single chokepoint every exec-backed resolution passes through, so this covers every fan-out path, not just `list-wikis`.

## Caveat

This collapses to one prompt only if the first prompt is approved before its 30s timeout. If the first run times out it's evicted and the next queued run will prompt again — same retry behavior as today.

## Testing

- Two new unit tests: concurrent runs never overlap (`maxLive === 1`, the second command doesn't start until the first's callback fires) and a failed run releases the next queued run.
- Smoke test with **real** subprocesses (not mocks): 4 concurrent `runExecSecret` calls ran strictly sequentially (`START1 END1 START2 END2 START3 END3 START4 END4`), total elapsed ≈ 4× the per-command sleep — the sequential signature.
- Full suite green (1103 tests); lint, format, and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)