### PR TITLE
Add NeoWiki read-only query and discovery tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- NeoWiki integration: tools to explore a NeoWiki knowledge graph — list schemas, inspect a schema's properties, search subjects by name, fetch a subject or a page's subjects, and run read-only Cypher queries. Available on wikis with the NeoWiki extension installed.
 - `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`. Images and files MediaWiki can rasterize (SVG, PDF, DjVu) come back as an image; non-renderable types (audio, video, binaries) error and point to `get-file`.
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
 - `whoami` tool: reports which account the current session is acting as on a wiki — the username, whether the session is anonymous, and the user groups it belongs to (optionally the full rights list). Use it to confirm who edits will be attributed to before writing, for example when creating a page under your own user namespace.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `cargo-query` | Run a [Cargo extension](https://www.mediawiki.org/wiki/Extension:Cargo) SQL-style query. Enabled only when the wiki has Cargo installed. |
 | `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. Enabled only when the wiki has SMW installed. |
 | `smw-query` | Run a Semantic MediaWiki `#ask` query. Enabled only when the wiki has SMW installed. |
+| `neowiki-list-schemas` | List NeoWiki schemas (entity types) and their property counts. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-schema` | Get one NeoWiki schema's property definitions, relations, and select options. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-cypher-query` | Run a read-only Cypher query against the NeoWiki knowledge graph. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-search-subjects` | Find NeoWiki subject IDs by label within a schema. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-subject` | Fetch one NeoWiki subject's structured data by ID. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-page-subjects` | List the NeoWiki subjects attached to a wiki page. Enabled only when the wiki has NeoWiki installed. |
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `cargo-query` | Run a [Cargo extension](https://www.mediawiki.org/wiki/Extension:Cargo) SQL-style query. Enabled only when the wiki has Cargo installed. |
 | `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. Enabled only when the wiki has SMW installed. |
 | `smw-query` | Run a Semantic MediaWiki `#ask` query. Enabled only when the wiki has SMW installed. |
-| `neowiki-list-schemas` | List NeoWiki schemas (entity types) and their property counts. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-schema` | Get one NeoWiki schema's property definitions, relations, and select options. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-cypher-query` | Run a read-only Cypher query against the NeoWiki knowledge graph. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-search-subjects` | Find NeoWiki subject IDs by label within a schema. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-subject` | Fetch one NeoWiki subject's structured data by ID. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-page-subjects` | List the NeoWiki subjects attached to a wiki page. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-list-schemas` | List [NeoWiki](https://neowiki.ai/) schemas (entity types) and their property counts. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-schema` | Get one [NeoWiki](https://neowiki.ai/) schema's property definitions, relations, and select options. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-cypher-query` | Run a read-only Cypher query against the [NeoWiki](https://neowiki.ai/) knowledge graph. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-search-subjects` | Find [NeoWiki](https://neowiki.ai/) subject IDs by label within a schema. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-subject` | Fetch one [NeoWiki](https://neowiki.ai/) subject's structured data by ID. Enabled only when the wiki has NeoWiki installed. |
+| `neowiki-get-page-subjects` | List the [NeoWiki](https://neowiki.ai/) subjects attached to a wiki page. Enabled only when the wiki has NeoWiki installed. |
 
 ### Resources
 

--- a/src/tools/extensions/index.ts
+++ b/src/tools/extensions/index.ts
@@ -2,6 +2,12 @@ import type { ExtensionPack } from './types.js';
 import { smwPack } from './smw/index.js';
 import { bucketPack } from './bucket/index.js';
 import { cargoPack } from './cargo/index.js';
+import { neowikiPack } from './neowiki/index.js';
 
 export type { ExtensionPack } from './types.js';
-export const extensionPacks: readonly ExtensionPack[] = [smwPack, bucketPack, cargoPack];
+export const extensionPacks: readonly ExtensionPack[] = [
+	smwPack,
+	bucketPack,
+	cargoPack,
+	neowikiPack,
+];

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -1,8 +1,9 @@
 import type { ExtensionPack } from '../types.js';
 import { neowikiListSchemas } from './neowiki-list-schemas.js';
+import { neowikiGetSchema } from './neowiki-get-schema.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
 	extensionNames: ['NeoWiki'],
-	tools: [neowikiListSchemas],
+	tools: [neowikiListSchemas, neowikiGetSchema],
 };

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -3,9 +3,16 @@ import { neowikiListSchemas } from './neowiki-list-schemas.js';
 import { neowikiGetSchema } from './neowiki-get-schema.js';
 import { neowikiCypherQuery } from './neowiki-cypher-query.js';
 import { neowikiSearchSubjects } from './neowiki-search-subjects.js';
+import { neowikiGetSubject } from './neowiki-get-subject.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
 	extensionNames: ['NeoWiki'],
-	tools: [neowikiListSchemas, neowikiGetSchema, neowikiCypherQuery, neowikiSearchSubjects],
+	tools: [
+		neowikiListSchemas,
+		neowikiGetSchema,
+		neowikiCypherQuery,
+		neowikiSearchSubjects,
+		neowikiGetSubject,
+	],
 };

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -4,6 +4,7 @@ import { neowikiGetSchema } from './neowiki-get-schema.js';
 import { neowikiCypherQuery } from './neowiki-cypher-query.js';
 import { neowikiSearchSubjects } from './neowiki-search-subjects.js';
 import { neowikiGetSubject } from './neowiki-get-subject.js';
+import { neowikiGetPageSubjects } from './neowiki-get-page-subjects.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
@@ -14,5 +15,6 @@ export const neowikiPack: ExtensionPack = {
 		neowikiCypherQuery,
 		neowikiSearchSubjects,
 		neowikiGetSubject,
+		neowikiGetPageSubjects,
 	],
 };

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -1,9 +1,10 @@
 import type { ExtensionPack } from '../types.js';
 import { neowikiListSchemas } from './neowiki-list-schemas.js';
 import { neowikiGetSchema } from './neowiki-get-schema.js';
+import { neowikiCypherQuery } from './neowiki-cypher-query.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
 	extensionNames: ['NeoWiki'],
-	tools: [neowikiListSchemas, neowikiGetSchema],
+	tools: [neowikiListSchemas, neowikiGetSchema, neowikiCypherQuery],
 };

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -1,0 +1,8 @@
+import type { ExtensionPack } from '../types.js';
+import { neowikiListSchemas } from './neowiki-list-schemas.js';
+
+export const neowikiPack: ExtensionPack = {
+	id: 'neowiki',
+	extensionNames: ['NeoWiki'],
+	tools: [neowikiListSchemas],
+};

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -2,9 +2,10 @@ import type { ExtensionPack } from '../types.js';
 import { neowikiListSchemas } from './neowiki-list-schemas.js';
 import { neowikiGetSchema } from './neowiki-get-schema.js';
 import { neowikiCypherQuery } from './neowiki-cypher-query.js';
