### PR TITLE
Add NeoWiki subject write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 
 - NeoWiki integration: tools to explore a NeoWiki knowledge graph — list schemas, inspect a schema's properties, search subjects by name, fetch a subject or a page's subjects, and run read-only Cypher queries. Available on wikis with the NeoWiki extension installed.
+- NeoWiki write tools: create a subject on a page (as a child or the main subject), replace a subject's label and statements, delete a subject, set or clear a page's main subject, and dry-run validate a proposed subject before writing. The four write tools require the `edit` right on the target wiki; validation is read-only. Available on wikis with the NeoWiki extension installed.
 - `get-file-data` tool: returns a wiki file's image inline (base64) so clients that can't reach the wiki host can still send the image to the model for visual analysis. Returns a scaled rendition sized by `width`. Images and files MediaWiki can rasterize (SVG, PDF, DjVu) come back as an image; non-renderable types (audio, video, binaries) error and point to `get-file`.
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
 - `whoami` tool: reports which account the current session is acting as on a wiki — the username, whether the session is anonymous, and the user groups it belongs to (optionally the full rights list). Use it to confirm who edits will be attributed to before writing, for example when creating a page under your own user namespace.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Each pack's tools register only on wikis where its extension is installed.
 | `neowiki-search-subjects` | Find subject IDs by label within a schema. |
 | `neowiki-get-subject` | Fetch one subject's structured data by ID. |
 | `neowiki-get-page-subjects` | List the subjects attached to a wiki page. |
