### PR TITLE
Group README extension packs by extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,6 @@ Each pack's tools register only on wikis where its extension is installed.
 | `cargo-describe-table` | List a Cargo table's fields with their types and list-flags. |
 | `cargo-query` | Run a Cargo SQL-style query. |
 
-**[Semantic MediaWiki](https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki)**
-
-| Name | Description |
-|---|---|
-| `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. |
-| `smw-query` | Run a Semantic MediaWiki `#ask` query. |
-
 **[NeoWiki](https://neowiki.ai/)**
 
 | Name | Description |
@@ -93,6 +86,13 @@ Each pack's tools register only on wikis where its extension is installed.
 | `neowiki-search-subjects` | Find subject IDs by label within a schema. |
 | `neowiki-get-subject` | Fetch one subject's structured data by ID. |
 | `neowiki-get-page-subjects` | List the subjects attached to a wiki page. |
+
+**[Semantic MediaWiki](https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki)**
+
+| Name | Description |
+|---|---|
+| `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. |
+| `smw-query` | Run a Semantic MediaWiki `#ask` query. |
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,39 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 
 #### Extension packs
 
+Each pack's tools register only on wikis where its extension is installed.
+
+**[Bucket](https://github.com/weirdgloop/mediawiki-extensions-Bucket)**
+
 | Name | Description |
 |---|---|
-| `bucket-query` | Run a [Bucket extension](https://github.com/weirdgloop/mediawiki-extensions-Bucket) Lua query. Enabled only when the wiki has Bucket installed. |
-| `cargo-describe-table` | List the fields of a [Cargo extension](https://www.mediawiki.org/wiki/Extension:Cargo) table with their types and list-flags. Enabled only when the wiki has Cargo installed. |
-| `cargo-list-tables` | List Cargo tables defined on the wiki. Enabled only when the wiki has Cargo installed. |
-| `cargo-query` | Run a [Cargo extension](https://www.mediawiki.org/wiki/Extension:Cargo) SQL-style query. Enabled only when the wiki has Cargo installed. |
-| `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. Enabled only when the wiki has SMW installed. |
-| `smw-query` | Run a Semantic MediaWiki `#ask` query. Enabled only when the wiki has SMW installed. |
-| `neowiki-list-schemas` | List [NeoWiki](https://neowiki.ai/) schemas (entity types) and their property counts. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-schema` | Get one [NeoWiki](https://neowiki.ai/) schema's property definitions, relations, and select options. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-cypher-query` | Run a read-only Cypher query against the [NeoWiki](https://neowiki.ai/) knowledge graph. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-search-subjects` | Find [NeoWiki](https://neowiki.ai/) subject IDs by label within a schema. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-subject` | Fetch one [NeoWiki](https://neowiki.ai/) subject's structured data by ID. Enabled only when the wiki has NeoWiki installed. |
-| `neowiki-get-page-subjects` | List the [NeoWiki](https://neowiki.ai/) subjects attached to a wiki page. Enabled only when the wiki has NeoWiki installed. |
+| `bucket-query` | Run a Bucket Lua query. |
+
+**[Cargo](https://www.mediawiki.org/wiki/Extension:Cargo)**
+
+| Name | Description |
+|---|---|
+| `cargo-list-tables` | List Cargo tables defined on the wiki. |
+| `cargo-describe-table` | List a Cargo table's fields with their types and list-flags. |
+| `cargo-query` | Run a Cargo SQL-style query. |
+
+**[Semantic MediaWiki](https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki)**
+
+| Name | Description |
+|---|---|
+| `smw-list-properties` | List Semantic MediaWiki properties with copy-paste templates for `smw-query`. |
+| `smw-query` | Run a Semantic MediaWiki `#ask` query. |
+
+**[NeoWiki](https://neowiki.ai/)**
+
+| Name | Description |
+|---|---|
+| `neowiki-list-schemas` | List schemas (entity types) and their property counts. |
+| `neowiki-get-schema` | Get one schema's property definitions, relations, and select options. |
+| `neowiki-cypher-query` | Run a read-only Cypher query against the knowledge graph. |
+| `neowiki-search-subjects` | Find subject IDs by label within a schema. |
+| `neowiki-get-subject` | Fetch one subject's structured data by ID. |
+| `neowiki-get-page-subjects` | List the subjects attached to a wiki page. |
 
 ### Resources
 


### PR DESCRIPTION
## Summary

The `#### Extension packs` section of the README had grown into a single flat table of 12 tools spanning four extensions, with every row repeating "Enabled only when the wiki has X installed." and the extension link duplicated per row (NeoWiki's link appeared 6 times, Cargo's 3).

This reorganises it into one labelled group per extension, mirroring the source layout under `src/tools/extensions/<id>/`:

- Gate sentence stated once up front ("Each pack's tools register only on wikis where its extension is installed.") instead of on all 12 rows.
- Each pack's link stated once in its group header; redundant inline links and extension-name prefixes trimmed from descriptions.
- Added the previously-missing Semantic MediaWiki link for parity with the other three packs.

Tool names and substantive descriptions are unchanged. Docs-only presentation change — no tool surface or behaviour change, so no CHANGELOG entry per the repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)