### PR TITLE
Add MCP_TRUSTED_HOSTS to exempt internal hosts from the SSRF guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Each pack's tools register only on wikis where its extension is installed.
 | `MCP_SESSION_IDLE_TIMEOUT` | Seconds an HTTP session may sit idle before it is closed and removed (StreamableHTTP transport). Any request resets the timer. `0` disables expiry. | `1800` |
 | `MCP_SHUTDOWN_GRACE_MS` | Maximum ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT`. See [docs/operations.md — Graceful shutdown](docs/operations.md#graceful-shutdown). | `10000` |
 | `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
+| `MCP_TRUSTED_HOSTS` | Comma-separated hosts exempt from the **outbound** SSRF guard's public-IP check — for deliberately pointing the server at an internal destination such as a Docker-network alias (`mediawiki.svc`). Distinct from the inbound `MCP_ALLOWED_HOSTS`; see [Security](#security). | `unset` |
 | `PORT` | Port used for StreamableHTTP transport | `3000` |
 
 ## Configuration
@@ -308,6 +309,7 @@ Defaults are safe for single-user use. Before exposing the HTTP transport to oth
 - **Trust the proxy, not the header.** The server forwards any `Authorization: Bearer` header straight to MediaWiki — authentication is the reverse proxy's job. Terminate TLS there, and don't expose the MCP port directly on an untrusted network. See [docs/deployment.md — reverse proxy requirements](docs/deployment.md#reverse-proxy-requirements).
 - **Pair `MCP_BIND` with `MCP_ALLOWED_HOSTS` and `MCP_ALLOWED_ORIGINS`.** The HTTP transport binds to `127.0.0.1` by default. When you open it up with `MCP_BIND=0.0.0.0`, set `MCP_ALLOWED_HOSTS` to the hostnames your proxy forwards and `MCP_ALLOWED_ORIGINS` to the browser origins allowed to call the server — these block DNS-rebinding and cross-origin attacks respectively.
 - **Uploads are opt-in.** `upload-file` is disabled until you list allowed directories in `uploadDirs` or `MCP_UPLOAD_DIRS`. See [docs/configuration.md — upload directories](docs/configuration.md#upload-directories).
+- **Internal destinations need `MCP_TRUSTED_HOSTS`.** Outbound fetches — the anonymous siteinfo probe, wiki discovery, `*-file-from-url` — are SSRF-guarded: a destination resolving to a private or loopback address is refused. To deliberately run against an internal host — e.g. a Docker-network alias like `mediawiki.svc` that bypasses your public proxy — list it in `MCP_TRUSTED_HOSTS` to exempt it from the public-IP check. The host is still resolved and pinned, and the guard stays on for every other destination. This is the **outbound** counterpart to the inbound `MCP_ALLOWED_HOSTS` (Host-header) check — the two are unrelated despite the similar names.
 
 Report a vulnerability via GitHub's [security advisory form](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/security/advisories/new) — full policy in [SECURITY.md](SECURITY.md).
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,7 @@ The path is fixed and not configurable.
 | `MCP_SHUTDOWN_GRACE_MS` | `10000` | Drain timeout in ms on `SIGTERM` / `SIGINT`. See [Graceful shutdown](operations.md#graceful-shutdown). |
 | `MCP_ALLOWED_HOSTS` | auto on localhost | Comma-separated Host-header allowlist. See [Reverse proxy requirements](#reverse-proxy-requirements). |
 | `MCP_ALLOWED_ORIGINS` | auto on localhost | Comma-separated `Origin`-header allowlist. See [Reverse proxy requirements](#reverse-proxy-requirements). |
+| `MCP_TRUSTED_HOSTS` | unset | Comma-separated **outbound** SSRF-guard exemptions for internal destinations (e.g. `mediawiki.svc`). See [Outbound SSRF guard](#outbound-ssrf-guard). |
 | `MCP_MAX_REQUEST_BODY` | `1mb` | HTTP request body cap. Accepts size strings (`b`, `kb`, `mb`, `gb`). |
 
 `MCP_MAX_REQUEST_BODY` matches nginx's `client_max_body_size 1m`. Raise it if `update-page` calls return 413 on legitimately large edits or your wiki has raised `$wgMaxArticleSize` (MediaWiki default 2 MB). Lower it for a tighter DoS guard.
@@ -141,6 +142,19 @@ Matching is exact string equality against what the browser sends. These values a
 When in doubt, open your deployed site in a browser and log `window.location.origin` — copy that value verbatim.
 
 Both allowlists apply only to `/mcp`. The `/health` endpoint is always reachable so container healthchecks and liveness probes (which hit `http://localhost:<port>/health`) keep working regardless of what you put in `MCP_ALLOWED_HOSTS` or `MCP_ALLOWED_ORIGINS`.
+
+### Outbound SSRF guard
+
+The server makes a few outbound fetches — the anonymous siteinfo probe (which gates extension tools and fills the `extensions` field of `get-site-info`), wiki discovery, and `*-file-from-url` uploads. These are SSRF-guarded: a destination resolving to a private, loopback, or other non-public address is refused. This stops a client-supplied URL from steering the server at internal infrastructure or cloud metadata.
+
+Running deliberately against an internal host trips this guard — the common Docker case, where a wiki's `server` is a network alias such as `http://mediawiki.svc` chosen to bypass a public reverse proxy. The probe is refused, so extension tools silently disappear and `get-site-info` reports no extensions. List the host in `MCP_TRUSTED_HOSTS` to exempt it from the public-IP check. Entries are comma-separated and match exactly — case-folded, no wildcards or suffixes:
+
+- a **bare host** (`mediawiki.svc`) matches any port;
+- a **`host:port`** entry matches only that port.
+
+The exemption skips **only** the public-IP check. The host is still DNS-resolved and its addresses are still pinned, and the guard stays on for every other destination. A listed host is trusted for **every** outbound fetch — wiki discovery and `*-file-from-url`, not only the probe — so list only hosts you control; exact matching means a client cannot reach anything beyond that one declared destination.
+
+`MCP_TRUSTED_HOSTS` is the **outbound** counterpart to `MCP_ALLOWED_HOSTS` (the inbound Host-header check) — the two are unrelated despite the similar names.
 
 ## Docker
 

--- a/src/transport/ssrfGuard.ts
+++ b/src/transport/ssrfGuard.ts
@@ -18,6 +18,27 @@ const EXTRA_BLOCKED_V6: Record<string, [ipaddr.IPv6, number]> = {
 	deprecated6bone: [ipaddr.IPv6.parse('3ffe::'), 16],
 };
 
+// Operator-controlled allowlist (MCP_TRUSTED_HOSTS) of hosts whose resolved
+// address is permitted to be non-public — e.g. an internal Docker-network alias
+// like `mediawiki.svc` the operator deliberately pointed the server at. Read from
+// the environment on each call so it stays testable and reflects runtime config.
+// Entries are comma-separated, trimmed and case-folded. A bare host (e.g.
+// `mediawiki.svc`) matches that host on any port; a `host:port` entry matches
+// only that port. Matching is exact — no wildcard/suffix — so a public host such
+// as `mediawiki.svc.attacker.com` can never match a `mediawiki.svc` entry.
+function readTrustedHosts(): Set<string> {
+	const raw = process.env.MCP_TRUSTED_HOSTS;
+	if (raw === undefined || raw === '') {
+		return new Set();
+	}
+	return new Set(
+		raw
+			.split(',')
+			.map((entry) => entry.trim().toLowerCase())
+			.filter((entry) => entry !== ''),
+	);
+}
+
 export async function assertPublicDestination(urlString: string): Promise<LookupAddress[]> {
 	// MediaWiki's siteinfo.general.server uses protocol-relative URLs (e.g.
 	// '//en.wikipedia.org'). Normalise to https so the guard accepts them.
@@ -40,6 +61,20 @@ export async function assertPublicDestination(urlString: string): Promise<Lookup
 			`DNS lookup for "${hostname}" returned no addresses: ${normalized}`,
 		);
 	}
+
+	// Operator-allowlisted host: skip ONLY the public-address assertion. We still
+	// resolved the name above and still return those addresses, so fetchCore pins
+	// them via buildPinnedAgent — preserving DNS-rebinding/TOCTOU defense even for
+	// the trusted host. url.host omits a protocol-default port (so a bare-host
+	// entry matches default-port URLs); the stripped hostname matches any port.
+	const trusted = readTrustedHosts();
+	if (
+		trusted.size > 0 &&
+		(trusted.has(hostname.toLowerCase()) || trusted.has(url.host.toLowerCase()))
+	) {
+		return addresses;
+	}
+
 	for (const { address } of addresses) {
 		assertAddressIsUnicast(address, normalized);
 	}

--- a/tests/transport/ssrfGuard.test.ts
+++ b/tests/transport/ssrfGuard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:dns/promises', () => ({
 	lookup: vi.fn(),
@@ -117,6 +117,72 @@ describe('ssrfGuard.assertPublicDestination', () => {
 			Object.assign(new Error('getaddrinfo ENOTFOUND nope.invalid'), { code: 'ENOTFOUND' }),
 		);
 		await expect(assertPublicDestination('https://nope.invalid/')).rejects.toThrow(/ENOTFOUND/);
+	});
+});
+
+describe('ssrfGuard.assertPublicDestination with MCP_TRUSTED_HOSTS', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		delete process.env.MCP_TRUSTED_HOSTS;
+	});
+
+	it('allows a trusted host that resolves to a private IP, still returning the addresses for pinning', async () => {
+		process.env.MCP_TRUSTED_HOSTS = 'mediawiki.svc';
+		const addrs = [{ address: '172.18.0.5', family: 4 }];
+		vi.mocked(lookup).mockResolvedValue(addrs);
+
+		const result = await assertPublicDestination('http://mediawiki.svc:80/w/api.php');
+
+		expect(result).toEqual(addrs);
+		// Still resolves the name — pinning (buildPinnedAgent) depends on these addresses.
+		expect(lookup).toHaveBeenCalledWith('mediawiki.svc', { all: true });
+	});
+
+	it('still rejects a non-listed private host while an allowlist is set', async () => {
+		process.env.MCP_TRUSTED_HOSTS = 'mediawiki.svc';
+		vi.mocked(lookup).mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+		await expect(assertPublicDestination('http://other.svc/')).rejects.toThrow(/10\.0\.0\.5/);
+	});
+
+	it('matches the allowlist exactly, not as a suffix (no mediawiki.svc.evil.com bypass)', async () => {
+		process.env.MCP_TRUSTED_HOSTS = 'mediawiki.svc';
+		vi.mocked(lookup).mockResolvedValue([{ address: '172.18.0.5', family: 4 }]);
+		await expect(assertPublicDestination('http://mediawiki.svc.evil.com/')).rejects.toThrow(
+			/172\.18\.0\.5/,
+		);
+	});
+
+	it('still requires DNS to resolve to at least one address for a trusted host', async () => {
+		process.env.MCP_TRUSTED_HOSTS = 'mediawiki.svc';
+		vi.mocked(lookup).mockResolvedValue([]);
+		await expect(assertPublicDestination('http://mediawiki.svc/')).rejects.toThrow(/no addresses/i);
+	});
+
+	it('honours a host:port entry only for the matching port', async () => {
+		process.env.MCP_TRUSTED_HOSTS = 'mediawiki.svc:8080';
+		vi.mocked(lookup).mockResolvedValue([{ address: '172.18.0.5', family: 4 }]);
+		await expect(assertPublicDestination('http://mediawiki.svc:8080/')).resolves.toEqual([
+			{ address: '172.18.0.5', family: 4 },
+		]);
+		await expect(assertPublicDestination('http://mediawiki.svc:9999/')).rejects.toThrow(
+			/172\.18\.0\.5/,
+		);
+	});
+
+	it('trims and case-folds comma-separated entries', async () => {
+		process.env.MCP_TRUSTED_HOSTS = ' Foo.Internal , Mediawiki.SVC ';
+		vi.mocked(lookup).mockResolvedValue([{ address: '172.18.0.5', family: 4 }]);
+		await expect(assertPublicDestination('http://mediawiki.svc/')).resolves.toEqual([
+			{ address: '172.18.0.5', family: 4 },
+		]);
+	});
+
+	it('has no effect when unset (guard stays on for private IPs)', async () => {
+		vi.mocked(lookup).mockResolvedValue([{ address: '172.18.0.5', family: 4 }]);
+		await expect(assertPublicDestination('http://mediawiki.svc/')).rejects.toThrow(/172\.18\.0\.5/);
 	});
 });
 


