### PR TITLE
Add whoami tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`. Images and files MediaWiki can rasterize (SVG, PDF, DjVu) come back as an image; non-renderable types (audio, video, binaries) error and point to `get-file`.
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
+- `whoami` tool: reports which account the current session is acting as on a wiki — the username, whether the session is anonymous, and the user groups it belongs to (optionally the full rights list). Use it to confirm who edits will be attributed to before writing, for example when creating a page under your own user namespace.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
 | `search-page` | Search wiki page titles and contents. |
 | `search-page-by-prefix` | Search page titles by prefix. |
+| `whoami` | Report the identity the current session is authenticated as on the targeted wiki — username, whether it is anonymous, and group memberships (optionally user rights). |
 
 #### Page writes
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -19,6 +19,10 @@ Anthropic's engineering guidance recommends consolidating multiple actions into 
 
 This codebase follows **one job per tool** (separate `create-page`, `update-page`, `delete-page`, `undelete-page`, etc.). Do not consolidate when adding new tools; match the existing pattern. This is an explicit choice, not an oversight.
 
+#### Tool names
+
+Tool names are verb-noun kebab-case (`get-page`, `create-page`, `list-wikis`). The identity-introspection tool is named `whoami` as a deliberate exception: it is a widely recognised idiom for "who is the current authenticated principal," and it answers a question about the session rather than fetching a named resource. Do not rename it to `get-*` for consistency.
+
 ### Descriptions
 
 #### Voice and opening

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,7 @@ import { getSiteInfo } from './get-site-info.js';
 import { getCategoryMembers } from './get-category-members.js';
 import { getLinksHere } from './get-links-here.js';
 import { listWikis } from './list-wikis.js';
+import { whoami } from './whoami.js';
 import { extensionPacks } from './extensions/index.js';
 import { createPage } from './create-page.js';
 import { updatePage } from './update-page.js';
@@ -59,6 +60,7 @@ const standardTools: Tool<any>[] = [
 	getCategoryMembers,
 	getLinksHere,
 	listWikis,
+	whoami,
 	createPage,
 	updatePage,
 	movePage,

--- a/src/tools/whoami.ts
+++ b/src/tools/whoami.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../runtime/tool.js';
+import type { ToolContext } from '../runtime/context.js';
+
+const inputSchema = {
+	includeRights: z
+		.boolean()
+		.optional()
+		.describe(
+			'Also return the full list of user rights granted on this wiki (a long list). Defaults to false.',
+		),
+} as const;
+
+type WhoamiArgs = z.infer<z.ZodObject<typeof inputSchema>>;
+
+interface RawUserinfo {
+	id: number;
+	name: string;
+	anon?: boolean;
+	groups?: string[];
+	rights?: string[];
+}
+
+interface UserinfoResponse {
+	query?: { userinfo?: RawUserinfo };
+}
+
+interface WhoamiResult {
+	id: number;
+	username: string;
+	anonymous: boolean;
+	groups: string[];
+	rights?: string[];
+}
+
+export const whoami: Tool<typeof inputSchema> = {
+	name: 'whoami',
+	description:
+		'Returns the identity the current session is authenticated as on the targeted wiki: the username, whether the session is anonymous (no user is logged in), and the user groups it belongs to. Set includeRights to also return the full list of user rights. Use to confirm who edits and uploads will be attributed to before writing — for example, to resolve your own username before building a title under your own user namespace (User:<username>/…). Reports anonymous access rather than failing when the session has no credentials. For which wikis have stored OAuth tokens and their scopes, use oauth-status instead.',
+	inputSchema,
+	annotations: {
+		title: 'Who am I',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'read user identity',
+
+	async handle(args: WhoamiArgs, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		const uiprop = args.includeRights === true ? 'groups|rights' : 'groups';
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		const response = (await mwn.request({
+			action: 'query',
+			meta: 'userinfo',
+			uiprop,
+			formatversion: '2',
+		})) as UserinfoResponse;
+
+		const userinfo = response.query?.userinfo;
+		if (!userinfo) {
+			throw new Error('userinfo response did not include user data');
+		}
+
+		const result: WhoamiResult = {
+			id: userinfo.id,
+			username: userinfo.name,
+			anonymous: userinfo.anon === true,
+			groups: userinfo.groups ?? [],
+		};
+		if (args.includeRights === true) {
+			result.rights = userinfo.rights ?? [];
+		}
+
+		return ctx.format.ok(result);
+	},
+};

--- a/tests/tools/whoami.test.ts
+++ b/tests/tools/whoami.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { whoami } from '../../src/tools/whoami.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+import { createMockMwn } from '../helpers/mock-mwn.js';
+import { dispatch } from '../../src/runtime/dispatcher.js';
+import { assertStructuredData, assertStructuredError } from '../helpers/structuredResult.js';
+
+function ctxWith(request: ReturnType<typeof vi.fn>) {
+	const mwn = createMockMwn({ request });
+	return fakeContext({ mwn: () => Promise.resolve(mwn as never) });
+}
+
+function userinfoResponse(overrides: Record<string, unknown> = {}) {
+	return {
+		query: {
+			userinfo: {
+				id: 12345,
+				name: 'Alistair3149',
+				groups: ['*', 'user', 'autoconfirmed', 'sysop'],
+				...overrides,
+			},
+		},
+	};
+}
+
+describe('whoami', () => {
+	it('returns the authenticated user with groups and no rights by default', async () => {
+		const request = vi.fn().mockResolvedValue(userinfoResponse());
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(whoami, ctx)({} as never));
+
+		expect(data.id).toBe(12345);
+		expect(data.username).toBe('Alistair3149');
+		expect(data.anonymous).toBe(false);
+		expect(data.groups).toEqual(['*', 'user', 'autoconfirmed', 'sysop']);
+		expect(data.rights).toBeUndefined();
+		expect(data.wiki).toBe('test-wiki');
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(request.mock.calls[0][0].uiprop).toBe('groups');
+	});
+
+	it('reports anonymous access instead of failing when no user is logged in', async () => {
+		const request = vi
+			.fn()
+			.mockResolvedValue(
+				userinfoResponse({ id: 0, name: '203.0.113.5', anon: true, groups: ['*'] }),
+			);
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(await dispatch(whoami, ctx)({} as never));
+
+		expect(data.anonymous).toBe(true);
+		expect(data.id).toBe(0);
+		expect(data.username).toBe('203.0.113.5');
+		expect(data.groups).toEqual(['*']);
+	});
+
+	it('includes rights and requests them only when includeRights is true', async () => {
+		const request = vi
+			.fn()
+			.mockResolvedValue(userinfoResponse({ rights: ['read', 'edit', 'createpage', 'upload'] }));
+		const ctx = ctxWith(request);
+
+		const data = assertStructuredData(
+			await dispatch(whoami, ctx)({ includeRights: true } as never),
+		);
+
+		expect(data.groups).toEqual(['*', 'user', 'autoconfirmed', 'sysop']);
+		expect(data.rights).toEqual(['read', 'edit', 'createpage', 'upload']);
+		expect(request.mock.calls[0][0].uiprop).toBe('groups|rights');
+	});
+
+	it('fails with upstream_failure when the response lacks userinfo', async () => {
+		const request = vi.fn().mockResolvedValue({ query: {} });
+		const ctx = ctxWith(request);
+
+		const result = await dispatch(whoami, ctx)({} as never);
+
+		assertStructuredError(result, 'upstream_failure');
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `whoami`, a wiki-scoped read-only tool reporting the identity the current session is authenticated as on the targeted wiki: `username`, `anonymous`, `groups`, and optional `rights` (via `includeRights`). It issues a single `meta=userinfo` query and treats anonymous access as a normal result, not an error.
- **Motivation:** agents have no way to resolve their own account, so writes can land under the wrong user subpage (e.g. a sandbox created at `User:<wrong>/Sandbox`). `whoami`'s own description points at this use case — resolving your username before building a `User:<username>/…` title.
- Names the tool `whoami` as a deliberate idiom exception to the repo's verb-noun convention (recorded in `docs/tool-conventions.md`), matching how Figma/Entra/Jenkins MCP servers and CLIs (`kubectl auth whoami`, `op whoami`) name this capability.

## Test plan

- **Unit** (`tests/tools/whoami.test.ts`): authenticated user, anonymous session (`id 0` / `anon`), `includeRights` on/off, and missing-`userinfo` → `upstream_failure`. Full suite green (1114 tests); oxlint and `tsgo` build clean.
- **Live smoke test** via MCP Inspector CLI against `en.wikipedia.org` (anonymous): returned `anonymous: true`, the egress IP as `username`, `groups: ["*"]`, and the dispatcher's `wiki` echo; `includeRights=true` returned a populated `rights` array and was correctly absent by default.

## Notes

- A `create-page` description nudge ("resolve your account via `whoami` before creating `User:` subpages") was considered and dropped: a soft per-call nudge buys a permanent description cost without reliably stopping a confident wrong guess. If the wrong-subpage footgun recurs, it's better solved by a behavioural guard (warn when a `User:` title's root ≠ the acting user) than by description text. `whoami`'s own description still carries the user-namespace guidance.
- Non-blocking review nits left for follow-up: the annotation `title: "Who am I"` is interrogative vs sibling titles; and there's no explicit test for the `rights ?? []` fallback when a restricted wiki omits rights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)