### PR TITLE
Add bot parameter to update-page and create-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `MCP_FILE_DATA_MAX_BYTES` environment variable: a hard ceiling on the encoded size of a `get-file-data` response (default 1 MB).
 - `whoami` tool: reports which account the current session is acting as on a wiki — the username, whether the session is anonymous, and the user groups it belongs to (optionally the full rights list). Use it to confirm who edits will be attributed to before writing, for example when creating a page under your own user namespace.
 - `MCP_UPLOAD_MAX_BYTES` environment variable: caps the size the server buffers when fetching a URL for `upload-file-from-url` / `update-file-from-url` (default 100 MB). Larger files are handed to the wiki's own copy-upload.
+- `update-page` and `create-page` accept a `bot` parameter that marks the edit as a bot edit. The flag takes effect only when the authenticated account has the `bot` right (bot group, or the high-volume grant on a bot password or OAuth consumer); the response reports whether the flag applied via `botMarked`.
 
 ### Changed
 

--- a/src/services/editService.ts
+++ b/src/services/editService.ts
@@ -28,10 +28,47 @@ export interface EditService {
 
 	/** Pure helper: returns options with tags injected from the targeted wiki's config. Used by mwn.create/delete/undelete callers. */
 	applyTags<T extends Record<string, unknown>>(options: T): T;
+
+	/**
+	 * Reports whether the authenticated account holds the `bot` right on the
+	 * targeted wiki — i.e. whether a bot-flagged edit will actually be marked.
+	 * Resolves undefined when the rights probe fails; a probe failure never
+	 * blocks a write. The probe is cached per Mwn instance.
+	 */
+	botRight(mwn: Mwn): Promise<boolean | undefined>;
 }
 
 export class EditServiceImpl implements EditService {
 	public constructor(private readonly activeWiki: ActiveWiki) {}
+
+	private readonly botRightCache = new WeakMap<Mwn, Promise<boolean>>();
+
+	public async botRight(mwn: Mwn): Promise<boolean | undefined> {
+		let pending = this.botRightCache.get(mwn);
+		if (!pending) {
+			pending = this.queryBotRight(mwn);
+			this.botRightCache.set(mwn, pending);
+		}
+		try {
+			return await pending;
+		} catch {
+			// Drop the failed probe so the next bot-flagged edit retries instead
+			// of pinning the failure for the lifetime of the Mwn instance.
+			this.botRightCache.delete(mwn);
+			return undefined;
+		}
+	}
+
+	private async queryBotRight(mwn: Mwn): Promise<boolean> {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		const response = (await mwn.request({
+			action: 'query',
+			meta: 'userinfo',
+			uiprop: 'rights',
+			formatversion: '2',
+		})) as { query?: { userinfo?: { rights?: string[] } } };
+		return response.query?.userinfo?.rights?.includes('bot') ?? false;
+	}
 
 	public async submit(mwn: Mwn, params: Record<string, unknown>): Promise<unknown> {
 		const token = await mwn.getCsrfToken();

--- a/src/services/editService.ts
+++ b/src/services/editService.ts
@@ -33,7 +33,9 @@ export interface EditService {
 	 * Reports whether the authenticated account holds the `bot` right on the
 	 * targeted wiki — i.e. whether a bot-flagged edit will actually be marked.
 	 * Resolves undefined when the rights probe fails; a probe failure never
-	 * blocks a write. The probe is cached per Mwn instance.
+	 * blocks a write. The probe is cached per Mwn instance; sessions that
+	 * authenticate with a per-request bearer token get a fresh Mwn per call,
+	 * so the probe re-runs for each bot-flagged edit there.
 	 */
 	botRight(mwn: Mwn): Promise<boolean | undefined>;
 }
@@ -53,8 +55,12 @@ export class EditServiceImpl implements EditService {
 			return await pending;
 		} catch {
 			// Drop the failed probe so the next bot-flagged edit retries instead
-			// of pinning the failure for the lifetime of the Mwn instance.
-			this.botRightCache.delete(mwn);
+			// of pinning the failure for the lifetime of the Mwn instance. The
+			// identity check keeps a late rejection from evicting a newer probe
+			// that another caller has already reseeded.
+			if (this.botRightCache.get(mwn) === pending) {
+				this.botRightCache.delete(mwn);
+			}
 			return undefined;
 		}
 	}

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -15,6 +15,12 @@ const inputSchema = {
 		.describe(
 			"Content model of the new page. If omitted, MediaWiki picks the default for the title's namespace.",
 		),
+	bot: z
+		.boolean()
+		.optional()
+		.describe(
+			'Marks the edit as a bot edit, which Special:RecentChanges hides by default. Takes effect only when the authenticated account has the `bot` right (granted by the bot group, or by the high-volume grant on a bot password or OAuth consumer); without it the edit saves unflagged and the response reports botMarked: false. Use when performing bulk or automated edit runs, or when the user requests it.',
+		),
 } as const;
 
 export const createPage: Tool<typeof inputSchema> = {
@@ -33,7 +39,7 @@ export const createPage: Tool<typeof inputSchema> = {
 	target: (a) => a.title,
 
 	async handle(
-		{ source, title, comment, contentModel },
+		{ source, title, comment, contentModel, bot },
 		ctx: ToolContext,
 	): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
@@ -41,6 +47,9 @@ export const createPage: Tool<typeof inputSchema> = {
 		if (contentModel !== undefined) {
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- input is validated against ApiEditPageParams.contentmodel via the inputSchema enum
 			baseOptions.contentmodel = contentModel as ApiEditPageParams['contentmodel'];
+		}
+		if (bot === true) {
+			baseOptions.bot = true;
 		}
 		const options = ctx.edit.applyTags<ApiEditPageParams>(baseOptions);
 		const result = await mwn.create(
@@ -56,6 +65,7 @@ export const createPage: Tool<typeof inputSchema> = {
 			latestRevisionId: result.newrevid,
 			latestRevisionTimestamp: result.newtimestamp,
 			contentModel: result.contentmodel,
+			...(bot === true ? { botMarked: await ctx.edit.botRight(mwn) } : {}),
 			url: await buildPageUrl(ctx, result.title),
 		});
 	},

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -45,6 +45,12 @@ const inputSchema = {
 		.string()
 		.optional()
 		.describe("Heading for a new section; required when section='new', rejected otherwise."),
+	bot: z
+		.boolean()
+		.optional()
+		.describe(
+			'Marks the edit as a bot edit, which Special:RecentChanges hides by default. Takes effect only when the authenticated account has the `bot` right (granted by the bot group, or by the high-volume grant on a bot password or OAuth consumer); without it the edit saves unflagged and the response reports botMarked: false. Use when performing bulk or automated edit runs, or when the user requests it.',
+		),
 } as const;
 
 type UpdatePageArgs = z.infer<z.ZodObject<typeof inputSchema>>;
@@ -70,6 +76,7 @@ function buildEditParams({
 	section,
 	mode,
 	sectionTitle,
+	bot,
 }: UpdatePageArgs): Record<string, string | number | boolean> {
 	const sourceField =
 		mode === 'append' ? 'appendtext' : mode === 'prepend' ? 'prependtext' : 'text';
@@ -82,6 +89,7 @@ function buildEditParams({
 		...(latestId !== undefined ? { baserevid: latestId } : {}),
 		...(section !== undefined ? { section: String(section) } : {}),
 		...(sectionTitle !== undefined ? { sectiontitle: sectionTitle } : {}),
+		...(bot === true ? { bot: true } : {}),
 	};
 }
 
@@ -124,6 +132,7 @@ export const updatePage: Tool<typeof inputSchema> = {
 			latestRevisionId: edit.newrevid,
 			latestRevisionTimestamp: edit.newtimestamp,
 			contentModel: edit.contentmodel,
+			...(args.bot === true ? { botMarked: await ctx.edit.botRight(mwn) } : {}),
 			url: await buildPageUrl(ctx, resolvedTitle),
 		});
 	},

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -77,6 +77,7 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 			submitUpload: throws('edit.submitUpload') as never,
 			submitUploadFromBytes: throws('edit.submitUploadFromBytes') as never,
 			applyTags: (o) => ({ ...o }),
+			botRight: throws('edit.botRight') as never,
 		},
 		revision: new RevisionNormalizerImpl(),
 		format: new ResponseFormatterImpl(),

--- a/tests/services/editService.test.ts
+++ b/tests/services/editService.test.ts
@@ -83,6 +83,53 @@ describe('EditServiceImpl', () => {
 		});
 	});
 