+import { neowikiSearchSubjects } from './neowiki-search-subjects.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
 	extensionNames: ['NeoWiki'],
-	tools: [neowikiListSchemas, neowikiGetSchema, neowikiCypherQuery],
+	tools: [neowikiListSchemas, neowikiGetSchema, neowikiCypherQuery, neowikiSearchSubjects],
 };

--- a/src/tools/extensions/neowiki/neowiki-cypher-query.ts
+++ b/src/tools/extensions/neowiki/neowiki-cypher-query.ts
@@ -13,7 +13,7 @@ const inputSchema = {
 			'A single read-only Cypher statement. Backtick-escape property names with spaces (`s.`Birth year``). Do NOT RETURN whole nodes — project scalar properties and cast temporals with toString().',
 		),
 	parameters: z
-		.record(z.unknown())
+		.record(z.string(), z.unknown())
 		.optional()
 		.describe(
 			'Parameter map referenced as $name in the query. Prefer this over string concatenation.',

--- a/src/tools/extensions/neowiki/neowiki-cypher-query.ts
+++ b/src/tools/extensions/neowiki/neowiki-cypher-query.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const inputSchema = {
+	cypher: z
+		.string()
+		.min(1)
+		.describe(
+			'A single read-only Cypher statement. Backtick-escape property names with spaces (`s.`Birth year``). Do NOT RETURN whole nodes — project scalar properties and cast temporals with toString().',
+		),
+	parameters: z
+		.record(z.unknown())
+		.optional()
+		.describe(
+			'Parameter map referenced as $name in the query. Prefer this over string concatenation.',
+		),
+} as const;
+
+interface CypherResponse {
+	columns?: unknown[];
+	rows?: unknown[];
+	resultCount?: number;
+	durationMs?: number;
+	truncated?: boolean;
+}
+
+export const neowikiCypherQuery: Tool<typeof inputSchema> = {
+	name: 'neowiki-cypher-query',
+	description:
+		'Runs a read-only Cypher query against the wiki\'s NeoWiki knowledge graph (Neo4j) and returns rows. Enabled only when the wiki has NeoWiki installed.\n\nDiscover the data model first — the graph CANNOT be introspected from Cypher (CALL db.labels(), db.schema.* and all procedure calls are rejected as not-read-only). Use neowiki-list-schemas for the entity types, then neowiki-get-schema for a type\'s properties and relations.\n\nGraph model:\n- Subjects are nodes labelled `:Subject` plus a per-schema label, e.g. (s:Subject:Person). Subject node properties are the schema\'s properties plus `id` and `name`; backtick-escape names with spaces: s.`Birth year`.\n- Pages are (:Page) nodes linked by (:Page)-[:HasSubject]->(:Subject). Subject-to-subject relations are typed edges named in the schema\'s `relation` field (see neowiki-get-schema).\n- `select` values are stored as opaque option IDs (e.g. o1abc…), not labels — decode them with neowiki-get-schema.\n\nGotchas:\n- Do NOT RETURN whole nodes: a node carrying a temporal property fails the request. Return specific scalar properties and cast temporals: toString(s.creationTime).\n- Plain list values (labels(n), collect(...)) come back as 1-indexed JSON objects ({"1":…,"2":…}), not arrays.\n- Read-only only; write clauses are rejected.\n\nLimits: ~5,000 rows / 30s by default (50,000 / 300s with the apihighlimits right). When `truncated` is true, narrow with WHERE or add LIMIT/SKIP. Pre-1.0: the NeoWiki API may change without notice.\n\nExample:\n  cypher: MATCH (s:Subject:Person) WHERE s.`Birth year` > $minYear RETURN s.name AS name, s.`Birth year` AS year ORDER BY year\n  parameters: { "minYear": 2000 }',
+	inputSchema,
+	annotations: {
+		title: 'Run NeoWiki Cypher query',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'run NeoWiki Cypher query',
+	target: (a) => a.cypher,
+
+	async handle({ cypher, parameters }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /query/cypher response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'POST',
+				path: '/query/cypher',
+				body: { cypher, ...(parameters !== undefined ? { parameters } : {}) },
+			})) as CypherResponse;
+
+			const columns = Array.isArray(data.columns) ? data.columns : [];
+			const rows = Array.isArray(data.rows) ? data.rows : [];
+			const truncation: TruncationInfo | null =
+				data.truncated === true
+					? {
+							reason: 'capped-no-continuation',
+							returnedCount: rows.length,
+							limit: rows.length,
+							itemNoun: 'rows',
+							narrowHint:
+								'narrow with WHERE, add LIMIT/SKIP to paginate, or use an account with the apihighlimits right for a higher cap.',
+						}
+					: null;
+
+			return ctx.format.ok({
+				columns,
+				rows,
+				resultCount: typeof data.resultCount === 'number' ? data.resultCount : rows.length,
+				...(typeof data.durationMs === 'number' ? { durationMs: data.durationMs } : {}),
+				...(truncation !== null ? { truncation } : {}),
+			});
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+import { flattenSubject } from './neowiki-get-subject.js';
+
+const inputSchema = {
+	title: z
+		.string()
+		.min(1)
+		.optional()
+		.describe('Wiki page title. Provide this OR pageId, not both.'),
+	pageId: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Numeric MediaWiki page ID. Provide this OR title, not both.'),
+} as const;
+
+interface PageInfoResponse {
+	query?: { pages?: Array<{ pageid?: number; missing?: boolean; title?: string }> };
+}
+
+interface SubjectData {
+	id?: string;
+	label?: string;
+	schema?: string;
+	statements?: Record<string, { type?: string; value?: unknown }>;
+}
+
+interface PageSubjectsResponse {
+	pageId?: number;
+	mainSubjectId?: string | null;
+	subjects?: Record<string, SubjectData>;
+}
+
+export const neowikiGetPageSubjects: Tool<typeof inputSchema> = {
+	name: 'neowiki-get-page-subjects',
+	description:
+		"Lists the NeoWiki Subjects attached to a wiki page — each with full structured data — and identifies the page's Main Subject. Enabled only when the wiki has NeoWiki installed. This is the bridge from a wiki page (which you may already have from get-page) into its knowledge-graph data: one call returns every subject's statements, so you don't need to resolve subject IDs first. Accepts a page title or a numeric page ID. Pre-1.0: the NeoWiki API may change without notice.",
+	inputSchema,
+	annotations: {
+		title: 'Get NeoWiki page subjects',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'get NeoWiki page subjects',
+	target: (a) => a.title ?? (a.pageId !== undefined ? String(a.pageId) : ''),
+
+	async handle({ title, pageId }, ctx: ToolContext): Promise<CallToolResult> {
+		if ((title === undefined) === (pageId === undefined)) {
+			return ctx.format.invalidInput('Provide exactly one of title or pageId.');
+		}
+
+		const mwn = await ctx.mwn();
+		try {
+			let resolvedPageId = pageId;
+			if (resolvedPageId === undefined) {
+				const info = (await mwn.request({
+					action: 'query',
+					titles: title,
+					formatversion: 2,
+					format: 'json',
+					// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- action=query info response shape; trusted at this boundary
+				})) as PageInfoResponse;
+				const page = info.query?.pages?.[0];
+				if (page === undefined || page.missing === true || typeof page.pageid !== 'number') {
+					return ctx.format.notFound(`Page "${title}" not found`);
+				}
+				resolvedPageId = page.pageid;
+			}
+
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /page/{id}/subjects response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'GET',
+				path: `/page/${resolvedPageId}/subjects`,
+			})) as PageSubjectsResponse;
+
+			const mainSubjectId = data.mainSubjectId ?? null;
+			const subjects = Object.entries(data.subjects ?? {}).map(([id, subject]) => ({
+				...flattenSubject(subject, id),
+				isMain: id === mainSubjectId,
+			}));
+
+			return ctx.format.ok({
+				pageId: data.pageId ?? resolvedPageId,
+				mainSubjectId,
+				subjects,
+			});
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -62,7 +62,9 @@ export const neowikiGetPageSubjects: Tool<typeof inputSchema> = {
 			if (resolvedPageId === undefined) {
 				const info = (await mwn.request({
 					action: 'query',
-					titles: title,
+					// title is defined here: the XOR guard above ensures title is set when pageId is absent
+					// oxlint-disable-next-line typescript/no-non-null-assertion -- narrowed by XOR guard above
+					titles: title!,
 					formatversion: 2,
 					format: 'json',
 					// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- action=query info response shape; trusted at this boundary

--- a/src/tools/extensions/neowiki/neowiki-get-schema.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-schema.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const inputSchema = {
+	name: z.string().min(1).describe('Schema name. Use neowiki-list-schemas to discover names.'),
+} as const;
+
+interface GetSchemaResponse {
+	schema?: {
+		description?: string;
+		propertyDefinitions?: Record<string, Record<string, unknown>>;
+	};
+}
+
+export const neowikiGetSchema: Tool<typeof inputSchema> = {
+	name: 'neowiki-get-schema',
+	description:
+		"Returns one NeoWiki Schema's property definitions: each property's name, type (text/number/boolean/url/date/datetime/select/relation), and type-specific attributes. Enabled only when the wiki has NeoWiki installed. `relation` properties name the graph edge (`relation`) and the `targetSchema` they point to — this is the relationship vocabulary for neowiki-cypher-query. `select` properties carry the option ID->label map needed to decode select values returned by queries. Use neowiki-list-schemas to discover schema names. Pre-1.0: the NeoWiki API may change without notice.",
+	inputSchema,
+	annotations: {
+		title: 'Get NeoWiki schema',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'get NeoWiki schema',
+	target: (a) => a.name,
+
+	async handle({ name }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /schema response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'GET',
+				path: `/schema/${encodeURIComponent(name)}`,
+			})) as GetSchemaResponse;
+
+			if (data.schema === undefined || data.schema === null) {
+				return ctx.format.notFound(`NeoWiki schema "${name}" not found`);
+			}
+
+			const definitions = data.schema.propertyDefinitions ?? {};
+			const properties = Object.entries(definitions).map(([propName, def]) => ({
+				name: propName,
+				...def,
+			}));
+
+			return ctx.format.ok({
+				name,
+				description: data.schema.description ?? '',
+				properties,
+			});
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-get-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-subject.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const inputSchema = {
+	id: z
+		.string()
+		.min(1)
+		.describe(
+			'Subject ID (starts with s…). Use neowiki-search-subjects to resolve one from a label.',
+		),
+} as const;
+
+interface SubjectStatement {
+	type?: string;
+	value?: unknown;
+}
+
+interface SubjectData {
+	id?: string;
+	label?: string;
+	schema?: string;
+	statements?: Record<string, SubjectStatement>;
+}
+
+interface GetSubjectResponse {
+	requestedId?: string;
+	subjects?: Record<string, SubjectData>;
+}
+
+export const neowikiGetSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-get-subject',
+	description:
+		'Fetches one NeoWiki Subject by ID — its label, schema, and statements with typed values. Enabled only when the wiki has NeoWiki installed. Richer than a flattened Cypher node: it preserves multi-part values and per-statement types. `select` values are option IDs — decode them with neowiki-get-schema. Get an ID from neowiki-search-subjects or a Cypher query. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Get NeoWiki subject',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'get NeoWiki subject',
+	target: (a) => a.id,
+
+	async handle({ id }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /subject response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'GET',
+				path: `/subject/${encodeURIComponent(id)}`,
+			})) as GetSubjectResponse;
+
+			const subject = data.subjects?.[id];
+			if (subject === undefined) {
+				return ctx.format.notFound(`NeoWiki subject "${id}" not found`);
+			}
+
+			return ctx.format.ok(flattenSubject(subject, id));
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};
+
+export function flattenSubject(
+	subject: SubjectData,
+	fallbackId: string,
+): {
+	id: string;
+	label: string;
+	schema: string;
+	statements: Array<{ property: string; type: string; value: unknown }>;
+} {
+	const statements = Object.entries(subject.statements ?? {}).map(([property, statement]) => ({
+		property,
+		type: typeof statement.type === 'string' ? statement.type : '',
+		value: statement.value,
+	}));
+	return {
+		id: subject.id ?? fallbackId,
+		label: subject.label ?? '',
+		schema: subject.schema ?? '',
+		statements,
+	};
+}

--- a/src/tools/extensions/neowiki/neowiki-list-schemas.ts
+++ b/src/tools/extensions/neowiki/neowiki-list-schemas.ts
@@ -63,8 +63,11 @@ export const neowikiListSchemas: Tool<typeof inputSchema> = {
 			const schemas = Array.isArray(data.schemas) ? data.schemas : [];
 			const totalRows = typeof data.totalRows === 'number' ? data.totalRows : schemas.length;
 
+			// Require a non-empty page before advancing: a degenerate response
+			// (0 rows but totalRows still > offset) must not hand back a token
+			// that never advances, which would loop a paginating client forever.
 			const truncation: TruncationInfo | null =
-				offset + schemas.length < totalRows
+				schemas.length > 0 && offset + schemas.length < totalRows
 					? {
 							reason: 'more-available',
 							returnedCount: schemas.length,

--- a/src/tools/extensions/neowiki/neowiki-list-schemas.ts
+++ b/src/tools/extensions/neowiki/neowiki-list-schemas.ts
@@ -5,7 +5,9 @@ import type { ToolContext } from '../../../runtime/context.js';
 import type { TruncationInfo } from '../../../results/truncation.js';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
 
-const PAGE_LIMIT = 500;
+// The /schemas endpoint caps `limit` at 50 (rejects higher with a 400).
+// Paginate beyond that via the offset carried in continueFrom.
+const PAGE_LIMIT = 50;
 
 const inputSchema = {
 	continueFrom: z

--- a/src/tools/extensions/neowiki/neowiki-list-schemas.ts
+++ b/src/tools/extensions/neowiki/neowiki-list-schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import type { TruncationInfo } from '../../../results/truncation.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const PAGE_LIMIT = 500;
+
+const inputSchema = {
+	continueFrom: z
+		.string()
+		.optional()
+		.describe('Opaque offset token from a previous response; omit on first call.'),
+} as const;
+
+interface SchemaSummary {
+	name?: string;
+	description?: string;
+	propertyCount?: number;
+}
+
+interface ListSchemasResponse {
+	schemas?: SchemaSummary[];
+	totalRows?: number;
+}
+
+export const neowikiListSchemas: Tool<typeof inputSchema> = {
+	name: 'neowiki-list-schemas',
+	description:
+		"Lists the Schemas (entity types, e.g. Person, Company) defined in the wiki's NeoWiki knowledge graph, each with its description and property count. Enabled only when the wiki has NeoWiki installed. Start here to discover what types exist, then use neowiki-get-schema for one type's properties, or neowiki-cypher-query to query the graph. Paginate with continueFrom. Pre-1.0: the NeoWiki API may change without notice.",
+	inputSchema,
+	annotations: {
+		title: 'List NeoWiki schemas',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'list NeoWiki schemas',
+
+	async handle({ continueFrom }, ctx: ToolContext): Promise<CallToolResult> {
+		let offset = 0;
+		if (continueFrom !== undefined) {
+			const parsed = Number.parseInt(continueFrom, 10);
+			if (!Number.isFinite(parsed) || parsed < 0 || String(parsed) !== continueFrom) {
+				return ctx.format.invalidInput('continueFrom must be a non-negative integer');
+			}
+			offset = parsed;
+		}
+
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /schemas response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'GET',
+				path: '/schemas',
+				query: { limit: String(PAGE_LIMIT), offset: String(offset) },
+			})) as ListSchemasResponse;
+
+			const schemas = Array.isArray(data.schemas) ? data.schemas : [];
+			const totalRows = typeof data.totalRows === 'number' ? data.totalRows : schemas.length;
+
+			const truncation: TruncationInfo | null =
+				offset + schemas.length < totalRows
+					? {
+							reason: 'more-available',
+							returnedCount: schemas.length,
+							itemNoun: 'schemas',
+							toolName: 'neowiki-list-schemas',
+							continueWith: { param: 'continueFrom', value: String(offset + schemas.length) },
+						}
+					: null;
+
+			return ctx.format.ok({ schemas, ...(truncation !== null ? { truncation } : {}) });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-search-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-search-subjects.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const inputSchema = {
+	schema: z
+		.string()
+		.min(1)
+		.describe('Schema to search within. Use neowiki-list-schemas to discover names.'),
+	search: z.string().min(1).describe('Label text to match (e.g. a name or prefix).'),
+} as const;
+
+interface SubjectLabel {
+	id?: string;
+	label?: string;
+}
+
+export const neowikiSearchSubjects: Tool<typeof inputSchema> = {
+	name: 'neowiki-search-subjects',
+	description:
+		"Finds NeoWiki Subjects by label within a Schema, returning each match's opaque Subject ID (s…) and label. Enabled only when the wiki has NeoWiki installed. Subject IDs are not human-readable, so use this to resolve a name to an ID for neowiki-get-subject or a parameterized neowiki-cypher-query. Pre-1.0: the NeoWiki API may change without notice.",
+	inputSchema,
+	annotations: {
+		title: 'Search NeoWiki subjects',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'search NeoWiki subjects',
+	target: (a) => a.search,
+
+	async handle({ schema, search }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /subject-labels response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'GET',
+				path: '/subject-labels',
+				query: { schema, search },
+			})) as SubjectLabel[];
+
+			const subjects = Array.isArray(data) ? data : [];
+			return ctx.format.ok({ subjects });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowikiRequest.ts
+++ b/src/tools/extensions/neowiki/neowikiRequest.ts
@@ -84,11 +84,13 @@ export async function neowikiRequest(mwn: Mwn, spec: NeoWikiRequestSpec): Promis
 
 function classifyNeoWikiError(err: unknown): NeoWikiApiError {
 	// axios throws on non-2xx with `err.response.{status,data}`.
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios error shape at this boundary
 	const response = (err as { response?: { status?: number; data?: unknown } }).response;
 	const status = response?.status;
 	const data = response?.data;
 
 	if (data !== null && typeof data === 'object') {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- verified non-null object above; narrow to inspect keys
 		const record = data as Record<string, unknown>;
 
 		const errorType = record.errorType;
@@ -101,6 +103,7 @@ function classifyNeoWikiError(err: unknown): NeoWikiApiError {
 		// REST param-validation envelope: { error, messageTranslations: { en } }.
 		if (typeof record.error === 'string') {
 			const translations = record.messageTranslations;
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- messageTranslations sub-object shape at this boundary
 			const en =
 				translations !== null && typeof translations === 'object'
 					? (translations as { en?: unknown }).en
@@ -126,6 +129,7 @@ function classifyNeoWikiError(err: unknown): NeoWikiApiError {
 		return new NeoWikiApiError('rate_limited', 'NeoWiki rate limit exceeded.');
 	}
 
+	// Covers both axios network errors (no .response — timeout, ECONNREFUSED) and unrecognised body shapes.
 	const message = err instanceof Error ? err.message : String(err);
 	return new NeoWikiApiError('upstream_failure', message);
 }

--- a/src/tools/extensions/neowiki/neowikiRequest.ts
+++ b/src/tools/extensions/neowiki/neowikiRequest.ts
@@ -1,0 +1,143 @@
+import type { Mwn } from 'mwn';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ErrorCategory } from '../../../errors/classifyError.js';
+import type { ToolContext } from '../../../runtime/context.js';
+
+/** A NeoWiki REST failure already classified into an MCP error category. */
+export class NeoWikiApiError extends Error {
+	public constructor(
+		public readonly category: ErrorCategory,
+		message: string,
+	) {
+		super(message);
+		this.name = 'NeoWikiApiError';
+	}
+}
+
+export interface NeoWikiRequestSpec {
+	readonly method: 'GET' | 'POST';
+	/** Path under `/neowiki/v0`, already URL-encoded, e.g. `/schema/Person`. */
+	readonly path: string;
+	readonly query?: Record<string, string>;
+	readonly body?: unknown;
+}
+
+// NeoWiki's `errorType` strings are stable across releases (per query-api docs);
+// branch on them, never on the translated `message`.
+const ERROR_TYPE_TO_CATEGORY: Record<string, ErrorCategory> = {
+	emptyQuery: 'invalid_input',
+	parameterMissing: 'invalid_input',
+	cypherSyntaxError: 'invalid_input',
+	writeQueryRejected: 'invalid_input',
+	queryTimeout: 'upstream_failure',
+	rateLimitExceeded: 'rate_limited',
+	permissionDenied: 'permission_denied',
+	backendUnavailable: 'upstream_failure',
+	internalError: 'upstream_failure',
+};
+
+function restBaseFrom(apiUrl: string): string {
+	// apiUrl is `${server}${scriptpath}/api.php`; NeoWiki REST lives at
+	// `${server}${scriptpath}/rest.php/neowiki/v0` — same origin, so the bearer
+	// and cookies that reach the action API also reach here.
+	return `${apiUrl.replace(/\/api\.php$/, '/rest.php')}/neowiki/v0`;
+}
+
+export async function neowikiRequest(mwn: Mwn, spec: NeoWikiRequestSpec): Promise<unknown> {
+	const apiUrl = mwn.options.apiUrl;
+	if (typeof apiUrl !== 'string' || !/\/api\.php$/.test(apiUrl)) {
+		throw new NeoWikiApiError(
+			'upstream_failure',
+			'Cannot derive the NeoWiki REST base from the wiki API URL.',
+		);
+	}
+
+	let url = `${restBaseFrom(apiUrl)}${spec.path}`;
+	if (spec.query !== undefined && Object.keys(spec.query).length > 0) {
+		url += `?${new URLSearchParams(spec.query).toString()}`;
+	}
+
+	const headers: Record<string, string> = { Accept: 'application/json' };
+	if (spec.body !== undefined) {
+		headers['Content-Type'] = 'application/json';
+	}
+	// rawRequest skips mwn.applyAuthentication, so inject the OAuth2 bearer
+	// ourselves (same-origin by construction). Bot-password cookies still flow
+	// via mwn's axios interceptor.
+	if (mwn.usingOAuth2 && typeof mwn.options.OAuth2AccessToken === 'string') {
+		headers.Authorization = `Bearer ${mwn.options.OAuth2AccessToken}`;
+	}
+
+	try {
+		const response = await mwn.rawRequest({
+			url,
+			method: spec.method,
+			headers,
+			...(spec.body !== undefined ? { data: JSON.stringify(spec.body) } : {}),
+		});
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios response body at this boundary
+		return (response as { data: unknown }).data;
+	} catch (err: unknown) {
+		throw classifyNeoWikiError(err);
+	}
+}
+
+function classifyNeoWikiError(err: unknown): NeoWikiApiError {
+	// axios throws on non-2xx with `err.response.{status,data}`.
+	const response = (err as { response?: { status?: number; data?: unknown } }).response;
+	const status = response?.status;
+	const data = response?.data;
+
+	if (data !== null && typeof data === 'object') {
+		const record = data as Record<string, unknown>;
+
+		const errorType = record.errorType;
+		if (typeof errorType === 'string') {
+			const category = ERROR_TYPE_TO_CATEGORY[errorType] ?? 'upstream_failure';
+			const message = typeof record.message === 'string' ? record.message : errorType;
+			return new NeoWikiApiError(category, message);
+		}
+
+		// REST param-validation envelope: { error, messageTranslations: { en } }.
+		if (typeof record.error === 'string') {
+			const translations = record.messageTranslations;
+			const en =
+				translations !== null && typeof translations === 'object'
+					? (translations as { en?: unknown }).en
+					: undefined;
+			const message = typeof en === 'string' ? en : record.error;
+			return new NeoWikiApiError(status === 404 ? 'not_found' : 'invalid_input', message);
+		}
+
+		// Internal RuntimeException: { message, exception: {…backtrace…} }.
+		// Surface the message only — never the backtrace.
+		if (typeof record.message === 'string') {
+			return new NeoWikiApiError('upstream_failure', record.message);
+		}
+	}
+
+	if (status === 404) {
+		return new NeoWikiApiError('not_found', 'NeoWiki resource not found.');
+	}
+	if (status === 403) {
+		return new NeoWikiApiError('permission_denied', 'Permission denied by NeoWiki.');
+	}
+	if (status === 429) {
+		return new NeoWikiApiError('rate_limited', 'NeoWiki rate limit exceeded.');
+	}
+
+	const message = err instanceof Error ? err.message : String(err);
+	return new NeoWikiApiError('upstream_failure', message);
+}
+
+/**
+ * Converts a thrown `NeoWikiApiError` into an MCP error result; re-throws any
+ * other error so the dispatcher classifies it (→ `upstream_failure`). Call from
+ * a tool handler's catch block.
+ */
+export function neowikiErrorResult(err: unknown, ctx: ToolContext): CallToolResult {
+	if (err instanceof NeoWikiApiError) {
+		return ctx.format.error(err.category, err.message);
+	}
+	throw err;
+}

--- a/tests/tools/extensions/index.test.ts
+++ b/tests/tools/extensions/index.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { extensionPacks } from '../../../src/tools/extensions/index.js';
 
 describe('extensionPacks', () => {
-	it('contains smw, bucket, and cargo in registration order', () => {
-		expect(extensionPacks.map((p) => p.id)).toEqual(['smw', 'bucket', 'cargo']);
+	it('contains smw, bucket, cargo, and neowiki in registration order', () => {
+		expect(extensionPacks.map((p) => p.id)).toEqual(['smw', 'bucket', 'cargo', 'neowiki']);
+	});
+
+	it('lists NeoWiki as the NeoWiki extension name', () => {
+		const neowiki = extensionPacks.find((p) => p.id === 'neowiki');
+		expect(neowiki?.extensionNames).toEqual(['NeoWiki']);
 	});
 
 	it('lists Cargo and LIBRARIAN as Cargo extension names', () => {

--- a/tests/tools/extensions/neowiki/neowiki-cypher-query.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-cypher-query.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiCypherQuery } from '../../../../src/tools/extensions/neowiki/neowiki-cypher-query.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
+	err.response = { status, data };
+	return err;
+}
+
+describe('neowiki-cypher-query', () => {
+	it('posts cypher + parameters and returns the result envelope', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: {
+					columns: ['name'],
+					rows: [{ name: 'ACME Inc' }],
+					resultCount: 1,
+					durationMs: 11,
+					truncated: false,
+				},
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCypherQuery.handle(
+			{ cypher: 'MATCH (s:Subject:Company) RETURN s.name AS name', parameters: { x: 1 } },
+			ctx,
+		);
+		const call = mock.rawRequest.mock.calls[0][0] as { url: string; data: string };
+		expect(call.url).toContain('/query/cypher');
+		expect(JSON.parse(call.data)).toEqual({
+			cypher: 'MATCH (s:Subject:Company) RETURN s.name AS name',
+			parameters: { x: 1 },
+		});
+		expect(result.structuredContent).toMatchObject({
+			columns: ['name'],
+			rows: [{ name: 'ACME Inc' }],
+		});
+		expect(result.structuredContent).not.toHaveProperty('truncation');
+	});
+
+	it('omits parameters from the body when not provided', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockResolvedValue({ data: { columns: [], rows: [], resultCount: 0, truncated: false } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		await neowikiCypherQuery.handle({ cypher: 'RETURN 1' }, ctx);
+		const call = mock.rawRequest.mock.calls[0][0] as { data: string };
+		expect(JSON.parse(call.data)).toEqual({ cypher: 'RETURN 1' });
+	});
+
+	it('emits a capped truncation when the server truncated the result', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: { columns: ['n'], rows: [{ n: 1 }], resultCount: 1, durationMs: 5, truncated: true },
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCypherQuery.handle({ cypher: 'MATCH (s) RETURN s.name AS n' }, ctx);
+		expect(result.structuredContent).toMatchObject({
+			truncation: { reason: 'capped-no-continuation' },
+		});
+	});
+
+	it('maps a writeQueryRejected error to invalid_input', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockRejectedValue(
+					httpError(422, { errorType: 'writeQueryRejected', message: 'Query is not read-only.' }),
+				),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCypherQuery.handle({ cypher: 'CREATE (x)' }, ctx);
+		assertStructuredError(result, 'invalid_input');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-get-page-subjects.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-page-subjects.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiGetPageSubjects } from '../../../../src/tools/extensions/neowiki/neowiki-get-page-subjects.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+const pageSubjectsBody = {
+	data: {
+		pageId: 65,
+		mainSubjectId: 'sMain',
+		subjects: {
+			sMain: {
+				id: 'sMain',
+				label: 'Rijksmuseum',
+				schema: 'Museum',
+				statements: { Founded: { type: 'number', value: 1800 } },
+			},
+			sChild: { id: 'sChild', label: 'Rijksmuseum 2024', schema: 'Attendance', statements: {} },
+		},
+	},
+};
+
+describe('neowiki-get-page-subjects', () => {
+	it('resolves a title to a pageId, then flattens subjects with isMain', async () => {
+		const mock = createMockMwn({
+			request: vi
+				.fn()
+				.mockResolvedValue({ query: { pages: [{ pageid: 65, title: 'Rijksmuseum' }] } }),
+			rawRequest: vi.fn().mockResolvedValue(pageSubjectsBody),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetPageSubjects.handle({ title: 'Rijksmuseum' }, ctx);
+
+		expect((mock.request.mock.calls[0][0] as Record<string, unknown>).titles).toBe('Rijksmuseum');
+		expect((mock.rawRequest.mock.calls[0][0] as { url: string }).url).toContain(
+			'/page/65/subjects',
+		);
+		expect(result.structuredContent).toMatchObject({
+			pageId: 65,
+			mainSubjectId: 'sMain',
+			subjects: [
+				{ id: 'sMain', isMain: true, schema: 'Museum' },
+				{ id: 'sChild', isMain: false, schema: 'Attendance' },
+			],
+		});
+	});
+
+	it('uses a numeric pageId directly without a title lookup', async () => {
+		const mock = createMockMwn({
+			request: vi.fn(),
+			rawRequest: vi
+				.fn()
+				.mockResolvedValue({ data: { pageId: 65, mainSubjectId: null, subjects: {} } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetPageSubjects.handle({ pageId: 65 }, ctx);
+		expect(mock.request).not.toHaveBeenCalled();
+		expect(result.structuredContent).toMatchObject({ subjects: [] });
+	});
+
+	it('rejects when neither title nor pageId is given', async () => {
+		const ctx = fakeContext({ mwn: async () => createMockMwn() as never });
+		const result = await neowikiGetPageSubjects.handle({}, ctx);
+		assertStructuredError(result, 'invalid_input');
+	});
+
+	it('rejects when both title and pageId are given', async () => {
+		const ctx = fakeContext({ mwn: async () => createMockMwn() as never });
+		const result = await neowikiGetPageSubjects.handle({ title: 'X', pageId: 1 }, ctx);
+		assertStructuredError(result, 'invalid_input');
+	});
+
+	it('returns not_found for a missing title', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { pages: [{ title: 'Nope', missing: true }] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetPageSubjects.handle({ title: 'Nope' }, ctx);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-get-schema.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-schema.test.ts
@@ -49,4 +49,13 @@ describe('neowiki-get-schema', () => {
 		const result = await neowikiGetSchema.handle({ name: 'Nope' }, ctx);
 		assertStructuredError(result, 'not_found');
 	});
+
+	it('URL-encodes the schema name', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: { schema: {} } }) });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		await neowikiGetSchema.handle({ name: 'Schema Name' }, ctx);
+		expect((mock.rawRequest.mock.calls[0][0] as { url: string }).url).toContain(
+			'/schema/Schema%20Name',
+		);
+	});
 });

--- a/tests/tools/extensions/neowiki/neowiki-get-schema.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiGetSchema } from '../../../../src/tools/extensions/neowiki/neowiki-get-schema.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+describe('neowiki-get-schema', () => {
+	it('normalizes propertyDefinitions to a properties array, preserving relation/select metadata', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: {
+					schema: {
+						description: 'A company.',
+						propertyDefinitions: {
+							'Main product': {
+								type: 'relation',
+								relation: 'Has main product',
+								targetSchema: 'Product',
+								multiple: false,
+							},
+							Status: { type: 'select', required: true, options: [{ id: 'o1', label: 'Active' }] },
+						},
+					},
+				},
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetSchema.handle({ name: 'Company' }, ctx);
+
+		expect((mock.rawRequest.mock.calls[0][0] as { url: string }).url).toContain('/schema/Company');
+		expect(result.structuredContent).toMatchObject({
+			name: 'Company',
+			description: 'A company.',
+			properties: [
+				{
+					name: 'Main product',
+					type: 'relation',
+					relation: 'Has main product',
+					targetSchema: 'Product',
+				},
+				{ name: 'Status', type: 'select', options: [{ id: 'o1', label: 'Active' }] },
+			],
+		});
+	});
+
+	it('returns not_found when the response has no schema', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: {} }) });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetSchema.handle({ name: 'Nope' }, ctx);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-get-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-subject.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiGetSubject } from '../../../../src/tools/extensions/neowiki/neowiki-get-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+describe('neowiki-get-subject', () => {
+	it('unwraps the subject envelope and flattens statements', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: {
+					requestedId: 's1demo1aaaaaaa1',
+					subjects: {
+						s1demo1aaaaaaa1: {
+							id: 's1demo1aaaaaaa1',
+							label: 'ACME Inc',
+							schema: 'Company',
+							statements: { Status: { type: 'select', value: ['o1demo1aaaaaaa1'] } },
+						},
+					},
+				},
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetSubject.handle({ id: 's1demo1aaaaaaa1' }, ctx);
+
+		expect((mock.rawRequest.mock.calls[0][0] as { url: string }).url).toContain(
+			'/subject/s1demo1aaaaaaa1',
+		);
+		expect(result.structuredContent).toMatchObject({
+			id: 's1demo1aaaaaaa1',
+			label: 'ACME Inc',
+			schema: 'Company',
+			statements: [{ property: 'Status', type: 'select', value: ['o1demo1aaaaaaa1'] }],
+		});
+	});
+
+	it('returns not_found when the subject is absent', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({ data: { requestedId: 'sX', subjects: {} } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiGetSubject.handle({ id: 'sX' }, ctx);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
@@ -19,7 +19,7 @@ describe('neowiki-list-schemas', () => {
 
 		const url = (mock.rawRequest.mock.calls[0][0] as { url: string }).url;
 		expect(url).toContain('/rest.php/neowiki/v0/schemas?');
-		expect(url).toContain('limit=500');
+		expect(url).toContain('limit=50');
 		expect(url).toContain('offset=0');
 		expect(assertStructuredSuccess(result)).toContain('Company');
 		expect(result.structuredContent).toMatchObject({

--- a/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
@@ -19,6 +19,8 @@ describe('neowiki-list-schemas', () => {
 
 		const url = (mock.rawRequest.mock.calls[0][0] as { url: string }).url;
 		expect(url).toContain('/rest.php/neowiki/v0/schemas?');
+		expect(url).toContain('limit=500');
+		expect(url).toContain('offset=0');
 		expect(assertStructuredSuccess(result)).toContain('Company');
 		expect(result.structuredContent).toMatchObject({
 			schemas: [{ name: 'Company', propertyCount: 10 }],
@@ -37,5 +39,13 @@ describe('neowiki-list-schemas', () => {
 		expect(result.structuredContent).toMatchObject({
 			truncation: { reason: 'more-available', continueWith: { param: 'continueFrom', value: '1' } },
 		});
+	});
+
+	it('rejects a non-integer continueFrom', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn() });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiListSchemas.handle({ continueFrom: 'abc' }, ctx);
+		expect(result.isError).toBe(true);
+		expect(mock.rawRequest).not.toHaveBeenCalled();
 	});
 });

--- a/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiListSchemas } from '../../../../src/tools/extensions/neowiki/neowiki-list-schemas.js';
+import { assertStructuredSuccess } from '../../../helpers/structuredResult.js';
+
+describe('neowiki-list-schemas', () => {
+	it('requests /schemas and returns the schema summaries', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: {
+					schemas: [{ name: 'Company', description: '', propertyCount: 10 }],
+					totalRows: 1,
+				},
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiListSchemas.handle({}, ctx);
+
+		const url = (mock.rawRequest.mock.calls[0][0] as { url: string }).url;
+		expect(url).toContain('/rest.php/neowiki/v0/schemas?');
+		expect(assertStructuredSuccess(result)).toContain('Company');
+		expect(result.structuredContent).toMatchObject({
+			schemas: [{ name: 'Company', propertyCount: 10 }],
+		});
+		expect(result.structuredContent).not.toHaveProperty('truncation');
+	});
+
+	it('emits a more-available truncation when totalRows exceeds the returned page', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({
+				data: { schemas: [{ name: 'A', description: '', propertyCount: 1 }], totalRows: 17 },
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiListSchemas.handle({}, ctx);
+		expect(result.structuredContent).toMatchObject({
+			truncation: { reason: 'more-available', continueWith: { param: 'continueFrom', value: '1' } },
+		});
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-list-schemas.test.ts
@@ -41,6 +41,15 @@ describe('neowiki-list-schemas', () => {
 		});
 	});
 
+	it('does not emit truncation when the page is empty even if totalRows is higher', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({ data: { schemas: [], totalRows: 17 } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiListSchemas.handle({}, ctx);
+		expect(result.structuredContent).not.toHaveProperty('truncation');
+	});
+
 	it('rejects a non-integer continueFrom', async () => {
 		const mock = createMockMwn({ rawRequest: vi.fn() });
 		const ctx = fakeContext({ mwn: async () => mock as never });

--- a/tests/tools/extensions/neowiki/neowiki-search-subjects.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-search-subjects.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiSearchSubjects } from '../../../../src/tools/extensions/neowiki/neowiki-search-subjects.js';
+
+describe('neowiki-search-subjects', () => {
+	it('passes schema and search and returns matches', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockResolvedValue({ data: [{ id: 's1demo1aaaaaaa1', label: 'ACME Inc' }] }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiSearchSubjects.handle({ schema: 'Company', search: 'a' }, ctx);
+
+		const url = (mock.rawRequest.mock.calls[0][0] as { url: string }).url;
+		expect(url).toContain('/subject-labels?');
+		expect(url).toContain('schema=Company');
+		expect(url).toContain('search=a');
+		expect(result.structuredContent).toMatchObject({
+			subjects: [{ id: 's1demo1aaaaaaa1', label: 'ACME Inc' }],
+		});
+	});
+
+	it('returns an empty list when the response is not an array', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: {} }) });
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiSearchSubjects.handle({ schema: 'Company', search: 'zzz' }, ctx);
+		expect(result.structuredContent).toMatchObject({ subjects: [] });
+	});
+});

--- a/tests/tools/extensions/neowiki/neowikiRequest.test.ts
+++ b/tests/tools/extensions/neowiki/neowikiRequest.test.ts
@@ -137,4 +137,22 @@ describe('neowikiRequest', () => {
 		expect(res.isError).toBe(true);
 		expect(() => neowikiErrorResult(new Error('boom'), ctx)).toThrow('boom');
 	});
+
+	it('throws upstream_failure when apiUrl is not set', async () => {
+		const mock = createMockMwn({ options: { apiUrl: '' } });
+		await expect(
+			neowikiRequest(mock as never, { method: 'GET', path: '/schemas' }),
+		).rejects.toMatchObject({ category: 'upstream_failure' });
+	});
+
+	it('falls back to upstream_failure for an unknown errorType', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockRejectedValue(httpError(500, { errorType: 'someFutureType', message: 'x' })),
+		});
+		await expect(
+			neowikiRequest(mock as never, { method: 'POST', path: '/query/cypher', body: {} }),
+		).rejects.toMatchObject({ category: 'upstream_failure' });
+	});
 });

--- a/tests/tools/extensions/neowiki/neowikiRequest.test.ts
+++ b/tests/tools/extensions/neowiki/neowikiRequest.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import {
+	neowikiRequest,
+	neowikiErrorResult,
+	NeoWikiApiError,
+} from '../../../../src/tools/extensions/neowiki/neowikiRequest.js';
+
+// Builds an axios-style rejection: a thrown error carrying `.response`.
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
+	err.response = { status, data };
+	return err;
+}
+
+describe('neowikiRequest', () => {
+	it('derives the REST base from apiUrl and sends a GET with query string', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({ data: { schemas: [], totalRows: 0 } }),
+		});
+		await neowikiRequest(mock as never, {
+			method: 'GET',
+			path: '/schemas',
+			query: { limit: '500', offset: '0' },
+		});
+		const call = mock.rawRequest.mock.calls[0][0] as Record<string, unknown>;
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/schemas?limit=500&offset=0');
+		expect(call.method).toBe('GET');
+	});
+
+	it('JSON-encodes a POST body and sets Content-Type', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: { rows: [] } }) });
+		await neowikiRequest(mock as never, {
+			method: 'POST',
+			path: '/query/cypher',
+			body: { cypher: 'RETURN 1' },
+		});
+		const call = mock.rawRequest.mock.calls[0][0] as Record<string, unknown>;
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/query/cypher');
+		expect(call.method).toBe('POST');
+		expect(call.data).toBe(JSON.stringify({ cypher: 'RETURN 1' }));
+		expect((call.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+	});
+
+	it('injects the bearer when using OAuth2, and omits it otherwise', async () => {
+		const withTok = createMockMwn({
+			usingOAuth2: true,
+			options: { apiUrl: 'https://test.wiki/w/api.php', OAuth2AccessToken: 'tok' },
+			rawRequest: vi.fn().mockResolvedValue({ data: {} }),
+		});
+		await neowikiRequest(withTok as never, { method: 'GET', path: '/schemas' });
+		const h1 = (withTok.rawRequest.mock.calls[0][0] as { headers: Record<string, string> }).headers;
+		expect(h1.Authorization).toBe('Bearer tok');
+
+		const noTok = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: {} }) });
+		await neowikiRequest(noTok as never, { method: 'GET', path: '/schemas' });
+		const h2 = (noTok.rawRequest.mock.calls[0][0] as { headers: Record<string, string> }).headers;
+		expect(h2.Authorization).toBeUndefined();
+	});
+
+	it('maps an errorType envelope to the right category', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockRejectedValue(
+					httpError(422, { errorType: 'writeQueryRejected', message: 'Query is not read-only.' }),
+				),
+		});
+		await expect(
+			neowikiRequest(mock as never, { method: 'POST', path: '/query/cypher', body: {} }),
+		).rejects.toMatchObject({ category: 'invalid_input', message: 'Query is not read-only.' });
+	});
+
+	it('maps permission/rate/backend errorTypes', async () => {
+		const cases: Array<[string, string]> = [
+			['permissionDenied', 'permission_denied'],
+			['rateLimitExceeded', 'rate_limited'],
+			['backendUnavailable', 'upstream_failure'],
+		];
+		for (const [errorType, category] of cases) {
+			const mock = createMockMwn({
+				rawRequest: vi.fn().mockRejectedValue(httpError(500, { errorType, message: 'x' })),
+			});
+			await expect(
+				neowikiRequest(mock as never, { method: 'POST', path: '/query/cypher', body: {} }),
+			).rejects.toMatchObject({ category });
+		}
+	});
+
+	it('maps a REST param-validation envelope to invalid_input with the English message', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockRejectedValue(
+				httpError(400, {
+					error: 'parameter-validation-failed',
+					messageTranslations: { en: 'The "schema" parameter must be set.' },
+				}),
+			),
+		});
+		await expect(
+			neowikiRequest(mock as never, { method: 'GET', path: '/subject-labels' }),
+		).rejects.toMatchObject({
+			category: 'invalid_input',
+			message: 'The "schema" parameter must be set.',
+		});
+	});
+
+	it('maps a 404 to not_found', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockRejectedValue(httpError(404, { error: 'not-found' })),
+		});
+		await expect(
+			neowikiRequest(mock as never, { method: 'GET', path: '/schema/Nope' }),
+		).rejects.toMatchObject({ category: 'not_found' });
+	});
+
+	it('sanitizes an internal-exception body to message only', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockRejectedValue(
+				httpError(500, {
+					message: 'Error: Unsupported Cypher value type: DateTime',
+					exception: { backtrace: ['secret/path.php:67'] },
+				}),
+			),
+		});
+		await expect(
+			neowikiRequest(mock as never, { method: 'POST', path: '/query/cypher', body: {} }),
+		).rejects.toMatchObject({
+			category: 'upstream_failure',
+			message: 'Error: Unsupported Cypher value type: DateTime',
+		});
+	});
+
+	it('neowikiErrorResult renders a NeoWikiApiError and re-throws others', () => {
+		const ctx = fakeContext();
+		const res = neowikiErrorResult(new NeoWikiApiError('not_found', 'gone'), ctx);
+		expect(res.isError).toBe(true);
+		expect(() => neowikiErrorResult(new Error('boom'), ctx)).toThrow('boom');
+	});
+});