### PR DESCRIPTION
## Summary

Adds an operator-controlled `MCP_TRUSTED_HOSTS` allowlist that exempts named hosts from the outbound SSRF guard's public-IP rejection, so the server can be deliberately pointed at an internal destination (e.g. a Docker-network alias like `mediawiki.svc`) behind a reverse proxy.

## Motivation

`assertPublicDestination` (the outbound SSRF guard) refuses any destination resolving to a private/non-public address. That's correct for client-supplied URLs (`add-wiki`/discovery, `*-file-from-url`), but it also blocks the **anonymous siteinfo probe** when an operator legitimately configures a wiki `server` on an internal host. The result: the probe fails, every extension tool-pack (`cargo-*`, `smw-*`, `bucket-*`, `neowiki-*`) silently disappears, and `get-site-info` reports no extensions — while core (`mwn`-based) tools keep working, making it easy to miss.

This is the "host-scoped guard relaxation" already noted as future hardening in `get-file-data.ts`.

## Design

- Scoped, **opt-in** host allowlist read from `MCP_TRUSTED_HOSTS` (comma-separated). **Not** a global "allow private" toggle — the guard stays on by default for every other destination.
- Consulted **after** DNS resolution and **before** the unicast check: it skips *only* the public-address assertion, while still resolving the name and still returning the resolved addresses, so `fetchCore` → `buildPinnedAgent` still pins them. **DNS-rebinding/TOCTOU defense is preserved** for the trusted host too.
- **Exact match**, case-folded, no wildcard/suffix — a public host like `mediawiki.svc.attacker.com` can never match a `mediawiki.svc` entry. A bare host matches any port; `host:port` matches only that port.
- Distinct from the **inbound** `MCP_ALLOWED_HOSTS` (Host-header / DNS-rebinding check) — documented to avoid the naming collision.

## Testing

- 7 new tests in `tests/transport/ssrfGuard.test.ts` (trusted private host allowed + addresses returned for pinning; non-listed host still rejected; suffix-bypass rejected; empty-DNS still throws; `host:port` scoping; trim/case-fold; no-op when unset).
- Full suite green (1202 tests); `oxlint` and `oxfmt --check` clean; `tsgo --noEmit` passes.

## Docs

`README.md` (env table + Security section) and `docs/deployment.md` (new "Outbound SSRF guard" section), both contrasting it with the inbound `MCP_ALLOWED_HOSTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