+	describe('botRight', () => {
+		it('returns true when userinfo rights include bot', async () => {
+			const mock = createMockMwn({
+				request: vi
+					.fn()
+					.mockResolvedValue({ query: { userinfo: { rights: ['edit', 'bot', 'read'] } } }),
+			});
+			const edit = new EditServiceImpl(fakeActiveWiki());
+			await expect(edit.botRight(mock as never)).resolves.toBe(true);
+			expect(mock.request).toHaveBeenCalledWith({
+				action: 'query',
+				meta: 'userinfo',
+				uiprop: 'rights',
+				formatversion: '2',
+			});
+		});
+
+		it('returns false when userinfo rights lack bot', async () => {
+			const mock = createMockMwn({
+				request: vi.fn().mockResolvedValue({ query: { userinfo: { rights: ['edit', 'read'] } } }),
+			});
+			const edit = new EditServiceImpl(fakeActiveWiki());
+			await expect(edit.botRight(mock as never)).resolves.toBe(false);
+		});
+
+		it('caches the probe per Mwn instance', async () => {
+			const request = vi.fn().mockResolvedValue({ query: { userinfo: { rights: ['bot'] } } });
+			const mock = createMockMwn({ request });
+			const edit = new EditServiceImpl(fakeActiveWiki());
+			await edit.botRight(mock as never);
+			await edit.botRight(mock as never);
+			expect(request).toHaveBeenCalledTimes(1);
+		});
+
+		it('resolves undefined when the probe fails, and retries on the next call', async () => {
+			const request = vi
+				.fn()
+				.mockRejectedValueOnce(new Error('network down'))
+				.mockResolvedValueOnce({ query: { userinfo: { rights: ['bot'] } } });
+			const mock = createMockMwn({ request });
+			const edit = new EditServiceImpl(fakeActiveWiki());
+			await expect(edit.botRight(mock as never)).resolves.toBeUndefined();
+			await expect(edit.botRight(mock as never)).resolves.toBe(true);
+			expect(request).toHaveBeenCalledTimes(2);
+		});
+	});
+
 	it('submitUploadFromBytes posts a multipart upload with token, tags, and ignorewarnings', async () => {
 		const mock = createMockMwn({
 			getCsrfToken: vi.fn().mockResolvedValue('CSRFTOKEN'),

--- a/tests/tools/create-page.test.ts
+++ b/tests/tools/create-page.test.ts
@@ -170,4 +170,82 @@ describe('create-page', () => {
 		const opts = mock.create.mock.calls[0][3];
 		expect(opts).not.toHaveProperty('tags');
 	});
+
+	describe('bot flag', () => {
+		function fakeCreate() {
+			const mock = createMockMwn({
+				create: vi.fn().mockResolvedValue({
+					result: 'Success',
+					pageid: 12,
+					title: 'Bot Page',
+					contentmodel: 'wikitext',
+					oldrevid: 0,
+					newrevid: 3,
+					newtimestamp: '2026-01-01T00:00:00Z',
+				}),
+			});
+			const botRight = vi.fn().mockResolvedValue(true);
+			const ctx = fakeContext({
+				mwn: async () => mock as never,
+				edit: {
+					submit: vi.fn() as never,
+					submitUpload: vi.fn() as never,
+					applyTags: (o: object) => ({ ...o }),
+					botRight: botRight as never,
+				},
+			});
+			return { mock, botRight, ctx };
+		}
+
+		it('forwards bot=true in create options and reports botMarked true', async () => {
+			const { mock, botRight, ctx } = fakeCreate();
+
+			const result = await createPage.handle(
+				{ source: 'Hello', title: 'Bot Page', bot: true },
+				ctx,
+			);
+
+			const opts = mock.create.mock.calls[0][3];
+			expect(opts).toMatchObject({ bot: true });
+			const text = assertStructuredSuccess(result);
+			expect(text).toContain('Bot marked: true');
+			expect(botRight).toHaveBeenCalled();
+		});
+
+		it('reports botMarked false when the account lacks the bot right', async () => {
+			const { botRight, ctx } = fakeCreate();
+			botRight.mockResolvedValue(false);
+
+			const result = await createPage.handle(
+				{ source: 'Hello', title: 'Bot Page', bot: true },
+				ctx,
+			);
+
+			const text = assertStructuredSuccess(result);
+			expect(text).toContain('Bot marked: false');
+		});
+
+		it('omits botMarked when the rights probe fails', async () => {
+			const { botRight, ctx } = fakeCreate();
+			botRight.mockResolvedValue(undefined);
+
+			const result = await createPage.handle(
+				{ source: 'Hello', title: 'Bot Page', bot: true },
+				ctx,
+			);
+
+			const text = assertStructuredSuccess(result);
+			expect(text).not.toContain('Bot marked');
+		});
+
+		it('omits the bot option and skips the rights probe when bot is not requested', async () => {
+			const { mock, botRight, ctx } = fakeCreate();
+
+			await createPage.handle({ source: 'Hello', title: 'Bot Page' }, ctx);
+
+			const opts = mock.create.mock.calls[0][3];
+			expect(opts).not.toHaveProperty('bot');
+			expect(botRight).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -31,15 +31,17 @@ function fakeEdit(response: unknown = successResponse()) {
 		.mockImplementation(async (_m: never, params: Record<string, unknown>) =>
 			mock.request({ ...params, token: 'csrf-token', formatversion: '2' }),
 		);
+	const botRight = vi.fn().mockResolvedValue(true);
 	const ctx = fakeContext({
 		mwn: async () => mock as never,
 		edit: {
 			submit: submit as never,
 			submitUpload: vi.fn() as never,
 			applyTags: (o: object) => ({ ...o }),
+			botRight: botRight as never,
 		},
 	});
-	return { mock, request, submit, ctx };
+	return { mock, request, submit, botRight, ctx };
 }
 
 describe('update-page', () => {
@@ -383,6 +385,81 @@ describe('update-page', () => {
 
 			const envelope = assertStructuredError(result, 'invalid_input');
 			expect(envelope.message).toContain("mode is not compatible with section='new'");
+		});
+	});
+
+	describe('bot flag', () => {
+		it('forwards bot=true and reports botMarked true when the account has the bot right', async () => {
+			const { submit, botRight, ctx } = fakeEdit();
+
+			const result = await updatePage.handle(
+				{ title: 'My Page', source: 'content', bot: true },
+				ctx,
+			);
+
+			expect(submit.mock.calls[0][1]).toMatchObject({ bot: true });
+			const text = assertStructuredSuccess(result);
+			expect(text).toContain('Bot marked: true');
+			expect(botRight).toHaveBeenCalled();
+		});
+
+		it('reports botMarked false when the account lacks the bot right', async () => {
+			const { botRight, ctx } = fakeEdit();
+			botRight.mockResolvedValue(false);
+
+			const result = await updatePage.handle(
+				{ title: 'My Page', source: 'content', bot: true },
+				ctx,
+			);
+
+			const text = assertStructuredSuccess(result);
+			expect(text).toContain('Bot marked: false');
+		});
+
+		it('omits botMarked when the rights probe fails', async () => {
+			const { botRight, ctx } = fakeEdit();
+			botRight.mockResolvedValue(undefined);
+
+			const result = await updatePage.handle(
+				{ title: 'My Page', source: 'content', bot: true },
+				ctx,
+			);
+
+			const text = assertStructuredSuccess(result);
+			expect(text).not.toContain('Bot marked');
+		});
+
+		it('omits the bot param and skips the rights probe when bot is not requested', async () => {
+			const { submit, botRight, ctx } = fakeEdit();
+
+			await updatePage.handle({ title: 'My Page', source: 'content' }, ctx);
+
+			expect(submit.mock.calls[0][1]).not.toHaveProperty('bot');
+			expect(botRight).not.toHaveBeenCalled();
+		});
+
+		it('treats bot=false like an unflagged edit', async () => {
+			const { submit, botRight, ctx } = fakeEdit();
+
+			await updatePage.handle({ title: 'My Page', source: 'content', bot: false }, ctx);
+
+			expect(submit.mock.calls[0][1]).not.toHaveProperty('bot');
+			expect(botRight).not.toHaveBeenCalled();
+		});
+
+		it('composes with section and mode paths', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			await updatePage.handle(
+				{ title: 'My Page', source: '\n* row', section: 2, mode: 'append', bot: true },
+				ctx,
+			);
+
+			expect(submit.mock.calls[0][1]).toMatchObject({
+				section: '2',
+				appendtext: '\n* row',
+				bot: true,
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- update-page and create-page accept an optional `bot` parameter that marks the edit as a bot edit, which Special:RecentChanges hides by default.
- The response reports whether the flag actually applied via `botMarked: true|false`, computed by a new cached rights probe (`EditService.botRight`). MediaWiki silently ignores `bot=1` when the account lacks the `bot` right; the server makes that visible instead of letting callers assume it worked.
- When the rights probe fails, the field is omitted and the write proceeds — a probe failure never blocks an edit.

## Design notes

- Control is split the way MediaWiki splits it: the operator grants or withholds the **permission** (the `bot` right, via the bot group or the high-volume grant on a bot password / OAuth consumer), and the agent makes the per-edit **choice**. There is deliberately no config.json knob — over HTTP, rights arrive per bearer token while config is shared, so a config-level flag would misfire for exactly the multi-user case.
- Only `action=edit` accepts `bot`, so move / delete / undelete / upload are excluded by MediaWiki, not by this server.
- Probe cost: for config-credential wikis the probe is cached per `Mwn` instance (roughly one extra API call per process). Bearer-token sessions get a fresh `Mwn` per request, so the probe re-runs for each bot-flagged edit there; the per-instance cache key is what guarantees one caller's verdict is never served to another identity.

## Test plan

- [x] Unit tests: probe true / false / failure / caching / retry; per-tool forwarding, `botMarked` matrix, omission when not requested, section/mode composition (1195 tests green)
- [x] fmt, lint, build green
- [x] Smoke test (Inspector CLI against live wikis): create-page and update-page with bot=true on test.pro.wiki — flag accepted by the live API through both code paths, probe correctly reported `botMarked: false` (the account holds `markbotedits` but not `bot`); response omits `botMarked` when bot is not requested
- [x] `botMarked: true` + RecentChanges hiding against an account that actually holds the `bot` right (needs a high-volume bot password on a test wiki; not yet exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)