### PR TITLE
Gate extension-pack write tools behind readOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Extension-pack write tools (NeoWiki's `create-subject`, `update-subject`, `delete-subject`, and `set-main-subject`) are now hidden from `tools/list` and rejected by the per-call guard when the active wiki is configured `readOnly`, the same as core write tools. Previously the read-only gate covered only the core writes, so a read-only endpoint still advertised and dispatched extension-pack writes; an actual write was then stopped only by the wiki's own permissions. Write tools are identified by their `readOnlyHint: false` annotation, so future packs are covered automatically. (#411)
+
 ## [0.12.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For the full field reference, env-var substitution, secret sources, change tags,
 
 ## Authentication
 
-Tools marked 🔐 require authentication. They are also hidden from `tools/list` when the configured default wiki has `readOnly: true` — see [Deployment](#deployment).
+Tools marked 🔐 require authentication. Write tools (including extension-pack writes) are hidden from `tools/list` when the configured default wiki has `readOnly: true` — see [Deployment](#deployment).
 
 - **Browser-based OAuth (recommended).** Sign in through a browser tab the first time a tool needs auth. Set `oauth2ClientId` and `oauth2CallbackPort` per wiki — see [docs/configuration.md — OAuth (browser-based)](docs/configuration.md#oauth-browser-based).
 - **Per-request bearer token (HTTP).** Each request carries `Authorization: Bearer <token>`; the server forwards it to MediaWiki. See [docs/deployment.md — per-request bearer token](docs/deployment.md#per-request-bearer-token-http-transport).

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -61,10 +61,10 @@ export interface WikiConfig {
 	 */
 	private?: boolean;
 	/**
-	 * When true, the six write tools (create-page, update-page,
-	 * delete-page, undelete-page, upload-file, upload-file-from-url)
-	 * are hidden from tools/list while this wiki is the active wiki.
-	 * Defaults to false.
+	 * When true, write tools — the core page/file writes plus extension-pack
+	 * writes (identified by readOnlyHint: false) — are rejected for this wiki
+	 * by the per-call guard, and hidden from tools/list when no configured
+	 * wiki is writable. Defaults to false.
 	 */
 	readOnly?: boolean;
 	/**

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -5,9 +5,7 @@ import { extensionPacks } from '../tools/extensions/index.js';
 import { getRuntimeToken } from '../transport/requestContext.js';
 import { hasStaticCredentials } from '../transport/bearerGuard.js';
 
-// The wiki-mutating tools. Shared by reconcile's read-only rule and the
-// per-call capability guard.
-export const WRITE_TOOL_NAMES: readonly string[] = [
+const CORE_WRITE_TOOL_NAMES: readonly string[] = [
 	'create-page',
 	'move-page',
 	'update-page',
@@ -17,6 +15,17 @@ export const WRITE_TOOL_NAMES: readonly string[] = [
 	'upload-file-from-url',
 	'update-file',
 	'update-file-from-url',
+];
+
+const EXTENSION_WRITE_TOOL_NAMES: readonly string[] = extensionPacks.flatMap((pack) =>
+	pack.tools.filter((tool) => tool.annotations.readOnlyHint === false).map((tool) => tool.name),
+);
+
+// The wiki-mutating tools. Shared by reconcile's read-only rule and the
+// per-call capability guard.
+export const WRITE_TOOL_NAMES: readonly string[] = [
+	...CORE_WRITE_TOOL_NAMES,
+	...EXTENSION_WRITE_TOOL_NAMES,
 ];
 
 const WRITE_TOOL_SET: ReadonlySet<string> = new Set(WRITE_TOOL_NAMES);

--- a/tests/runtime/reconcile.test.ts
+++ b/tests/runtime/reconcile.test.ts
@@ -6,19 +6,9 @@ import type { ActiveWiki } from '../../src/wikis/activeWiki.js';
 import type { WikiProbe } from '../../src/wikis/wikiProbe.js';
 import { reconcileTools, computeDesiredEnabledState } from '../../src/runtime/reconcile.js';
 import type { ToolGatingRule, ReconcileContext } from '../../src/runtime/reconcile.js';
+import { WRITE_TOOL_NAMES } from '../../src/runtime/wikiCapability.js';
 import type { ExtensionPack } from '../../src/tools/extensions/types.js';
 import type { Tool } from '../../src/runtime/tool.js';
-
-const WRITE_TOOL_NAMES = [
-	'create-page',
-	'update-page',
-	'delete-page',
-	'undelete-page',
-	'upload-file',
-	'upload-file-from-url',
-	'update-file',
-	'update-file-from-url',
-];
 
 const NON_WRITE_TOOL_NAMES = ['get-page', 'search-page'];
 const WIKI_SET_TOOL_NAMES = ['add-wiki', 'remove-wiki', 'list-wikis'];
@@ -275,6 +265,70 @@ describe('reconcileTools — applyReadOnlyRule', () => {
 			}
 			expect(mocks.get(name)!.disable).toHaveBeenCalledTimes(1);
 		}
+	});
+});
+
+describe('reconcileTools — read-only gating of extension write tools', () => {
+	const NEOWIKI_WRITE_TOOL = 'neowiki-create-subject';
+	const NEOWIKI_READ_TOOL = 'neowiki-cypher-query';
+	const NEOWIKI_PACK = makeFakePack(
+		'neowiki',
+		['NeoWiki'],
+		[NEOWIKI_WRITE_TOOL, NEOWIKI_READ_TOOL],
+	);
+
+	function makeNeowikiToolMap(initiallyEnabled: boolean): {
+		tools: Map<string, RegisteredTool>;
+		mocks: Map<string, MockTool>;
+	} {
+		const mocks = new Map<string, MockTool>();
+		const tools = new Map<string, RegisteredTool>();
+		for (const name of [NEOWIKI_WRITE_TOOL, NEOWIKI_READ_TOOL]) {
+			const mock = makeMockTool(initiallyEnabled);
+			mocks.set(name, mock);
+			tools.set(name, mock as unknown as RegisteredTool);
+		}
+		return { tools, mocks };
+	}
+
+	it('hides an extension write tool from tools/list on a read-only wiki while keeping the read tool', async () => {
+		const { tools, mocks } = makeNeowikiToolMap(true);
+		const wiki = { ...baseWiki, readOnly: true };
+		const { registry } = makeMocks({
+			activeWikiConfig: wiki,
+			wikis: { a: wiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			wikiProbe: makeFakeProbe({ 'a:NeoWiki': true }),
+			extensionPacks: [NEOWIKI_PACK],
+		});
+		// The read-only rule keys off the production WRITE_TOOL_NAMES, which now
+		// includes extension writes — so the write tool is gated even though the
+		// extension is present, while the read tool stays offered.
+		expect(mocks.get(NEOWIKI_WRITE_TOOL)!.enabled).toBe(false);
+		expect(mocks.get(NEOWIKI_WRITE_TOOL)!.disable).toHaveBeenCalledTimes(1);
+		expect(mocks.get(NEOWIKI_READ_TOOL)!.enabled).toBe(true);
+		expect(mocks.get(NEOWIKI_READ_TOOL)!.disable).not.toHaveBeenCalled();
+	});
+
+	it('offers extension write tools on a writable wiki with the extension present', async () => {
+		const { tools, mocks } = makeNeowikiToolMap(false);
+		const { registry } = makeMocks({
+			activeWikiConfig: baseWiki,
+			wikis: { a: baseWiki },
+			allowManagement: true,
+		});
+		await reconcileTools(tools, {
+			wikiRegistry: registry,
+			transport: 'stdio',
+			wikiProbe: makeFakeProbe({ 'a:NeoWiki': true }),
+			extensionPacks: [NEOWIKI_PACK],
+		});
+		expect(mocks.get(NEOWIKI_WRITE_TOOL)!.enabled).toBe(true);
+		expect(mocks.get(NEOWIKI_READ_TOOL)!.enabled).toBe(true);
 	});
 });
 

--- a/tests/runtime/wikiCapability.test.ts
+++ b/tests/runtime/wikiCapability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { checkWikiCapability } from '../../src/runtime/wikiCapability.js';
+import { checkWikiCapability, WRITE_TOOL_NAMES } from '../../src/runtime/wikiCapability.js';
 import { fakeContext } from '../helpers/fakeContext.js';
 import { withRequestFields } from '../../src/transport/requestContext.js';
 
@@ -132,5 +132,46 @@ describe('checkWikiCapability', () => {
 	it('does not block an HTTP call to a non-OAuth wiki', async () => {
 		const result = await checkWikiCapability('get-page', 'w', ctx(false, rwWiki, true, 'http'));
 		expect(result).toBeUndefined();
+	});
+});
+
+describe('WRITE_TOOL_NAMES', () => {
+	it('includes the core write tools', () => {
+		for (const name of [
+			'create-page',
+			'move-page',
+			'update-page',
+			'delete-page',
+			'undelete-page',
+			'upload-file',
+			'upload-file-from-url',
+			'update-file',
+			'update-file-from-url',
+		]) {
+			expect(WRITE_TOOL_NAMES).toContain(name);
+		}
+	});
+
+	it('derives extension-pack write tools from their readOnlyHint annotation', () => {
+		for (const name of [
+			'neowiki-create-subject',
+			'neowiki-update-subject',
+			'neowiki-delete-subject',
+			'neowiki-set-main-subject',
+		]) {
+			expect(WRITE_TOOL_NAMES).toContain(name);
+		}
+	});
+
+	it('excludes extension read tools', () => {
+		for (const name of [
+			'neowiki-cypher-query',
+			'neowiki-get-subject',
+			'smw-query',
+			'cargo-query',
+			'bucket-query',
+		]) {
+			expect(WRITE_TOOL_NAMES).not.toContain(name);
+		}
 	});
 });

--- a/tests/runtime/wikiCapability.test.ts
+++ b/tests/runtime/wikiCapability.test.ts
@@ -70,6 +70,18 @@ describe('checkWikiCapability', () => {
 		expect(await checkWikiCapability('update-page', 'w', ctx(true, rwWiki))).toBeUndefined();
 	});
 
+	it('rejects an extension write tool against a read-only wiki', async () => {
+		const result = await checkWikiCapability('neowiki-create-subject', 'w', ctx(true, roWiki));
+		expect(result?.isError).toBe(true);
+		expect(JSON.stringify(result?.content)).toContain('read-only');
+	});
+
+	it('allows an extension read tool against a read-only wiki', async () => {
+		expect(
+			await checkWikiCapability('neowiki-cypher-query', 'w', ctx(true, roWiki)),
+		).toBeUndefined();
+	});
+
 	it('returns undefined for a plain read tool', async () => {
 		expect(await checkWikiCapability('get-page', 'w', ctx(false, rwWiki))).toBeUndefined();
 	});

--- a/tests/tools/extensions/index.test.ts
+++ b/tests/tools/extensions/index.test.ts
@@ -55,4 +55,19 @@ describe('extensionPacks', () => {
 			}
 		}
 	});
+
+	it('every tool declares an explicit boolean readOnlyHint annotation', () => {
+		// The read-only gate derives extension write tools from
+		// readOnlyHint === false (WRITE_TOOL_NAMES in src/runtime/wikiCapability.ts).
+		// readOnlyHint is optional in the SDK type, so a mutating tool that omits it
+		// would silently escape the gate. Require every pack tool to state it.
+		for (const pack of extensionPacks) {
+			for (const tool of pack.tools) {
+				expect(
+					typeof tool.annotations.readOnlyHint,
+					`${tool.name} must declare a boolean readOnlyHint`,
+				).toBe('boolean');
+			}
+		}
+	});
 });


### PR DESCRIPTION
Closes #411.

## Problem

The read-only gate (`reconcile`'s `read-only` rule and the per-call guard in `checkWikiCapability`) both key off `WRITE_TOOL_NAMES`, a hardcoded core-only list. Extension-pack write tools (NeoWiki's `create-subject`, `update-subject`, `delete-subject`, `set-main-subject`) declare `readOnlyHint: false` but were absent from that list, so on a `readOnly` wiki they were still listed in `tools/list` and dispatched. The only thing stopping an actual mutation was the target wiki's own permissions, not the server.

## Fix

Fold extension-pack write tools into `WRITE_TOOL_NAMES` by selecting pack tools whose `readOnlyHint` annotation is `false`. Both consumers inherit the change, and future packs are covered automatically without editing the list, consistent with the self-describing-packs stance in `AGENTS.md`. Read extension tools are unaffected.

## Tests

Added test-first (RED verified before the fix):

- `wikiCapability.test.ts`: the per-call guard rejects an extension write tool (`neowiki-create-subject`) on a read-only wiki, and still allows an extension read tool (`neowiki-cypher-query`).
- `reconcile.test.ts`: extension write tools are disabled in `tools/list` under `readOnly`, while read tools stay offered.

Full suite (1205 tests), lint, format, and build all pass.
