### PR TITLE
Upload from URL without requiring wiki copy-uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`. Images and files MediaWiki can rasterize (SVG, PDF, DjVu) come back as an image; non-renderable types (audio, video, binaries) error and point to `get-file`.
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
 - `whoami` tool: reports which account the current session is acting as on a wiki — the username, whether the session is anonymous, and the user groups it belongs to (optionally the full rights list). Use it to confirm who edits will be attributed to before writing, for example when creating a page under your own user namespace.
+- `MCP_UPLOAD_MAX_BYTES` environment variable: caps the size the server buffers when fetching a URL for `upload-file-from-url` / `update-file-from-url` (default 100 MB). Larger files are handed to the wiki's own copy-upload.
 
 ### Changed
 
@@ -19,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - The timeout for an `exec`-backed credential command was raised from 10 to 30 seconds, giving an interactive unlock (such as a 1Password prompt) time to be approved. If the command still times out, the error now explains that approving the prompt and retrying re-runs it.
 - `exec`-backed credential commands now run one at a time instead of concurrently. Resolving secrets for several wikis at once (for example when listing wikis) previously launched every command together, so an interactive unlock such as a 1Password prompt appeared once per wiki; now the first command's unlock is reused by the rest, so a single prompt covers them all.
 - `list-wikis` no longer logs into or unlocks credentials for each configured wiki. It now reads each wiki's public site data anonymously, so listing wikis never triggers a credential prompt or a login — authentication happens only when you act on a wiki.
+- `upload-file-from-url` and `update-file-from-url` now work on wikis without upload-by-URL enabled. The server fetches the file and uploads it directly, only asking the wiki to fetch the URL when the server cannot reach it (for example a private, server-unreachable address). Previously these tools failed unless the wiki had copy-uploads enabled and the account held the `upload_by_url` right.
 
 ## [0.10.0] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. See [docs/deployment.md — Shape 2](docs/deployment.md#shape-2--single-wiki-per-user-oauth2-bearer-passthrough). | `unset` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs). Tune to the target LLM client's tool-response budget. | `50000` |
 | `MCP_FILE_DATA_MAX_BYTES` | Hard cap on the base64-encoded size of a `get-file-data` response. A transport/safety backstop; tune the actual size per call with the tool's `width`. Over-cap calls error rather than truncate. | `1000000` |
+| `MCP_UPLOAD_MAX_BYTES` | Memory cap on the server-side fetch used by `upload-file-from-url` / `update-file-from-url`. Files larger than this are handed to the wiki's own copy-upload instead of being buffered by the server. Guards this server's memory, not the wiki's `$wgMaxUploadSize`. | `104857600` |
 | `MCP_LOG_LEVEL` | Minimum severity for logger output. One of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, or `silent`. | `debug` |
 | `MCP_OAUTH_CREDENTIALS_FILE` | Override the default credentials store path. Default: `~/.config/mediawiki-mcp/credentials.json` (Linux/macOS) or `%APPDATA%\mediawiki-mcp\credentials.json` (Windows). | `unset` |
 | `MCP_OAUTH_NO_BROWSER` | Set to `1` to skip launching a browser during the OAuth flow; the auth URL is logged to stderr instead. Useful in headless environments. | `unset` |

--- a/server.json
+++ b/server.json
@@ -99,6 +99,12 @@
           "default": "stdio"
         },
         {
+          "name": "MCP_UPLOAD_MAX_BYTES",
+          "description": "Memory cap on the server-side fetch used by upload-file-from-url and update-file-from-url. Files larger than this are routed to the wiki's own copy-upload instead of being buffered by the server. Guards this server's memory, not the wiki's $wgMaxUploadSize.",
+          "format": "number",
+          "default": "104857600"
+        },
+        {
           "name": "PORT",
           "description": "Port used for StreamableHTTP transport",
           "format": "number",
@@ -195,6 +201,12 @@
             "http"
           ],
           "default": "stdio"
+        },
+        {
+          "name": "MCP_UPLOAD_MAX_BYTES",
+          "description": "Memory cap on the server-side fetch used by upload-file-from-url and update-file-from-url. Files larger than this are routed to the wiki's own copy-upload instead of being buffered by the server. Guards this server's memory, not the wiki's $wgMaxUploadSize.",
+          "format": "number",
+          "default": "104857600"
         },
         {
           "name": "PORT",

--- a/src/services/editService.ts
+++ b/src/services/editService.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import type { ApiParams, Mwn } from 'mwn';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
@@ -11,6 +12,16 @@ export interface EditService {
 	submitUpload(
 		mwn: Mwn,
 		filepath: string,
+		title: string,
+		text: string,
+		params: ApiUploadParams,
+	): Promise<ApiUploadResponse>;
+
+	/** Uploads in-memory bytes (or a stream) via a multipart action=upload — parallel to submitUpload but without a local filepath. Injects CSRF token, tags, and ignorewarnings. */
+	submitUploadFromBytes(
+		mwn: Mwn,
+		data: Buffer | Readable,
+		filename: string,
 		title: string,
 		text: string,
 		params: ApiUploadParams,
@@ -47,6 +58,36 @@ export class EditServiceImpl implements EditService {
 			fullParams.tags = tags;
 		}
 		return mwn.upload(filepath, title, text, fullParams);
+	}
+
+	public async submitUploadFromBytes(
+		mwn: Mwn,
+		data: Buffer | Readable,
+		filename: string,
+		title: string,
+		text: string,
+		params: ApiUploadParams,
+	): Promise<ApiUploadResponse> {
+		const token = await mwn.getCsrfToken();
+		const tags = this.activeWiki.get().config.tags;
+		const stream = data instanceof Buffer ? Readable.from(data) : data;
+		const fullParams: Record<string, unknown> = {
+			action: 'upload',
+			file: { stream, name: filename },
+			filename: title,
+			text,
+			ignorewarnings: true,
+			token,
+			...params,
+		};
+		if (tags !== null && tags !== undefined) {
+			fullParams.tags = tags;
+		}
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn ApiParams shape; the multipart `file` field is mwn's documented upload form
+		const response = (await mwn.request(fullParams as ApiParams, {
+			headers: { 'Content-Type': 'multipart/form-data' },
+		})) as { upload: ApiUploadResponse };
+		return response.upload;
 	}
 
 	public applyTags<T extends Record<string, unknown>>(options: T): T {

--- a/src/services/editService.ts
+++ b/src/services/editService.ts
@@ -1,4 +1,3 @@
-import { Readable } from 'node:stream';
 import type { ApiParams, Mwn } from 'mwn';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
@@ -17,10 +16,10 @@ export interface EditService {
 		params: ApiUploadParams,
 	): Promise<ApiUploadResponse>;
 
-	/** Uploads in-memory bytes (or a stream) via a multipart action=upload — parallel to submitUpload but without a local filepath. Injects CSRF token, tags, and ignorewarnings. */
+	/** Uploads in-memory bytes via a multipart action=upload — parallel to submitUpload but without a local filepath. Injects CSRF token, tags, and ignorewarnings. The bytes are passed to form-data as a Buffer (a plain Readable has no length and form-data rejects it with "Unknown stream"). */
 	submitUploadFromBytes(
 		mwn: Mwn,
-		data: Buffer | Readable,
+		data: Buffer,
 		filename: string,
 		title: string,
 		text: string,
@@ -62,7 +61,7 @@ export class EditServiceImpl implements EditService {
 
 	public async submitUploadFromBytes(
 		mwn: Mwn,
-		data: Buffer | Readable,
+		data: Buffer,
 		filename: string,
 		title: string,
 		text: string,
@@ -70,10 +69,12 @@ export class EditServiceImpl implements EditService {
 	): Promise<ApiUploadResponse> {
 		const token = await mwn.getCsrfToken();
 		const tags = this.activeWiki.get().config.tags;
-		const stream = data instanceof Buffer ? Readable.from(data) : data;
+		// Pass the Buffer straight to mwn's multipart `file` field. form-data sizes
+		// a Buffer directly; a Readable (e.g. Readable.from(buffer)) has no known
+		// length and form-data rejects it with "Unknown stream".
 		const fullParams: Record<string, unknown> = {
 			action: 'upload',
-			file: { stream, name: filename },
+			file: { stream: data, name: filename },
 			filename: title,
 			text,
 			ignorewarnings: true,

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -6,6 +6,7 @@ import type { Tool } from '../runtime/tool.js';
 import type { ToolContext } from '../runtime/context.js';
 import { errorMessage } from '../errors/isErrnoException.js';
 import { assertFileExists, FileNotFoundError } from '../transport/fileExistence.js';
+import { fetchFileBytes, shouldRescueToWiki } from '../transport/httpFetch.js';
 import { formatEditComment, buildPageUrl } from '../wikis/utils.js';
 
 const inputSchema = {
@@ -17,7 +18,7 @@ const inputSchema = {
 export const updateFileFromUrl: Tool<typeof inputSchema> = {
 	name: 'update-file-from-url',
 	description:
-		"Fetches a file from a remote web URL and uploads it as a new revision of an existing file, preserving prior revisions in the file history, and returns the file title and URL. The upload appears in the wiki's upload log. Replaces the file content (bytes) only; for editing the wikitext on a file's description page, use update-page. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use update-file instead. Fails if no file exists at the target title; for the initial upload, use upload-file-from-url.",
+		"Fetches a file from a remote web URL and uploads it as a new revision of an existing file, preserving prior revisions in the file history, and returns the file title and URL. The upload appears in the wiki's upload log. Replaces the file content (bytes) only; for editing the wikitext on a file's description page, use update-page. Works whether or not the wiki has upload-by-URL enabled: the server retrieves the file and uploads it directly, falling back to wiki-side fetching only when it cannot reach the URL itself. Fails if no file exists at the target title; for the initial upload, use upload-file-from-url.",
 	inputSchema,
 	annotations: {
 		title: 'Update file from URL',
@@ -46,24 +47,38 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 			comment: formatEditComment('update-file-from-url', comment),
 			ignorewarnings: true,
 		};
-		const params = ctx.edit.applyTags<ApiUploadParams>(baseParams);
+
+		// Server-first: fetch the bytes ourselves (SSRF-guarded, size-capped) and
+		// upload via a normal multipart request; fall back to wiki-side fetching
+		// only when we can't reach the URL.
+		let bytes: Buffer | undefined;
+		try {
+			bytes = await fetchFileBytes(url);
+		} catch (error) {
+			if (!shouldRescueToWiki(error)) {
+				throw error;
+			}
+		}
 
 		let data: ApiUploadResponse;
-		try {
-			data = await mwn.uploadFromUrl(url, title, '', params);
-		} catch (error) {
-			const errorText = errorMessage(error);
-			// Mirror upload-file-from-url: redirect the model away from retrying via URL when
-			// the wiki has copyuploads disabled. Routing hint points at the update-file (local)
-			// sibling for this tool's update intent.
-			if (errorText.includes('copyuploaddisabled')) {
-				return ctx.format.error(
-					'invalid_input',
-					'Upload by URL is disabled on this wiki. Download the file locally, then use update-file with the local file path.',
-					'copyuploaddisabled',
-				);
+		if (bytes !== undefined) {
+			const partName = title.replace(/^File:/, '');
+			data = await ctx.edit.submitUploadFromBytes(mwn, bytes, partName, title, '', baseParams);
+		} else {
+			const params = ctx.edit.applyTags<ApiUploadParams>(baseParams);
+			try {
+				data = await mwn.uploadFromUrl(url, title, '', params);
+			} catch (error) {
+				const errorText = errorMessage(error);
+				if (errorText.includes('copyuploaddisabled')) {
+					return ctx.format.error(
+						'upstream_failure',
+						`Could not retrieve the file from ${url}: the server could not reach it and the wiki has upload-by-URL disabled.`,
+						'copyuploaddisabled',
+					);
+				}
+				throw error;
 			}
-			throw error;
 		}
 
 		const imageinfo = (

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -5,6 +5,7 @@ import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.js';
 import type { ToolContext } from '../runtime/context.js';
 import { errorMessage } from '../errors/isErrnoException.js';
+import { fetchFileBytes, shouldRescueToWiki } from '../transport/httpFetch.js';
 import { formatEditComment, buildPageUrl } from '../wikis/utils.js';
 
 const inputSchema = {
@@ -17,7 +18,7 @@ const inputSchema = {
 export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 	name: 'upload-file-from-url',
 	description:
-		"Fetches a file from a remote web URL and uploads it into the wiki's File namespace, returning the resulting file title and URL. The upload appears in the wiki's upload log. Requires the wiki to have upload-by-URL enabled; if it is disabled, download the file locally and use upload-file instead. Fails if a file with the target title already exists. To replace an existing file with a new revision, use update-file-from-url.",
+		"Fetches a file from a remote web URL and uploads it into the wiki's File namespace, returning the resulting file title and URL. The upload appears in the wiki's upload log. Works whether or not the wiki has upload-by-URL enabled: the server retrieves the file and uploads it directly, falling back to wiki-side fetching only when it cannot reach the URL itself. Fails if a file with the target title already exists. To replace an existing file with a new revision, use update-file-from-url.",
 	inputSchema,
 	annotations: {
 		title: 'Upload file from URL',
@@ -34,23 +35,39 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 		const baseParams: ApiUploadParams = {
 			comment: formatEditComment('upload-file-from-url', comment),
 		};
-		const params = ctx.edit.applyTags<ApiUploadParams>(baseParams);
+
+		// Server-first: fetch the bytes ourselves (SSRF-guarded, size-capped) and
+		// upload via a normal multipart request, so the wiki needs no copy-upload
+		// config or upload_by_url right.
+		let bytes: Buffer | undefined;
+		try {
+			bytes = await fetchFileBytes(url);
+		} catch (error) {
+			if (!shouldRescueToWiki(error)) {
+				throw error;
+			}
+			// Reachability/size failure → fall through to wiki-side copy-upload.
+		}
 
 		let data: ApiUploadResponse;
-		try {
-			data = await mwn.uploadFromUrl(url, title, text, params);
-		} catch (error) {
-			const errorText = errorMessage(error);
-			// Prevent the LLM from attempting to find an existing image on the wiki
-			// after failing to upload by URL.
-			if (errorText.includes('copyuploaddisabled')) {
-				return ctx.format.error(
-					'invalid_input',
-					'Upload by URL is disabled on this wiki. Download the file locally, then use upload-file with the local file path.',
-					'copyuploaddisabled',
-				);
+		if (bytes !== undefined) {
+			const partName = title.replace(/^File:/, '');
+			data = await ctx.edit.submitUploadFromBytes(mwn, bytes, partName, title, text, baseParams);
+		} else {
+			const params = ctx.edit.applyTags<ApiUploadParams>(baseParams);
+			try {
+				data = await mwn.uploadFromUrl(url, title, text, params);
+			} catch (error) {
+				const errorText = errorMessage(error);
+				if (errorText.includes('copyuploaddisabled')) {
+					return ctx.format.error(
+						'upstream_failure',
+						`Could not retrieve the file from ${url}: the server could not reach it and the wiki has upload-by-URL disabled.`,
+						'copyuploaddisabled',
+					);
+				}
+				throw error;
 			}
-			throw error;
 		}
 
 		const imageinfo = (

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -1,8 +1,25 @@
 import fetch, { Response, FetchError } from 'node-fetch';
 import { USER_AGENT } from '../runtime/constants.js';
+import { isErrnoException } from '../errors/isErrnoException.js';
 import { assertPublicDestination, buildPinnedAgent, SsrfValidationError } from './ssrfGuard.js';
 
 const MAX_REDIRECTS = 5;
+
+// Node syscall error codes that mean "the server could not reach the source"
+// (DNS failure, connection refused/reset, unreachable/timed-out). These should
+// rescue to wiki-side copy-upload — the wiki may reach a host the server can't.
+// DNS failures (ENOTFOUND/EAI_AGAIN) surface from assertPublicDestination's
+// lookup BEFORE node-fetch runs, so they arrive as plain Errors with a code
+// rather than as a node-fetch FetchError.
+const RESCUABLE_SYSCALL_CODES = new Set([
+	'ENOTFOUND',
+	'EAI_AGAIN',
+	'ECONNREFUSED',
+	'ECONNRESET',
+	'ETIMEDOUT',
+	'EHOSTUNREACH',
+	'ENETUNREACH',
+]);
 
 const DEFAULT_UPLOAD_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
 const FETCH_TIMEOUT_MS = 30_000;
@@ -198,5 +215,13 @@ export function shouldRescueToWiki(error: unknown): boolean {
 	) {
 		return true;
 	}
-	return error instanceof Error && error.name === 'AbortError';
+	if (isErrnoException(error)) {
+		if (error.name === 'AbortError') {
+			return true;
+		}
+		if (typeof error.code === 'string' && RESCUABLE_SYSCALL_CODES.has(error.code)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -1,8 +1,49 @@
-import fetch, { Response } from 'node-fetch';
+import fetch, { Response, FetchError } from 'node-fetch';
 import { USER_AGENT } from '../runtime/constants.js';
-import { assertPublicDestination, buildPinnedAgent } from './ssrfGuard.js';
+import { assertPublicDestination, buildPinnedAgent, SsrfValidationError } from './ssrfGuard.js';
 
 const MAX_REDIRECTS = 5;
+
+const DEFAULT_UPLOAD_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
+const FETCH_TIMEOUT_MS = 30_000;
+
+// Operator-owned cap on the server-side fetch used by upload-file-from-url /
+// update-file-from-url. Guards THIS server's memory; the wiki's own
+// $wgMaxUploadSize is separate. Over-cap is not fatal — the tools route to
+// wiki-side copy-upload instead.
+function resolveUploadMaxBytes(): number {
+	const raw = process.env.MCP_UPLOAD_MAX_BYTES;
+	if (raw === undefined || raw === '') {
+		return DEFAULT_UPLOAD_MAX_BYTES;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return DEFAULT_UPLOAD_MAX_BYTES;
+	}
+	return parsed;
+}
+
+/** A fetched URL responded with a non-2xx status: the source was reachable but rejected the request. */
+export class HttpStatusError extends Error {
+	public readonly status: number;
+	public constructor(status: number, url: string, body?: string) {
+		super(`HTTP error! status: ${status} for URL: ${url}.${body ? ` Response: ${body}` : ''}`);
+		this.name = 'HttpStatusError';
+		this.status = status;
+	}
+}
+
+/** A fetched body exceeded the server-side size cap (MCP_UPLOAD_MAX_BYTES). */
+export class FileTooLargeError extends Error {
+	public readonly size: number;
+	public readonly limit: number;
+	public constructor(size: number, limit: number) {
+		super(`Fetched file is ${size} bytes, over the ${limit}-byte limit (MCP_UPLOAD_MAX_BYTES).`);
+		this.name = 'FileTooLargeError';
+		this.size = size;
+		this.limit = limit;
+	}
+}
 
 async function fetchCore(
 	baseUrl: string,
@@ -67,10 +108,8 @@ async function fetchCore(
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- definite-assignment via the loop's at-least-once invariant; TS can't prove it
 	const finalResponse = response as Response;
 	if (!finalResponse.ok) {
-		const errorBody = await finalResponse.text().catch(() => 'Could not read error response body');
-		throw new Error(
-			`HTTP error! status: ${finalResponse.status} for URL: ${finalResponse.url}. Response: ${errorBody}`,
-		);
+		const errorBody = await finalResponse.text().catch(() => '');
+		throw new HttpStatusError(finalResponse.status, finalResponse.url, errorBody);
 	}
 	return finalResponse;
 }
@@ -96,4 +135,68 @@ export async function fetchPageHtml(url: string): Promise<string | null> {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Fetches a URL's bytes through the SSRF guard (DNS pinning, redirect validation),
+ * enforcing a size cap and an overall timeout. Used to upload an arbitrary,
+ * untrusted source URL to a wiki without relying on the wiki's copy-upload
+ * feature — and without sending the wiki's credentials to the source host.
+ *
+ * Throws: SsrfValidationError (non-public address), FileTooLargeError (over cap),
+ * HttpStatusError (source returned non-2xx), or node-fetch FetchError / AbortError
+ * (unreachable / timed out). Callers use shouldRescueToWiki() to decide whether to
+ * fall back to wiki-side copy-upload.
+ */
+export async function fetchFileBytes(
+	url: string,
+	options?: { maxBytes?: number; timeoutMs?: number },
+): Promise<Buffer> {
+	const maxBytes = options?.maxBytes ?? resolveUploadMaxBytes();
+	const timeoutMs = options?.timeoutMs ?? FETCH_TIMEOUT_MS;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const response = await fetchCore(url, { signal: controller.signal });
+		const declared = Number(response.headers.get('content-length'));
+		if (Number.isFinite(declared) && declared > maxBytes) {
+			throw new FileTooLargeError(declared, maxBytes);
+		}
+		const chunks: Buffer[] = [];
+		let total = 0;
+		if (response.body !== null) {
+			// node-fetch v3 exposes the body as a Node Readable (async-iterable).
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; narrowing to AsyncIterable<Buffer> is safe at this boundary
+			for await (const chunk of response.body as AsyncIterable<Buffer>) {
+				total += chunk.length;
+				if (total > maxBytes) {
+					throw new FileTooLargeError(total, maxBytes);
+				}
+				chunks.push(chunk);
+			}
+		}
+		return Buffer.concat(chunks);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Whether a failed server-side fetch should fall back to wiki-side copy-upload.
+ * Rescue when the server couldn't obtain the bytes for a reachability/size
+ * reason (the wiki might still reach the source); do NOT rescue when the source
+ * was reached and rejected the request (the wiki would hit the same response).
+ */
+export function shouldRescueToWiki(error: unknown): boolean {
+	if (error instanceof HttpStatusError) {
+		return false;
+	}
+	if (
+		error instanceof FileTooLargeError ||
+		error instanceof SsrfValidationError ||
+		error instanceof FetchError
+	) {
+		return true;
+	}
+	return error instanceof Error && error.name === 'AbortError';
 }

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -75,6 +75,7 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 		edit: {
 			submit: throws('edit.submit') as never,
 			submitUpload: throws('edit.submitUpload') as never,
+			submitUploadFromBytes: throws('edit.submitUploadFromBytes') as never,
 			applyTags: (o) => ({ ...o }),
 		},
 		revision: new RevisionNormalizerImpl(),

--- a/tests/services/editService.test.ts
+++ b/tests/services/editService.test.ts
@@ -109,6 +109,9 @@ describe('EditServiceImpl', () => {
 			tags: 'mcp-upload',
 		});
 		expect(params.file).toMatchObject({ name: 'F.png' });
+		// The file part must be a Buffer — form-data rejects a plain Readable
+		// (no known length) with "Unknown stream" at request time.
+		expect(Buffer.isBuffer(params.file.stream)).toBe(true);
 		expect(opts).toEqual({ headers: { 'Content-Type': 'multipart/form-data' } });
 	});
 });

--- a/tests/services/editService.test.ts
+++ b/tests/services/editService.test.ts
@@ -82,4 +82,33 @@ describe('EditServiceImpl', () => {
 			tags: 'mcp-upload',
 		});
 	});
+
+	it('submitUploadFromBytes posts a multipart upload with token, tags, and ignorewarnings', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('CSRFTOKEN'),
+			request: vi.fn().mockResolvedValue({ upload: { result: 'Success', filename: 'F.png' } }),
+		});
+		const edit = new EditServiceImpl(fakeActiveWiki('mcp-upload'));
+		const result = await edit.submitUploadFromBytes(
+			mock as never,
+			Buffer.from('bytes'),
+			'F.png',
+			'File:F.png',
+			'desc',
+			{ comment: 'c' },
+		);
+		expect(result).toEqual({ result: 'Success', filename: 'F.png' });
+		const [params, opts] = mock.request.mock.calls[0];
+		expect(params).toMatchObject({
+			action: 'upload',
+			filename: 'File:F.png',
+			text: 'desc',
+			comment: 'c',
+			ignorewarnings: true,
+			token: 'CSRFTOKEN',
+			tags: 'mcp-upload',
+		});
+		expect(params.file).toMatchObject({ name: 'F.png' });
+		expect(opts).toEqual({ headers: { 'Content-Type': 'multipart/form-data' } });
+	});
 });

--- a/tests/tools/update-file-from-url.test.ts
+++ b/tests/tools/update-file-from-url.test.ts
@@ -1,37 +1,69 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FetchError } from 'node-fetch';
 import { createMockMwn } from '../helpers/mock-mwn.js';
+import { createMockMwnError } from '../helpers/mock-mwn-error.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 
 vi.mock('../../src/transport/fileExistence.js', async () => {
 	const actual = await vi.importActual<typeof import('../../src/transport/fileExistence.js')>(
 		'../../src/transport/fileExistence.js',
 	);
-	return {
-		...actual,
-		assertFileExists: vi.fn(),
-	};
+	return { ...actual, assertFileExists: vi.fn() };
+});
+
+vi.mock('../../src/transport/httpFetch.js', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/httpFetch.js')>(
+		'../../src/transport/httpFetch.js',
+	);
+	return { ...actual, fetchFileBytes: vi.fn() };
 });
 
 import { assertFileExists, FileNotFoundError } from '../../src/transport/fileExistence.js';
+import { fetchFileBytes } from '../../src/transport/httpFetch.js';
 import { updateFileFromUrl } from '../../src/tools/update-file-from-url.js';
 import { dispatch } from '../../src/runtime/dispatcher.js';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
 
+const UPLOAD_OK = {
+	result: 'Success',
+	filename: 'Cat.jpg',
+	imageinfo: {
+		descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+		url: 'https://test.wiki/images/Cat.jpg',
+	},
+};
+
+function ctxWithServerUpload(
+	mock: ReturnType<typeof createMockMwn>,
+	submitUploadFromBytes = vi.fn().mockResolvedValue(UPLOAD_OK),
+	applyTags: (o: object) => object = (o) => ({ ...o }),
+) {
+	return fakeContext({
+		mwn: async () => mock as never,
+		edit: {
+			submit: vi.fn() as never,
+			submitUpload: vi.fn() as never,
+			submitUploadFromBytes: submitUploadFromBytes as never,
+			applyTags: applyTags as never,
+		},
+	});
+}
+
 describe('update-file-from-url', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.mocked(assertFileExists).mockResolvedValue(undefined);
+		vi.mocked(fetchFileBytes).mockResolvedValue(Buffer.from('IMG'));
 	});
 
 	it('returns not_found with routing hint when the file does not exist', async () => {
 		vi.mocked(assertFileExists).mockRejectedValue(new FileNotFoundError('Cat.jpg'));
 		const mock = createMockMwn({ uploadFromUrl: vi.fn() });
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		const submit = vi.fn();
+		const ctx = ctxWithServerUpload(mock, submit);
 
 		const result = await updateFileFromUrl.handle(
-			{
-				url: 'https://example.com/cat.jpg',
-				title: 'Cat.jpg',
-			},
+			{ url: 'https://example.com/cat.jpg', title: 'Cat.jpg' },
 			ctx,
 		);
 
@@ -39,28 +71,42 @@ describe('update-file-from-url', () => {
 		expect(envelope.message).toMatch(/Cat\.jpg/);
 		expect(envelope.message).toMatch(/upload-file-from-url\b/);
 		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
+		expect(submit).not.toHaveBeenCalled();
 	});
 
-	it('calls mwn.uploadFromUrl with ignorewarnings: true and the formatted comment', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockResolvedValue({
-				result: 'Success',
-				filename: 'Cat.jpg',
-				imageinfo: {
-					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
-					url: 'https://test.wiki/images/Cat.jpg',
-				},
+	it('server-first: fetches the bytes and uploads via multipart with text=""', async () => {
+		const mock = createMockMwn({ uploadFromUrl: vi.fn() });
+		const submit = vi.fn().mockResolvedValue(UPLOAD_OK);
+		const ctx = ctxWithServerUpload(mock, submit);
+
+		const result = await updateFileFromUrl.handle(
+			{ url: 'https://example.com/cat.jpg', title: 'File:Cat.jpg', comment: 'Higher res' },
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('Filename: Cat.jpg');
+		expect(submit).toHaveBeenCalledWith(
+			mock,
+			expect.any(Buffer),
+			'Cat.jpg',
+			'File:Cat.jpg',
+			'',
+			expect.objectContaining({
+				ignorewarnings: true,
+				comment: expect.stringMatching(/^Higher res.*update-file-from-url/),
 			}),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		);
+		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
+	});
+
+	it('rescues to wiki copy-upload (ignorewarnings:true, text="") when the server cannot reach', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('refused', 'system'));
+		const mock = createMockMwn({ uploadFromUrl: vi.fn().mockResolvedValue(UPLOAD_OK) });
+		const ctx = ctxWithServerUpload(mock, vi.fn());
 
 		await updateFileFromUrl.handle(
-			{
-				url: 'https://example.com/cat.jpg',
-				title: 'File:Cat.jpg',
-				comment: 'Higher resolution',
-			},
+			{ url: 'https://example.com/cat.jpg', title: 'File:Cat.jpg', comment: 'Higher res' },
 			ctx,
 		);
 
@@ -70,124 +116,51 @@ describe('update-file-from-url', () => {
 			'',
 			expect.objectContaining({
 				ignorewarnings: true,
-				comment: expect.stringMatching(/^Higher resolution.*update-file-from-url/),
+				comment: expect.stringMatching(/^Higher res.*update-file-from-url/),
 			}),
 		);
-	});
-
-	it('returns the same structured payload as upload-file-from-url on success', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockResolvedValue({
-				result: 'Success',
-				filename: 'Cat.jpg',
-				imageinfo: {
-					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
-					url: 'https://test.wiki/images/Cat.jpg',
-				},
-			}),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
-
-		const result = await updateFileFromUrl.handle(
-			{
-				url: 'https://example.com/cat.jpg',
-				title: 'File:Cat.jpg',
-			},
-			ctx,
-		);
-
-		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Filename: Cat.jpg');
-		expect(text).toContain('Page URL: https://test.wiki/wiki/File:Cat.jpg');
-		expect(text).toContain('File URL: https://test.wiki/images/Cat.jpg');
-	});
-
-	it('maps copyuploaddisabled errors to invalid_input with the routing hint', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
-		const mock = createMockMwn({
-			uploadFromUrl: vi
-				.fn()
-				.mockRejectedValue(
-					new Error('copyuploaddisabled: Upload by URL is disabled on this wiki.'),
-				),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
-
-		const result = await updateFileFromUrl.handle(
-			{
-				url: 'https://example.com/cat.jpg',
-				title: 'File:Cat.jpg',
-			},
-			ctx,
-		);
-
-		const envelope = assertStructuredError(result, 'invalid_input');
-		expect(envelope.code).toBe('copyuploaddisabled');
-		expect(envelope.message).toMatch(/Download the file locally.*update-file\b/);
 	});
 
 	it('dispatches generic upload errors with the standard verb prefix', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockRejectedValue(new Error('Boom')),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('refused', 'system'));
+		const mock = createMockMwn({ uploadFromUrl: vi.fn().mockRejectedValue(new Error('Boom')) });
+		const ctx = ctxWithServerUpload(mock, vi.fn());
 
 		const result = await dispatch(
 			updateFileFromUrl,
 			ctx,
-		)({
-			url: 'https://example.com/cat.jpg',
-			title: 'File:Cat.jpg',
-		});
+		)({ url: 'https://example.com/cat.jpg', title: 'File:Cat.jpg' });
 
 		const envelope = assertStructuredError(result, 'upstream_failure');
 		expect(envelope.message).toMatch(/Failed to update file: Boom/);
 	});
 
 	it('maps permissiondenied-coded errors to permission_denied', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
-		const err = Object.assign(new Error('You cannot reupload'), { code: 'permissiondenied' });
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockRejectedValue(err),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('refused', 'system'));
+		const err = createMockMwnError('permissiondenied', 'You cannot reupload');
+		const mock = createMockMwn({ uploadFromUrl: vi.fn().mockRejectedValue(err) });
+		const ctx = ctxWithServerUpload(mock, vi.fn());
 
 		const result = await dispatch(
 			updateFileFromUrl,
 			ctx,
-		)({
-			url: 'https://example.com/cat.jpg',
-			title: 'File:Cat.jpg',
-		});
+		)({ url: 'https://example.com/cat.jpg', title: 'File:Cat.jpg' });
 
 		assertStructuredError(result, 'permission_denied');
 	});
 
-	it('forwards configured tags via ctx.edit.applyTags', async () => {
-		vi.mocked(assertFileExists).mockResolvedValue(undefined);
+	it('forwards configured tags on the wiki-rescue path via applyTags', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('refused', 'system'));
 		const mock = createMockMwn({
 			uploadFromUrl: vi.fn().mockResolvedValue({ result: 'Success', filename: 'Cat.jpg' }),
 		});
-		const ctx = fakeContext({
-			mwn: async () => mock as never,
-			edit: {
-				submit: vi.fn() as never,
-				submitUpload: vi.fn() as never,
-				applyTags: (o: object) => ({ ...o, tags: 'mcp-server' }),
-			},
-		});
+		const ctx = ctxWithServerUpload(mock, vi.fn(), (o) => ({ ...o, tags: 'mcp-server' }));
 
 		await updateFileFromUrl.handle(
-			{
-				url: 'https://example.com/cat.jpg',
-				title: 'File:Cat.jpg',
-			},
+			{ url: 'https://example.com/cat.jpg', title: 'File:Cat.jpg' },
 			ctx,
 		);
 
-		const params = mock.uploadFromUrl.mock.calls[0][3];
-		expect(params).toHaveProperty('tags', 'mcp-server');
+		expect(mock.uploadFromUrl.mock.calls[0][3]).toHaveProperty('tags', 'mcp-server');
 	});
 });

--- a/tests/tools/upload-file-from-url.test.ts
+++ b/tests/tools/upload-file-from-url.test.ts
@@ -127,6 +127,22 @@ describe('upload-file-from-url', () => {
 		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
 	});
 
+	it('surfaces a permissiondenied from the server-side upload as permission_denied (no rescue)', async () => {
+		const mock = createMockMwn({ uploadFromUrl: vi.fn() });
+		const submit = vi
+			.fn()
+			.mockRejectedValue(createMockMwnError('permissiondenied', 'You do not have permission'));
+		const ctx = ctxWithServerUpload(mock, submit);
+
+		const result = await dispatch(
+			uploadFileFromUrl,
+			ctx,
+		)({ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: '' });
+
+		assertStructuredError(result, 'permission_denied');
+		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
+	});
+
 	it('when server cannot reach AND wiki copy-uploads disabled, returns a combined upstream_failure', async () => {
 		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('timeout', 'system'));
 		const mock = createMockMwn({

--- a/tests/tools/upload-file-from-url.test.ts
+++ b/tests/tools/upload-file-from-url.test.ts
@@ -1,31 +1,62 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FetchError } from 'node-fetch';
 import { createMockMwn } from '../helpers/mock-mwn.js';
 import { createMockMwnError } from '../helpers/mock-mwn-error.js';
 import { fakeContext } from '../helpers/fakeContext.js';
+
+vi.mock('../../src/transport/httpFetch.js', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/httpFetch.js')>(
+		'../../src/transport/httpFetch.js',
+	);
+	return { ...actual, fetchFileBytes: vi.fn() };
+});
+
+import {
+	fetchFileBytes,
+	FileTooLargeError,
+	HttpStatusError,
+} from '../../src/transport/httpFetch.js';
 import { uploadFileFromUrl } from '../../src/tools/upload-file-from-url.js';
 import { dispatch } from '../../src/runtime/dispatcher.js';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
 
+const UPLOAD_OK = {
+	result: 'Success',
+	filename: 'Cat.jpg',
+	imageinfo: {
+		descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
+		url: 'https://test.wiki/images/Cat.jpg',
+	},
+};
+
+function ctxWithServerUpload(
+	mock: ReturnType<typeof createMockMwn>,
+	submitUploadFromBytes = vi.fn().mockResolvedValue(UPLOAD_OK),
+) {
+	return fakeContext({
+		mwn: async () => mock as never,
+		edit: {
+			submit: vi.fn() as never,
+			submitUpload: vi.fn() as never,
+			submitUploadFromBytes: submitUploadFromBytes as never,
+			applyTags: (o: object) => ({ ...o }),
+		},
+	});
+}
+
 describe('upload-file-from-url', () => {
-	it('returns a structured payload on success', async () => {
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockResolvedValue({
-				result: 'Success',
-				filename: 'Cat.jpg',
-				imageinfo: {
-					descriptionurl: 'https://test.wiki/wiki/File:Cat.jpg',
-					url: 'https://test.wiki/images/Cat.jpg',
-				},
-			}),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(fetchFileBytes).mockResolvedValue(Buffer.from('IMG'));
+	});
+
+	it('server-first: fetches the bytes and uploads via multipart, not wiki copy-upload', async () => {
+		const mock = createMockMwn({ uploadFromUrl: vi.fn() });
+		const submit = vi.fn().mockResolvedValue(UPLOAD_OK);
+		const ctx = ctxWithServerUpload(mock, submit);
 
 		const result = await uploadFileFromUrl.handle(
-			{
-				url: 'https://source.example/cat.jpg',
-				title: 'File:Cat.jpg',
-				text: 'A cat.',
-			},
+			{ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: 'A cat.' },
 			ctx,
 		);
 
@@ -33,79 +64,109 @@ describe('upload-file-from-url', () => {
 		expect(text).toContain('Filename: Cat.jpg');
 		expect(text).toContain('Page URL: https://test.wiki/wiki/File:Cat.jpg');
 		expect(text).toContain('File URL: https://test.wiki/images/Cat.jpg');
+		expect(fetchFileBytes).toHaveBeenCalledWith('https://source.example/cat.jpg');
+		expect(submit).toHaveBeenCalledWith(
+			mock,
+			expect.any(Buffer),
+			'Cat.jpg',
+			'File:Cat.jpg',
+			'A cat.',
+			expect.objectContaining({ comment: expect.stringContaining('upload-file-from-url') }),
+		);
+		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
 	});
 
-	it('surfaces copyuploaddisabled as invalid_input with a remedy hint', async () => {
-		const mock = createMockMwn({
-			uploadFromUrl: vi
-				.fn()
-				.mockRejectedValue(
-					createMockMwnError(
-						'copyuploaddisabled',
-						'copyuploaddisabled: Uploads by URL are disabled on this wiki.',
-					),
-				),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+	it('rescues to wiki copy-upload when the server cannot reach the URL', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('connect ECONNREFUSED', 'system'));
+		const mock = createMockMwn({ uploadFromUrl: vi.fn().mockResolvedValue(UPLOAD_OK) });
+		const submit = vi.fn();
+		const ctx = ctxWithServerUpload(mock, submit);
 
 		const result = await uploadFileFromUrl.handle(
-			{
-				url: 'https://source.example/cat.jpg',
-				title: 'File:Cat.jpg',
-				text: 'A cat.',
-			},
+			{ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: 'A cat.' },
 			ctx,
 		);
 
-		const envelope = assertStructuredError(result, 'invalid_input', 'copyuploaddisabled');
-		expect(envelope.message).toMatch(/Upload by URL is disabled/);
+		assertStructuredSuccess(result);
+		expect(mock.uploadFromUrl).toHaveBeenCalledWith(
+			'https://source.example/cat.jpg',
+			'File:Cat.jpg',
+			'A cat.',
+			expect.objectContaining({ comment: expect.stringContaining('upload-file-from-url') }),
+		);
+		expect(submit).not.toHaveBeenCalled();
 	});
 
-	it('dispatches generic upstream failures with the standard verb prefix', async () => {
-		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockRejectedValue(new Error('Connection refused')),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+	it('rescues to wiki copy-upload when the file exceeds the size cap', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FileTooLargeError(200_000_000, 104_857_600));
+		const mock = createMockMwn({ uploadFromUrl: vi.fn().mockResolvedValue(UPLOAD_OK) });
+		const ctx = ctxWithServerUpload(mock, vi.fn());
+
+		const result = await uploadFileFromUrl.handle(
+			{ url: 'https://source.example/big.tif', title: 'File:Big.tif', text: '' },
+			ctx,
+		);
+
+		assertStructuredSuccess(result);
+		expect(mock.uploadFromUrl).toHaveBeenCalled();
+	});
+
+	it('does NOT rescue when the source returns an HTTP error; surfaces upstream_failure', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(
+			new HttpStatusError(404, 'https://source.example/cat.jpg'),
+		);
+		const mock = createMockMwn({ uploadFromUrl: vi.fn() });
+		const ctx = ctxWithServerUpload(mock, vi.fn());
 
 		const result = await dispatch(
 			uploadFileFromUrl,
 			ctx,
-		)({
-			url: 'https://source.example/cat.jpg',
-			title: 'File:Cat.jpg',
-			text: 'A cat.',
-		});
+		)({ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: '' });
 
-		const envelope = assertStructuredError(result, 'upstream_failure');
-		expect(envelope.message).toMatch(/Failed to upload file: Connection refused/);
+		assertStructuredError(result, 'upstream_failure');
+		expect(mock.uploadFromUrl).not.toHaveBeenCalled();
 	});
 
-	it('forwards configured tags via ctx.edit.applyTags', async () => {
+	it('when server cannot reach AND wiki copy-uploads disabled, returns a combined upstream_failure', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('timeout', 'system'));
 		const mock = createMockMwn({
-			uploadFromUrl: vi.fn().mockResolvedValue({
-				result: 'Success',
-				filename: 'Cat.jpg',
-			}),
+			uploadFromUrl: vi
+				.fn()
+				.mockRejectedValue(
+					createMockMwnError('copyuploaddisabled', 'copyuploaddisabled: disabled'),
+				),
+		});
+		const ctx = ctxWithServerUpload(mock, vi.fn());
+
+		const result = await uploadFileFromUrl.handle(
+			{ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: '' },
+			ctx,
+		);
+
+		const envelope = assertStructuredError(result, 'upstream_failure', 'copyuploaddisabled');
+		expect(envelope.message).toMatch(/could not reach it and the wiki has upload-by-URL disabled/);
+	});
+
+	it('forwards configured tags on the wiki-rescue path via applyTags', async () => {
+		vi.mocked(fetchFileBytes).mockRejectedValue(new FetchError('refused', 'system'));
+		const mock = createMockMwn({
+			uploadFromUrl: vi.fn().mockResolvedValue({ result: 'Success', filename: 'Cat.jpg' }),
 		});
 		const ctx = fakeContext({
 			mwn: async () => mock as never,
 			edit: {
 				submit: vi.fn() as never,
 				submitUpload: vi.fn() as never,
+				submitUploadFromBytes: vi.fn() as never,
 				applyTags: (o: object) => ({ ...o, tags: 'mcp-server' }),
 			},
 		});
 
 		await uploadFileFromUrl.handle(
-			{
-				url: 'https://source.example/cat.jpg',
-				title: 'File:Cat.jpg',
-				text: 'A cat.',
-			},
+			{ url: 'https://source.example/cat.jpg', title: 'File:Cat.jpg', text: 'A cat.' },
 			ctx,
 		);
 
-		const params = mock.uploadFromUrl.mock.calls[0][3];
-		expect(params).toHaveProperty('tags', 'mcp-server');
+		expect(mock.uploadFromUrl.mock.calls[0][3]).toHaveProperty('tags', 'mcp-server');
 	});
 });

--- a/tests/transport/httpFetch.test.ts
+++ b/tests/transport/httpFetch.test.ts
@@ -253,4 +253,22 @@ describe('shouldRescueToWiki', () => {
 		expect(shouldRescueToWiki(abort)).toBe(true);
 		expect(shouldRescueToWiki(new Error('other'))).toBe(false);
 	});
+
+	it('rescues on Node reachability syscall codes (DNS / connection failures)', () => {
+		// DNS failure surfaces from assertPublicDestination's lookup, before
+		// node-fetch — a plain Error with a syscall code, not a FetchError.
+		const dnsFail = Object.assign(new Error('getaddrinfo ENOTFOUND src.example'), {
+			code: 'ENOTFOUND',
+		});
+		expect(shouldRescueToWiki(dnsFail)).toBe(true);
+		const transientDns = Object.assign(new Error('getaddrinfo EAI_AGAIN src.example'), {
+			code: 'EAI_AGAIN',
+		});
+		expect(shouldRescueToWiki(transientDns)).toBe(true);
+		const refused = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+		expect(shouldRescueToWiki(refused)).toBe(true);
+		// A coded error that is NOT a reachability failure must not rescue.
+		const other = Object.assign(new Error('boom'), { code: 'EPERM' });
+		expect(shouldRescueToWiki(other)).toBe(false);
+	});
 });

--- a/tests/transport/httpFetch.test.ts
+++ b/tests/transport/httpFetch.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Response } from 'node-fetch';
 
 vi.mock('node-fetch', async () => {
 	const actual = await vi.importActual<typeof import('node-fetch')>('node-fetch');
@@ -9,14 +8,27 @@ vi.mock('node-fetch', async () => {
 	};
 });
 
-vi.mock('../../src/transport/ssrfGuard.js', () => ({
-	assertPublicDestination: vi.fn(),
-	buildPinnedAgent: vi.fn(),
-}));
+vi.mock('../../src/transport/ssrfGuard.js', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/ssrfGuard.js')>(
+		'../../src/transport/ssrfGuard.js',
+	);
+	return { ...actual, assertPublicDestination: vi.fn(), buildPinnedAgent: vi.fn() };
+});
 
-import fetch from 'node-fetch';
-import { assertPublicDestination, buildPinnedAgent } from '../../src/transport/ssrfGuard.js';
-import { makeApiRequest, fetchPageHtml } from '../../src/transport/httpFetch.js';
+import fetch, { Response, FetchError } from 'node-fetch';
+import {
+	assertPublicDestination,
+	buildPinnedAgent,
+	SsrfValidationError,
+} from '../../src/transport/ssrfGuard.js';
+import {
+	makeApiRequest,
+	fetchPageHtml,
+	fetchFileBytes,
+	shouldRescueToWiki,
+	HttpStatusError,
+	FileTooLargeError,
+} from '../../src/transport/httpFetch.js';
 
 describe('utils.fetchCore (via makeApiRequest / fetchPageHtml)', () => {
 	beforeEach(() => {
@@ -188,5 +200,57 @@ describe('utils.fetchCore (via makeApiRequest / fetchPageHtml)', () => {
 		expect(
 			fetch.mock ? fetch.mock.calls.length : vi.mocked(fetch).mock.calls.length,
 		).toBeLessThanOrEqual(6);
+	});
+});
+
+describe('fetchFileBytes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(assertPublicDestination).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+		vi.mocked(buildPinnedAgent).mockReturnValue({ __pinned: true } as never);
+	});
+
+	it('returns the body bytes when under the cap', async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(Buffer.from('hello'), { status: 200, headers: { 'content-length': '5' } }),
+		);
+		const buf = await fetchFileBytes('https://src.example/cat.jpg', { maxBytes: 1024 });
+		expect(buf.toString()).toBe('hello');
+	});
+
+	it('throws FileTooLargeError when content-length exceeds the cap', async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(Buffer.from('hello'), { status: 200, headers: { 'content-length': '5' } }),
+		);
+		await expect(
+			fetchFileBytes('https://src.example/big.bin', { maxBytes: 3 }),
+		).rejects.toBeInstanceOf(FileTooLargeError);
+	});
+
+	it('throws FileTooLargeError when the streamed body exceeds the cap', async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(new Response(Buffer.from('hello'), { status: 200 }));
+		await expect(
+			fetchFileBytes('https://src.example/big.bin', { maxBytes: 3 }),
+		).rejects.toBeInstanceOf(FileTooLargeError);
+	});
+
+	it('throws HttpStatusError on a non-2xx source response', async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(new Response('nope', { status: 404 }));
+		await expect(fetchFileBytes('https://src.example/missing.jpg')).rejects.toBeInstanceOf(
+			HttpStatusError,
+		);
+	});
+});
+
+describe('shouldRescueToWiki', () => {
+	it('rescues on reachability/size failures, not on HTTP status', () => {
+		expect(shouldRescueToWiki(new HttpStatusError(404, 'https://x/'))).toBe(false);
+		expect(shouldRescueToWiki(new FileTooLargeError(10, 5))).toBe(true);
+		expect(shouldRescueToWiki(new SsrfValidationError('nope'))).toBe(true);
+		expect(shouldRescueToWiki(new FetchError('boom', 'system'))).toBe(true);
+		const abort = new Error('aborted');
+		abort.name = 'AbortError';
+		expect(shouldRescueToWiki(abort)).toBe(true);
+		expect(shouldRescueToWiki(new Error('other'))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

`upload-file-from-url` and `update-file-from-url` previously delegated the fetch to the wiki (`action=upload&url=`), which only works when the wiki has `$wgAllowCopyUploads` enabled **and** the account holds the `upload_by_url` right — both off by default in MediaWiki, so the tools failed on most wikis.

These tools now use a **server-first + wiki-rescue** strategy:

- The MCP server fetches the file itself via a new SSRF-guarded, DNS-pinned, size-capped, timed `fetchFileBytes`, then uploads it with a normal multipart `action=upload` (new `EditService.submitUploadFromBytes`). This needs only the ordinary `upload` right — no copy-upload config.
- It falls back to wiki-side copy-upload (`mwn.uploadFromUrl`) **only** when the server can't reach the URL (DNS / connection / timeout / SSRF-blocked private address / over the size cap). A source that *is* reached but returns an HTTP error does **not** rescue (the wiki would hit the same response).
- Net security improvement: the common path is now SSRF-guarded, where the old wiki-fetch path had no guard from us.

New env var **`MCP_UPLOAD_MAX_BYTES`** (default 100 MB) caps what the server buffers; larger files are routed to the wiki's own copy-upload.

Tool input/output is unchanged — a URL goes in, a file gets uploaded. Descriptions, README env table, `server.json` (both blocks), and CHANGELOG are updated.

Relates to #393 as a stepping stone (a sandboxed server can let the *wiki* copy-upload from a reachable public location). #393 itself — uploads from files that live only in a client session — remains deferred; there is no clean, portable MCP mechanism for it yet.

## Test Plan

- [x] Full unit suite green (1123 tests); `tsgo --noEmit`, oxlint, oxfmt, and `npm run build` all clean.
- [x] Adversarial review pass; fixed: DNS/connection failures now rescue (they surface from the SSRF guard before node-fetch, as plain errors with syscall codes).
- [x] Smoke-tested against `en.wikipedia.org` via the MCP Inspector CLI on a local build:
  - `tools/list` shows the updated descriptions.
  - Server-side fetch + multipart upload reaches the wiki and returns `authentication: mustbeloggedin` for an anonymous call (the multipart form is valid; only auth is missing).
  - A source URL returning HTTP 400 surfaces as `upstream_failure` with **no** wiki rescue (correct).
  - This smoke test caught a real bug the mocked unit tests missed: wrapping the bytes in `Readable.from()` made form-data reject the upload with "Unknown stream"; fixed by passing the `Buffer` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)