+| `neowiki-create-subject` | Create a subject (child or main) on a page. Requires the `edit` right. |
+| `neowiki-update-subject` | Replace a subject's label and statements. Requires the `edit` right. |
+| `neowiki-delete-subject` | Delete a subject by ID. Requires the `edit` right. |
+| `neowiki-set-main-subject` | Set or clear a page's main subject. Requires the `edit` right. |
+| `neowiki-validate-subject` | Dry-run validate a proposed subject and return violations. |
 
 **[Semantic MediaWiki](https://www.mediawiki.org/wiki/Extension:Semantic_MediaWiki)**
 

--- a/src/tools/extensions/neowiki/index.ts
+++ b/src/tools/extensions/neowiki/index.ts
@@ -5,6 +5,11 @@ import { neowikiCypherQuery } from './neowiki-cypher-query.js';
 import { neowikiSearchSubjects } from './neowiki-search-subjects.js';
 import { neowikiGetSubject } from './neowiki-get-subject.js';
 import { neowikiGetPageSubjects } from './neowiki-get-page-subjects.js';
+import { neowikiCreateSubject } from './neowiki-create-subject.js';
+import { neowikiUpdateSubject } from './neowiki-update-subject.js';
+import { neowikiDeleteSubject } from './neowiki-delete-subject.js';
+import { neowikiSetMainSubject } from './neowiki-set-main-subject.js';
+import { neowikiValidateSubject } from './neowiki-validate-subject.js';
 
 export const neowikiPack: ExtensionPack = {
 	id: 'neowiki',
@@ -16,5 +21,10 @@ export const neowikiPack: ExtensionPack = {
 		neowikiSearchSubjects,
 		neowikiGetSubject,
 		neowikiGetPageSubjects,
+		neowikiCreateSubject,
+		neowikiUpdateSubject,
+		neowikiDeleteSubject,
+		neowikiSetMainSubject,
+		neowikiValidateSubject,
 	],
 };

--- a/src/tools/extensions/neowiki/neowiki-create-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-create-subject.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+import { resolvePageId, hasOnePageRef } from './pageId.js';
+
+// A statement keyed by property name. The write API reads `propertyType` (NOT
+// the `type` key read tools return) and silently drops entries without it, so
+// require it here — a malformed statement becomes an input error, not a no-op.
+const statementSchema = z.object({
+	propertyType: z
+		.string()
+		.min(1)
+		.describe('Property type: text, url, date, datetime, select, number, boolean, or relation.'),
+	value: z
+		.unknown()
+		.describe(
+			'text/url/date/datetime → array of strings; select → array of option IDs (decode via neowiki-get-schema); number → number; boolean → boolean; relation → array of { target: subjectId, properties? }.',
+		),
+});
+
+const inputSchema = {
+	title: z
+		.string()
+		.min(1)
+		.optional()
+		.describe('Wiki page title to attach the Subject to. Provide this OR pageId.'),
+	pageId: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Numeric MediaWiki page ID. Provide this OR title.'),
+	isMain: z
+		.boolean()
+		.optional()
+		.describe(
+			"When true, create the page's Main Subject (at most one per page) instead of a child Subject. Defaults to false.",
+		),
+	label: z.string().min(1).describe('Display label for the new Subject.'),
+	schema: z
+		.string()
+		.min(1)
+		.describe(
+			'Name of an existing Schema (entity type) the Subject instantiates. Discover names with neowiki-list-schemas.',
+		),
+	statements: z
+		.record(z.string(), statementSchema)
+		.describe(
+			'Map of property name → { propertyType, value }. The key is propertyType, NOT the `type` read tools return. Validate first with neowiki-validate-subject.',
+		),
+	comment: z.string().optional().describe('Optional edit summary.'),
+} as const;
+
+interface CreateResponse {
+	status?: string;
+	subjectId?: string;
+	message?: string;
+}
+
+export const neowikiCreateSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-create-subject',
+	description:
+		'Creates a new NeoWiki Subject on a wiki page and attaches its statements. Enabled only when the wiki has NeoWiki installed. Set isMain to make it the page\'s Main Subject (a page has at most one); otherwise it is added as a child Subject. Requires the edit right. Each statement is keyed by property name as { propertyType, value } — the key is propertyType, NOT the `type` key read tools return; a statement lacking propertyType is rejected. Value by type: text/url/date/datetime → array of strings (dates ISO, e.g. ["2020-12-31"]); select → array of option IDs (resolve labels via neowiki-get-schema); number → a number; boolean → a boolean; relation → array of { target: "<subjectId>", properties? }. Pre-validate with neowiki-validate-subject. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Create NeoWiki subject',
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'create NeoWiki subject',
+	target: (a) => a.label,
+
+	async handle(
+		{ title, pageId, isMain, label, schema, statements, comment },
+		ctx: ToolContext,
+	): Promise<CallToolResult> {
+		if (!hasOnePageRef({ title, pageId })) {
+			return ctx.format.invalidInput('Provide exactly one of title or pageId.');
+		}
+
+		const mwn = await ctx.mwn();
+		try {
+			const resolvedPageId = await resolvePageId(mwn, { title, pageId });
+			if (resolvedPageId === null) {
+				return ctx.format.notFound(`Page "${title}" not found`);
+			}
+
+			const segment = isMain === true ? 'mainSubject' : 'childSubjects';
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki create response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'POST',
+				path: `/page/${resolvedPageId}/${segment}`,
+				csrf: true,
+				body: { label, schema, statements, ...(comment !== undefined ? { comment } : {}) },
+			})) as CreateResponse;
+
+			// Upstream returns HTTP 201 with { status: "error" } when a main subject
+			// already exists (rather than a 4xx) — surface that as a conflict.
+			if (data.status === 'error') {
+				return ctx.format.conflict(data.message ?? 'Subject could not be created.');
+			}
+
+			return ctx.format.ok({
+				subjectId: data.subjectId ?? '',
+				status: data.status ?? 'created',
+				pageId: resolvedPageId,
+			});
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-delete-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-delete-subject.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const inputSchema = {
+	id: z
+		.string()
+		.min(1)
+		.describe('Subject ID to delete (starts with s…). Resolve one with neowiki-search-subjects.'),
+	comment: z.string().optional().describe('Optional edit summary.'),
+} as const;
+
+export const neowikiDeleteSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-delete-subject',
+	description:
+		'Deletes one NeoWiki Subject by ID from its page. Enabled only when the wiki has NeoWiki installed. Requires the edit right. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Delete NeoWiki subject',
+		readOnlyHint: false,
+		destructiveHint: true,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'delete NeoWiki subject',
+	target: (a) => a.id,
+
+	async handle({ id, comment }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// The endpoint returns an empty 200 body on success; ignore it.
+			await neowikiRequest(mwn, {
+				method: 'DELETE',
+				path: `/subject/${encodeURIComponent(id)}`,
+				csrf: true,
+				...(comment !== undefined ? { body: { comment } } : {}),
+			});
+
+			return ctx.format.ok({ subjectId: id, status: 'deleted' });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -4,6 +4,7 @@ import type { Tool } from '../../../runtime/tool.js';
 import type { ToolContext } from '../../../runtime/context.js';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
 import { flattenSubject } from './neowiki-get-subject.js';
+import { resolvePageId, hasOnePageRef } from './pageId.js';
 
 const inputSchema = {
 	title: z
@@ -18,10 +19,6 @@ const inputSchema = {
 		.optional()
 		.describe('Numeric MediaWiki page ID. Provide this OR title, not both.'),
 } as const;
-
-interface PageInfoResponse {
-	query?: { pages?: Array<{ pageid?: number; missing?: boolean; title?: string }> };
-}
 
 interface SubjectData {
 	id?: string;
@@ -52,28 +49,15 @@ export const neowikiGetPageSubjects: Tool<typeof inputSchema> = {
 	target: (a) => a.title ?? (a.pageId !== undefined ? String(a.pageId) : ''),
 
 	async handle({ title, pageId }, ctx: ToolContext): Promise<CallToolResult> {
-		if ((title === undefined) === (pageId === undefined)) {
+		if (!hasOnePageRef({ title, pageId })) {
 			return ctx.format.invalidInput('Provide exactly one of title or pageId.');
 		}
 
 		const mwn = await ctx.mwn();
 		try {
-			let resolvedPageId = pageId;
-			if (resolvedPageId === undefined) {
-				const info = (await mwn.request({
-					action: 'query',
-					// title is defined here: the XOR guard above ensures title is set when pageId is absent
-					// oxlint-disable-next-line typescript/no-non-null-assertion -- narrowed by XOR guard above
-					titles: title!,
-					formatversion: 2,
-					format: 'json',
-					// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- action=query info response shape; trusted at this boundary
-				})) as PageInfoResponse;
-				const page = info.query?.pages?.[0];
-				if (page === undefined || page.missing === true || typeof page.pageid !== 'number') {
-					return ctx.format.notFound(`Page "${title}" not found`);
-				}
-				resolvedPageId = page.pageid;
+			const resolvedPageId = await resolvePageId(mwn, { title, pageId });
+			if (resolvedPageId === null) {
+				return ctx.format.notFound(`Page "${title}" not found`);
 			}
 
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki /page/{id}/subjects response shape; trusted at this boundary

--- a/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+import { resolvePageId, hasOnePageRef } from './pageId.js';
+
+const inputSchema = {
+	title: z.string().min(1).optional().describe('Wiki page title. Provide this OR pageId.'),
+	pageId: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Numeric MediaWiki page ID. Provide this OR title.'),
+	subjectId: z
+		.string()
+		.min(1)
+		.nullable()
+		.describe(
+			'Subject ID (starts with s…) on this page to promote to Main Subject, or null to clear the Main Subject.',
+		),
+	comment: z.string().optional().describe('Optional edit summary.'),
+} as const;
+
+interface SetMainResponse {
+	status?: string;
+}
+
+export const neowikiSetMainSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-set-main-subject',
+	description:
+		'Sets which existing Subject on a wiki page is its Main Subject, or clears it. Enabled only when the wiki has NeoWiki installed. Pass subjectId to promote a Subject that already exists on the page, or null to clear the Main Subject. This differs from neowiki-create-subject with isMain, which creates a NEW main Subject. Requires the edit right. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Set NeoWiki main subject',
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'set NeoWiki main subject',
+	target: (a) => a.subjectId ?? '',
+
+	async handle({ title, pageId, subjectId, comment }, ctx: ToolContext): Promise<CallToolResult> {
+		if (!hasOnePageRef({ title, pageId })) {
+			return ctx.format.invalidInput('Provide exactly one of title or pageId.');
+		}
+
+		const mwn = await ctx.mwn();
+		try {
+			const resolvedPageId = await resolvePageId(mwn, { title, pageId });
+			if (resolvedPageId === null) {
+				return ctx.format.notFound(`Page "${title}" not found`);
+			}
+
+			// Always send the subjectId key: omitting it is a 400 upstream, whereas
+			// an explicit null is the documented way to clear the Main Subject.
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki set-main response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'PUT',
+				path: `/page/${resolvedPageId}/mainSubject`,
+				csrf: true,
+				body: { subjectId, ...(comment !== undefined ? { comment } : {}) },
+			})) as SetMainResponse;
+
+			return ctx.format.ok({ pageId: resolvedPageId, status: data.status ?? 'changed' });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-update-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-update-subject.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const statementSchema = z.object({
+	propertyType: z
+		.string()
+		.min(1)
+		.describe('Property type: text, url, date, datetime, select, number, boolean, or relation.'),
+	value: z
+		.unknown()
+		.describe(
+			'text/url/date/datetime → array of strings; select → array of option IDs; number → number; boolean → boolean; relation → array of { target: subjectId, properties? }.',
+		),
+});
+
+const inputSchema = {
+	id: z
+		.string()
+		.min(1)
+		.describe('Subject ID to replace (starts with s…). Resolve one with neowiki-search-subjects.'),
+	label: z.string().min(1).describe('New display label. Required, non-empty.'),
+	statements: z
+		.record(z.string(), statementSchema)
+		.describe(
+			'Full replacement statement map (property name → { propertyType, value }). Property names absent from this map are deleted; pass {} to clear all statements. The key is propertyType, NOT the `type` read tools return.',
+		),
+	comment: z.string().optional().describe('Optional edit summary.'),
+} as const;
+
+interface UpdateResponse {
+	status?: string;
+	subjectId?: string;
+}
+
+export const neowikiUpdateSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-update-subject',
+	description:
+		'Replaces a NeoWiki Subject\'s label and statements — a FULL replace: property names absent from `statements` are deleted, and {} clears all statements. Enabled only when the wiki has NeoWiki installed. The Subject\'s id and schema are immutable. Requires the edit right. Read the current state with neowiki-get-subject first. Each statement is keyed by property name as { propertyType, value } — the key is propertyType, NOT the `type` key read tools return. Value by type: text/url/date/datetime → array of strings; select → array of option IDs (resolve via neowiki-get-schema); number → a number; boolean → a boolean; relation → array of { target: "<subjectId>", properties? }. Pre-validate with neowiki-validate-subject. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Update NeoWiki subject',
+		readOnlyHint: false,
+		destructiveHint: true,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'update NeoWiki subject',
+	target: (a) => a.id,
+
+	async handle({ id, label, statements, comment }, ctx: ToolContext): Promise<CallToolResult> {
+		const mwn = await ctx.mwn();
+		try {
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki replace response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'PUT',
+				path: `/subject/${encodeURIComponent(id)}`,
+				csrf: true,
+				body: { label, statements, ...(comment !== undefined ? { comment } : {}) },
+			})) as UpdateResponse;
+
+			return ctx.format.ok({ subjectId: data.subjectId ?? id, status: data.status ?? 'updated' });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowiki-validate-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-validate-subject.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '../../../runtime/tool.js';
+import type { ToolContext } from '../../../runtime/context.js';
+import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.js';
+
+const statementSchema = z.object({
+	propertyType: z
+		.string()
+		.min(1)
+		.describe('Property type: text, url, date, datetime, select, number, boolean, or relation.'),
+	value: z
+		.unknown()
+		.describe('Value in the format for the propertyType (see neowiki-create-subject).'),
+});
+
+const inputSchema = {
+	id: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Subject ID to validate an UPDATE against (its schema is used). Omit to validate a NEW subject and pass schema instead.',
+		),
+	schema: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			'Schema name to validate a NEW subject against. Required when id is omitted; ignored when id is given.',
+		),
+	label: z
+		.string()
+		.describe(
+			'Proposed display label. May be empty — an empty label yields a label-required violation rather than an error.',
+		),
+	statements: z
+		.record(z.string(), statementSchema)
+		.describe(
+			'Proposed statement map (property name → { propertyType, value }). The key is propertyType, NOT the `type` read tools return.',
+		),
+} as const;
+
+interface ValidateResponse {
+	violations?: unknown[];
+}
+
+export const neowikiValidateSubject: Tool<typeof inputSchema> = {
+	name: 'neowiki-validate-subject',
+	description:
+		'Dry-runs validation of a proposed NeoWiki Subject against its Schema and returns any violations WITHOUT writing. Enabled only when the wiki has NeoWiki installed. Provide id to validate an update to an existing Subject (its schema is used), or omit id and provide schema to validate a new Subject. Use before neowiki-create-subject / neowiki-update-subject to catch type mismatches, missing required properties, and the propertyType-vs-type footgun. Returns { violations: [] } when valid. Pre-1.0: the NeoWiki API may change without notice.',
+	inputSchema,
+	annotations: {
+		title: 'Validate NeoWiki subject',
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	} as ToolAnnotations,
+	failureVerb: 'validate NeoWiki subject',
+	target: (a) => a.id ?? a.schema ?? '',
+
+	async handle({ id, schema, label, statements }, ctx: ToolContext): Promise<CallToolResult> {
+		if (id === undefined && schema === undefined) {
+			return ctx.format.invalidInput(
+				'Provide schema to validate a new subject, or id to validate an update.',
+			);
+		}
+
+		const mwn = await ctx.mwn();
+		try {
+			const spec =
+				id !== undefined
+					? { path: `/subject/${encodeURIComponent(id)}/validate`, body: { label, statements } }
+					: { path: '/subject/validate', body: { schema, label, statements } };
+
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki validate response shape; trusted at this boundary
+			const data = (await neowikiRequest(mwn, {
+				method: 'POST',
+				path: spec.path,
+				body: spec.body,
+			})) as ValidateResponse;
+
+			return ctx.format.ok({ violations: Array.isArray(data.violations) ? data.violations : [] });
+		} catch (err) {
+			return neowikiErrorResult(err, ctx);
+		}
+	},
+};

--- a/src/tools/extensions/neowiki/neowikiRequest.ts
+++ b/src/tools/extensions/neowiki/neowikiRequest.ts
@@ -94,11 +94,11 @@ export async function neowikiRequest(mwn: Mwn, spec: NeoWikiRequestSpec): Promis
 	if (mwn.usingOAuth2 && typeof mwn.options.OAuth2AccessToken === 'string') {
 		headers.Authorization = `Bearer ${mwn.options.OAuth2AccessToken}`;
 	}
+	if (spec.csrf === true) {
+		headers['X-CSRF-TOKEN'] = await mwn.getCsrfToken();
+	}
 
 	try {
-		if (spec.csrf === true) {
-			headers['X-CSRF-TOKEN'] = await mwn.getCsrfToken();
-		}
 		const response = await mwn.rawRequest({
 			url,
 			method: spec.method,
@@ -149,14 +149,11 @@ function classifyNeoWikiError(err: unknown): NeoWikiApiError {
 		}
 	}
 
-	if (status === 404) {
-		return new NeoWikiApiError('not_found', 'NeoWiki resource not found.');
-	}
-	if (status === 403) {
-		return new NeoWikiApiError('permission_denied', 'Permission denied by NeoWiki.');
-	}
-	if (status === 429) {
-		return new NeoWikiApiError('rate_limited', 'NeoWiki rate limit exceeded.');
+	// Bodyless / unrecognised-shape responses: map by HTTP status the same way as
+	// the message-bearing branch above, so the two paths can't disagree.
+	const statusCategory = categoryForStatus(status);
+	if (statusCategory !== undefined) {
+		return new NeoWikiApiError(statusCategory, `NeoWiki request failed (HTTP ${status}).`);
 	}
 
 	// Covers both axios network errors (no .response — timeout, ECONNREFUSED) and unrecognised body shapes.

--- a/src/tools/extensions/neowiki/neowikiRequest.ts
+++ b/src/tools/extensions/neowiki/neowikiRequest.ts
@@ -15,11 +15,17 @@ export class NeoWikiApiError extends Error {
 }
 
 export interface NeoWikiRequestSpec {
-	readonly method: 'GET' | 'POST';
-	/** Path under `/neowiki/v0`, already URL-encoded, e.g. `/schema/Person`. */
+	readonly method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	/** Path under `/neowiki/v0`, already URL-encoded, e.g. `/subject/s1`. */
 	readonly path: string;
 	readonly query?: Record<string, string>;
 	readonly body?: unknown;
+	/**
+	 * When true, fetch a CSRF token via `mwn.getCsrfToken()` and send it as the
+	 * `X-CSRF-TOKEN` header NeoWiki requires on every mutating endpoint. Omit for
+	 * reads and the `validate` dry-runs, which take no token.
+	 */
+	readonly csrf?: boolean;
 }
 
 // NeoWiki's `errorType` strings are stable across releases (per query-api docs);
@@ -35,6 +41,27 @@ const ERROR_TYPE_TO_CATEGORY: Record<string, ErrorCategory> = {
 	backendUnavailable: 'upstream_failure',
 	internalError: 'upstream_failure',
 };
+
+// The write endpoints (create/replace/delete/set-main) use a different error
+// envelope than the read endpoints — `{ status: "error", message }` with no
+// `errorType`. Map those by HTTP status; 5xx and unknown fall through to
+// upstream_failure so the internal-exception sanitisation below is preserved.
+function categoryForStatus(status: number | undefined): ErrorCategory | undefined {
+	switch (status) {
+		case 400:
+			return 'invalid_input';
+		case 403:
+			return 'permission_denied';
+		case 404:
+			return 'not_found';
+		case 409:
+			return 'conflict';
+		case 429:
+			return 'rate_limited';
+		default:
+			return undefined;
+	}
+}
 
 function restBaseFrom(apiUrl: string): string {
 	// apiUrl is `${server}${scriptpath}/api.php`; NeoWiki REST lives at
@@ -69,6 +96,9 @@ export async function neowikiRequest(mwn: Mwn, spec: NeoWikiRequestSpec): Promis
 	}
 
 	try {
+		if (spec.csrf === true) {
+			headers['X-CSRF-TOKEN'] = await mwn.getCsrfToken();
+		}
 		const response = await mwn.rawRequest({
 			url,
 			method: spec.method,
@@ -115,7 +145,7 @@ function classifyNeoWikiError(err: unknown): NeoWikiApiError {
 		// Internal RuntimeException: { message, exception: {…backtrace…} }.
 		// Surface the message only — never the backtrace.
 		if (typeof record.message === 'string') {
-			return new NeoWikiApiError('upstream_failure', record.message);
+			return new NeoWikiApiError(categoryForStatus(status) ?? 'upstream_failure', record.message);
 		}
 	}
 

--- a/src/tools/extensions/neowiki/pageId.ts
+++ b/src/tools/extensions/neowiki/pageId.ts
@@ -1,0 +1,40 @@
+import type { Mwn } from 'mwn';
+
+interface PageInfoResponse {
+	query?: { pages?: Array<{ pageid?: number; missing?: boolean; title?: string }> };
+}
+
+/** True when exactly one of `title` / `pageId` is provided. */
+export function hasOnePageRef(ref: { title?: string; pageId?: number }): boolean {
+	return (ref.title === undefined) !== (ref.pageId === undefined);
+}
+
+/**
+ * Resolves a page reference to a numeric page id. A passed `pageId` is returned
+ * as-is (no API call); a `title` is resolved via the action API. Returns `null`
+ * when the title does not exist. Callers should validate the reference with
+ * `hasOnePageRef` first; with that guard, `null` means "title not found".
+ */
+export async function resolvePageId(
+	mwn: Mwn,
+	ref: { title?: string; pageId?: number },
+): Promise<number | null> {
+	if (ref.pageId !== undefined) {
+		return ref.pageId;
+	}
+	if (ref.title === undefined) {
+		return null;
+	}
+	const info = (await mwn.request({
+		action: 'query',
+		titles: ref.title,
+		formatversion: 2,
+		format: 'json',
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- action=query info response shape; trusted at this boundary
+	})) as PageInfoResponse;
+	const page = info.query?.pages?.[0];
+	if (page === undefined || page.missing === true || typeof page.pageid !== 'number') {
+		return null;
+	}
+	return page.pageid;
+}

--- a/src/tools/extensions/neowiki/pageId.ts
+++ b/src/tools/extensions/neowiki/pageId.ts
@@ -20,6 +20,9 @@ export async function resolvePageId(
 	ref: { title?: string; pageId?: number },
 ): Promise<number | null> {
 	if (ref.pageId !== undefined) {
+		// A caller-supplied pageId is trusted and passed through unverified (no
+		// existence check) — the round-trip is skipped and a bad id surfaces as the
+		// downstream endpoint's 404. Only the title path resolves via the API.
 		return ref.pageId;
 	}
 	if (ref.title === undefined) {

--- a/tests/tools/extensions/index.test.ts
+++ b/tests/tools/extensions/index.test.ts
@@ -26,6 +26,23 @@ describe('extensionPacks', () => {
 		expect(bucket?.extensionNames).toEqual(['Bucket']);
 	});
 
+	it('exposes the eleven NeoWiki tools including the write tools', () => {
+		const neowiki = extensionPacks.find((p) => p.id === 'neowiki');
+		expect(neowiki?.tools.map((t) => t.name)).toEqual([
+			'neowiki-list-schemas',
+			'neowiki-get-schema',
+			'neowiki-cypher-query',
+			'neowiki-search-subjects',
+			'neowiki-get-subject',
+			'neowiki-get-page-subjects',
+			'neowiki-create-subject',
+			'neowiki-update-subject',
+			'neowiki-delete-subject',
+			'neowiki-set-main-subject',
+			'neowiki-validate-subject',
+		]);
+	});
+
 	it('all tool names across packs are unique', () => {
 		const allNames = extensionPacks.flatMap((p) => p.tools.map((t) => t.name));
 		expect(new Set(allNames).size).toBe(allNames.length);

--- a/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiCreateSubject } from '../../../../src/tools/extensions/neowiki/neowiki-create-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+const stmts = { Country: { propertyType: 'text', value: ['Germany'] } };
+
+describe('neowiki-create-subject', () => {
+	it('resolves a title and posts a child subject with a CSRF token', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { pages: [{ pageid: 7, title: 'Berlin' }] } }),
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'created', subjectId: 's1demo' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCreateSubject.handle(
+			{ title: 'Berlin', label: 'Berlin', schema: 'City', statements: stmts },
+			ctx,
+		);
+		const call = mock.rawRequest.mock.calls[0][0] as {
+			url: string;
+			method: string;
+			data: string;
+			headers: Record<string, string>;
+		};
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/page/7/childSubjects');
+		expect(call.method).toBe('POST');
+		expect(call.headers['X-CSRF-TOKEN']).toBe('tok');
+		expect(JSON.parse(call.data)).toMatchObject({
+			label: 'Berlin',
+			schema: 'City',
+			statements: stmts,
+		});
+		expect(result.structuredContent).toMatchObject({
+			subjectId: 's1demo',
+			status: 'created',
+			pageId: 7,
+		});
+	});
+
+	it('posts to /mainSubject when isMain is true', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'created', subjectId: 's1' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		await neowikiCreateSubject.handle(
+			{ pageId: 7, isMain: true, label: 'X', schema: 'City', statements: stmts },
+			ctx,
+		);
+		expect((mock.rawRequest.mock.calls[0][0] as { url: string }).url).toContain(
+			'/page/7/mainSubject',
+		);
+	});
+
+	it('surfaces a 201 error body as a conflict', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi
+				.fn()
+				.mockResolvedValue({ data: { status: 'error', message: 'Subject already exists' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCreateSubject.handle(
+			{ pageId: 7, isMain: true, label: 'X', schema: 'City', statements: stmts },
+			ctx,
+		);
+		assertStructuredError(result, 'conflict');
+	});
+
+	it('rejects when neither title nor pageId is given', async () => {
+		const ctx = fakeContext({ mwn: async () => createMockMwn() as never });
+		const result = await neowikiCreateSubject.handle(
+			{ label: 'X', schema: 'City', statements: stmts },
+			ctx,
+		);
+		assertStructuredError(result, 'invalid_input');
+	});
+
+	it('returns not_found for an unknown title', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { pages: [{ missing: true, title: 'Nope' }] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiCreateSubject.handle(
+			{ title: 'Nope', label: 'X', schema: 'City', statements: stmts },
+			ctx,
+		);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-delete-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-delete-subject.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiDeleteSubject } from '../../../../src/tools/extensions/neowiki/neowiki-delete-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
+	err.response = { status, data };
+	return err;
+}
+
+describe('neowiki-delete-subject', () => {
+	it('DELETEs with a CSRF token and reports deleted', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: '' }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiDeleteSubject.handle({ id: 's1demo', comment: 'spam' }, ctx);
+		const call = mock.rawRequest.mock.calls[0][0] as {
+			url: string;
+			method: string;
+			data: string;
+			headers: Record<string, string>;
+		};
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1demo');
+		expect(call.method).toBe('DELETE');
+		expect(call.headers['X-CSRF-TOKEN']).toBe('tok');
+		expect(JSON.parse(call.data)).toEqual({ comment: 'spam' });
+		expect(result.structuredContent).toMatchObject({ subjectId: 's1demo', status: 'deleted' });
+	});
+
+	it('omits the body when no comment is given', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: '' }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		await neowikiDeleteSubject.handle({ id: 's1demo' }, ctx);
+		expect((mock.rawRequest.mock.calls[0][0] as { data?: unknown }).data).toBeUndefined();
+	});
+
+	it('maps a 403 to permission_denied', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockRejectedValue(httpError(403, { status: 'error', message: 'nope' })),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiDeleteSubject.handle({ id: 's1demo' }, ctx);
+		assertStructuredError(result, 'permission_denied');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiSetMainSubject } from '../../../../src/tools/extensions/neowiki/neowiki-set-main-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
+	err.response = { status, data };
+	return err;
+}
+
+describe('neowiki-set-main-subject', () => {
+	it('promotes a subject and returns changed', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'changed' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiSetMainSubject.handle({ pageId: 7, subjectId: 's1demo' }, ctx);
+		const call = mock.rawRequest.mock.calls[0][0] as { url: string; method: string; data: string };
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/page/7/mainSubject');
+		expect(call.method).toBe('PUT');
+		expect(JSON.parse(call.data)).toEqual({ subjectId: 's1demo' });
+		expect(result.structuredContent).toMatchObject({ pageId: 7, status: 'changed' });
+	});
+
+	it('sends subjectId:null to clear the main subject', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'changed' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		await neowikiSetMainSubject.handle({ pageId: 7, subjectId: null }, ctx);
+		expect(JSON.parse((mock.rawRequest.mock.calls[0][0] as { data: string }).data)).toEqual({
+			subjectId: null,
+		});
+	});
+
+	it('rejects when neither title nor pageId is given', async () => {
+		const ctx = fakeContext({ mwn: async () => createMockMwn() as never });
+		const result = await neowikiSetMainSubject.handle({ subjectId: 's1' }, ctx);
+		assertStructuredError(result, 'invalid_input');
+	});
+
+	it('maps a 404 (subject not on page) to not_found', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi
+				.fn()
+				.mockRejectedValue(
+					httpError(404, { status: 'error', message: 'Subject not found on this page' }),
+				),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiSetMainSubject.handle({ pageId: 7, subjectId: 'sX' }, ctx);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiUpdateSubject } from '../../../../src/tools/extensions/neowiki/neowiki-update-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+function httpError(status: number, data: unknown): Error & { response: unknown } {
+	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
+	err.response = { status, data };
+	return err;
+}
+
+const stmts = { Founded: { propertyType: 'number', value: 2019 } };
+
+describe('neowiki-update-subject', () => {
+	it('PUTs a full replace with a CSRF token', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'updated', subjectId: 's1demo' } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiUpdateSubject.handle(
+			{ id: 's1demo', label: 'ACME', statements: stmts, comment: 'tidy' },
+			ctx,
+		);
+		const call = mock.rawRequest.mock.calls[0][0] as {
+			url: string;
+			method: string;
+			data: string;
+			headers: Record<string, string>;
+		};
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1demo');
+		expect(call.method).toBe('PUT');
+		expect(call.headers['X-CSRF-TOKEN']).toBe('tok');
+		expect(JSON.parse(call.data)).toEqual({ label: 'ACME', statements: stmts, comment: 'tidy' });
+		expect(result.structuredContent).toMatchObject({ subjectId: 's1demo', status: 'updated' });
+	});
+
+	it('maps a 404 to not_found', async () => {
+		const mock = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('tok'),
+			rawRequest: vi.fn().mockRejectedValue(httpError(404, { status: 'error', message: 'gone' })),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiUpdateSubject.handle({ id: 'sX', label: 'X', statements: {} }, ctx);
+		assertStructuredError(result, 'not_found');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowiki-validate-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-validate-subject.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { fakeContext } from '../../../helpers/fakeContext.js';
+import { neowikiValidateSubject } from '../../../../src/tools/extensions/neowiki/neowiki-validate-subject.js';
+import { assertStructuredError } from '../../../helpers/structuredResult.js';
+
+const stmts = { Founded: { propertyType: 'number', value: 2019 } };
+
+describe('neowiki-validate-subject', () => {
+	it('validates a new subject against a schema (no CSRF token)', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({ data: { violations: [] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiValidateSubject.handle(
+			{ schema: 'Company', label: 'ACME', statements: stmts },
+			ctx,
+		);
+		const call = mock.rawRequest.mock.calls[0][0] as {
+			url: string;
+			data: string;
+			headers: Record<string, string>;
+		};
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/validate');
+		expect(JSON.parse(call.data)).toEqual({ schema: 'Company', label: 'ACME', statements: stmts });
+		expect(call.headers['X-CSRF-TOKEN']).toBeUndefined();
+		expect(mock.getCsrfToken).not.toHaveBeenCalled();
+		expect(result.structuredContent).toMatchObject({ violations: [] });
+	});
+
+	it('validates an update when id is given', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi
+				.fn()
+				.mockResolvedValue({ data: { violations: [{ property: 'Founded', message: 'bad' }] } }),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+		const result = await neowikiValidateSubject.handle(
+			{ id: 's1demo', label: 'ACME', statements: stmts },
+			ctx,
+		);
+		const call = mock.rawRequest.mock.calls[0][0] as { url: string; data: string };
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1demo/validate');
+		expect(JSON.parse(call.data)).toEqual({ label: 'ACME', statements: stmts });
+		expect(result.structuredContent).toMatchObject({
+			violations: [{ property: 'Founded', message: 'bad' }],
+		});
+	});
+
+	it('rejects a new-subject validation with no schema', async () => {
+		const ctx = fakeContext({ mwn: async () => createMockMwn() as never });
+		const result = await neowikiValidateSubject.handle({ label: 'ACME', statements: stmts }, ctx);
+		assertStructuredError(result, 'invalid_input');
+	});
+});

--- a/tests/tools/extensions/neowiki/neowikiRequest.test.ts
+++ b/tests/tools/extensions/neowiki/neowikiRequest.test.ts
@@ -203,6 +203,7 @@ describe('neowikiRequest', () => {
 			[404, 'not_found'],
 			[409, 'conflict'],
 			[429, 'rate_limited'],
+			[500, 'upstream_failure'],
 		];
 		for (const [status, category] of cases) {
 			const mock = createMockMwn({

--- a/tests/tools/extensions/neowiki/neowikiRequest.test.ts
+++ b/tests/tools/extensions/neowiki/neowikiRequest.test.ts
@@ -155,4 +155,64 @@ describe('neowikiRequest', () => {
 			neowikiRequest(mock as never, { method: 'POST', path: '/query/cypher', body: {} }),
 		).rejects.toMatchObject({ category: 'upstream_failure' });
 	});
+
+	it('sends a PUT to the right URL', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockResolvedValue({ data: { status: 'updated', subjectId: 's1' } }),
+		});
+		await neowikiRequest(mock as never, {
+			method: 'PUT',
+			path: '/subject/s1',
+			body: { label: 'X', statements: {} },
+		});
+		const call = mock.rawRequest.mock.calls[0][0] as Record<string, unknown>;
+		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1');
+		expect(call.method).toBe('PUT');
+	});
+
+	it('sends a DELETE and tolerates an empty body', async () => {
+		const mock = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: '' }) });
+		const out = await neowikiRequest(mock as never, { method: 'DELETE', path: '/subject/s1' });
+		const call = mock.rawRequest.mock.calls[0][0] as Record<string, unknown>;
+		expect(call.method).toBe('DELETE');
+		expect(out).toBe('');
+	});
+
+	it('injects X-CSRF-TOKEN when csrf is set, and omits it otherwise', async () => {
+		const withCsrf = createMockMwn({
+			getCsrfToken: vi.fn().mockResolvedValue('csrf-tok'),
+			rawRequest: vi.fn().mockResolvedValue({ data: {} }),
+		});
+		await neowikiRequest(withCsrf as never, { method: 'DELETE', path: '/subject/s1', csrf: true });
+		const h1 = (withCsrf.rawRequest.mock.calls[0][0] as { headers: Record<string, string> })
+			.headers;
+		expect(h1['X-CSRF-TOKEN']).toBe('csrf-tok');
+		expect(withCsrf.getCsrfToken).toHaveBeenCalledTimes(1);
+
+		const noCsrf = createMockMwn({ rawRequest: vi.fn().mockResolvedValue({ data: {} }) });
+		await neowikiRequest(noCsrf as never, { method: 'GET', path: '/schemas' });
+		const h2 = (noCsrf.rawRequest.mock.calls[0][0] as { headers: Record<string, string> }).headers;
+		expect(h2['X-CSRF-TOKEN']).toBeUndefined();
+		expect(noCsrf.getCsrfToken).not.toHaveBeenCalled();
+	});
+
+	it('maps the write {status:error,message} envelope by HTTP status', async () => {
+		const cases: Array<[number, string]> = [
+			[400, 'invalid_input'],
+			[403, 'permission_denied'],
+			[404, 'not_found'],
+			[409, 'conflict'],
+			[429, 'rate_limited'],
+		];
+		for (const [status, category] of cases) {
+			const mock = createMockMwn({
+				rawRequest: vi
+					.fn()
+					.mockRejectedValue(httpError(status, { status: 'error', message: 'bad' })),
+			});
+			await expect(
+				neowikiRequest(mock as never, { method: 'PUT', path: '/subject/s1', body: {}, csrf: true }),
+			).rejects.toMatchObject({ category, message: 'bad' });
+		}
+	});
 });

--- a/tests/tools/extensions/neowiki/pageId.test.ts
+++ b/tests/tools/extensions/neowiki/pageId.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockMwn } from '../../../helpers/mock-mwn.js';
+import { resolvePageId, hasOnePageRef } from '../../../../src/tools/extensions/neowiki/pageId.js';
+
+describe('hasOnePageRef', () => {
+	it('is true for exactly one of title/pageId', () => {
+		expect(hasOnePageRef({ title: 'A' })).toBe(true);
+		expect(hasOnePageRef({ pageId: 1 })).toBe(true);
+		expect(hasOnePageRef({})).toBe(false);
+		expect(hasOnePageRef({ title: 'A', pageId: 1 })).toBe(false);
+	});
+});
+
+describe('resolvePageId', () => {
+	it('returns a passed pageId without calling the API', async () => {
+		const mock = createMockMwn();
+		expect(await resolvePageId(mock as never, { pageId: 42 })).toBe(42);
+		expect(mock.request).not.toHaveBeenCalled();
+	});
+
+	it('resolves a title to its page id', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { pages: [{ pageid: 7, title: 'Berlin' }] } }),
+		});
+		expect(await resolvePageId(mock as never, { title: 'Berlin' })).toBe(7);
+	});
+
+	it('returns null for a missing page', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({ query: { pages: [{ missing: true, title: 'Nope' }] } }),
+		});
+		expect(await resolvePageId(mock as never, { title: 'Nope' })).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Adds the write half of the NeoWiki integration (the read/query tools shipped in #395). Five new tools in the `neowiki` extension pack let an agent mutate a NeoWiki knowledge graph: create a subject on a page (as a child or the page's main subject), replace a subject's label and statements, delete a subject, set or clear a page's main subject, and dry-run-validate a proposed subject before writing.

| Tool | Behaviour |
|---|---|
| `neowiki-create-subject` | Create a child or main subject on a page. Guards an upstream quirk where creating a main subject that already exists returns HTTP 201 with an error body — surfaced as a `conflict`. |
| `neowiki-update-subject` | Full replace of a subject's label + statements (omitted properties are deleted; `{}` clears all). |
| `neowiki-delete-subject` | Delete a subject by ID. |
| `neowiki-set-main-subject` | Promote an existing subject to the page's main subject, or `null` to clear it. |
| `neowiki-validate-subject` | Read-only dry-run that returns schema violations without writing. |

The four mutating tools require the `edit` right; `validate` is read-only.

### Shared plumbing
- **`neowikiRequest`**: adds `PUT`/`DELETE`, and a `csrf` flag that fetches the CSRF token and sends it as `X-CSRF-TOKEN` (every mutating NeoWiki endpoint requires it; the token fetch sits before the request so an auth failure classifies as `authentication`). The error classifier now maps the write endpoints' `{status:"error", message}` envelope by HTTP status (400→invalid_input, 403→permission_denied, 404→not_found, 409→conflict, 429→rate_limited), unified across the message-bearing and bodyless paths.
- **`pageId` helper**: shared `hasOnePageRef` + `resolvePageId`; `neowiki-get-page-subjects` refactored onto it.

### Footgun defence
NeoWiki write bodies key statements by `propertyType` (not the `type` key read tools return); a statement missing it is silently dropped server-side. The input schemas require `propertyType`, so a copied-from-read statement is rejected as invalid input rather than vanishing.

README tool table and `CHANGELOG.md` (`[Unreleased]`) are updated per repo policy.

## Test plan

- [x] Full vitest suite green (1181 tests), `tsgo --noEmit`, oxlint, and `npm run build` all clean.
- [x] Each tool covered by tests asserting the real request shape (URL/method/CSRF header/serialized body) and the mapped error categories.
- [x] **Live authenticated lifecycle verified against neowiki.dev**: create a subject → read it back → full-replace update (confirmed an omitted property is deleted) → promote to main subject → delete → confirmed gone. All test data cleaned up.
- [x] Footgun confirmed live: a statement using `type` instead of `propertyType` is rejected as invalid input.

### Note
NeoWiki is pre-1.0; the tool descriptions carry that caveat. The currently-deployed neowiki.dev predates the `validate` endpoints, so `neowiki-validate-subject` returns an `upstream_failure` there until it updates (it is covered by unit tests and works against current NeoWiki). Worth filing upstream separately: the create-main "already exists" case returns HTTP 201 with an error body rather than a 409 (this PR guards against it client-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)