### PR DESCRIPTION
## Summary
Adds a read-only `neowiki` extension pack exposing six tools over NeoWiki's REST API (`/rest.php/neowiki/v0/*`), gated on the `NeoWiki` extension:

- `neowiki-list-schemas` — entity types + property counts (offset pagination)
- `neowiki-get-schema` — one schema's property definitions, relation edges + target schemas, and select option maps
- `neowiki-cypher-query` — read-only Cypher passthrough with a graph-model primer baked into the description
- `neowiki-search-subjects` — resolve a label to opaque subject IDs within a schema
- `neowiki-get-subject` — one subject's structured statements by ID
- `neowiki-get-page-subjects` — subjects attached to a wiki page (accepts a title or a numeric pageId)

All six route through a shared `neowikiRequest()` client that derives the REST base from the wiki's API URL, injects the OAuth2 bearer same-origin, and maps NeoWiki's error envelopes onto the server's error categories (sanitising backtrace-carrying internal-exception bodies). README tool table and CHANGELOG updated.

## Test plan
- `npm run lint`, `npm test` (1146 passing, incl. 32 new), `npm run build` — all green.
- Inspector CLI against the public neowiki.dev: all six tools register (extension gate matches); `list-schemas` (23 schemas) and `get-schema` (relations + select options) return live data; `cypher-query` correctly surfaces `permission_denied` for an account lacking the `neowiki-query` right.
- Handler-level run against a local NeoWiki instance (where anon has the query right): full agent chain — list-schemas → get-schema → search-subjects → get-subject → cypher-query — including select-option decoding and relation-edge traversal; read-only Cypher enforced (write queries rejected as `invalid_input`). This run caught and fixed a real bug: the `/schemas` endpoint rejects `limit` above 50, so the page size was capped at 50.

## Notes
- NeoWiki is pre-1.0 (`0.0.0-alpha`); its REST API may change without notice. The pack is intentionally thin and tool descriptions flag this. Writes, Layouts, and the schema-name autocomplete endpoint are deferred.
- A live MCP-server smoke test cannot run against a loopback/private wiki — the action-API siteinfo probe goes through the SSRF guard, so no extension pack registers there. This is existing by-design behaviour; the pack was validated against the public neowiki.dev plus handler-level runs against a local instance.
- Minor, non-blocking review follow-ups: the Cypher truncation marker reports `limit = returnedCount` (the server doesn't expose its row cap); a REST `401` falls through to `upstream_failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)