### PR TITLE
Make the hosted OAuth proxy scope-agnostic

### DIFF
--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -95,7 +95,7 @@ export function planAuthorize(
 		clientState: q.state ?? '',
 		clientCodeChallenge: q.code_challenge,
 		clientCodeChallengeMethod: 'S256',
-		scopes: q.scope?.split(' ').filter(Boolean) ?? client.scopes,
+		scopes: [],
 		proxyVerifier,
 	});
 
@@ -103,7 +103,13 @@ export function planAuthorize(
 	u.searchParams.set('response_type', 'code');
 	u.searchParams.set('client_id', pc.upstreamClientId);
 	u.searchParams.set('redirect_uri', pc.callbackUrl);
-	u.searchParams.set('scope', q.scope ?? client.scopes.join(' '));
+	// Scope-agnostic by design: the proxy always requests the empty scope, which makes
+	// MediaWiki grant the consumer's full registered grants (basic/read included). We do
+	// NOT forward the client's requested scope — that would let a narrow request drop
+	// `basic` (→ readapidenied) and would forward non-grant junk (e.g. a client appending
+	// `offline_access`) straight to the wiki. The proxy's own JWT scope claim stays
+	// informational, matching the refresh path (token.ts).
+	u.searchParams.set('scope', '');
 	u.searchParams.set('state', txnId);
 	u.searchParams.set('code_challenge', s256(proxyVerifier));
 	u.searchParams.set('code_challenge_method', 'S256');

--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -21,7 +21,7 @@ export interface ConsentClaims {
 
 export type AuthorizePlan =
 	| { kind: 'error'; status: number; body: Record<string, unknown> }
-	| { kind: 'consent'; clientName: string; scopes: string[] }
+	| { kind: 'consent'; clientName: string }
 	| { kind: 'redirect'; location: string };
 
 /**
@@ -80,11 +80,7 @@ export function planAuthorize(
 	const consentOk =
 		consent && consent.clientId === client.clientId && consent.redirectHost === redirectHost;
 	if (!consentOk) {
-		return {
-			kind: 'consent',
-			clientName: client.name,
-			scopes: q.scope?.split(' ').filter(Boolean) ?? client.scopes,
-		};
+		return { kind: 'consent', clientName: client.name };
 	}
 
 	const txnId = randomUUID();

--- a/src/auth/authorizationServer/consent.ts
+++ b/src/auth/authorizationServer/consent.ts
@@ -17,16 +17,16 @@ function esc(s: string): string {
 export function renderConsentPage(a: {
 	clientName: string;
 	wiki: string;
-	scopes: string[];
 	authorizeQuery: string;
 	csrfToken: string;
 }): string {
-	const scopes = a.scopes.length ? a.scopes.map(esc).join(', ') : 'basic access';
+	// No per-permission line: the proxy always requests the consumer's full grants
+	// (see authorize.ts), so it can't accurately enumerate them here. The user sees the
+	// exact grants on MediaWiki's own authorization screen during the upstream leg.
 	return `<!doctype html><meta charset="utf-8"><title>Authorize</title>
 <body style="font-family:system-ui;max-width:32rem;margin:4rem auto">
 <h1>Authorize application</h1>
 <p><strong>${esc(a.clientName)}</strong> wants to act as you on <strong>${esc(a.wiki)}</strong>.</p>
-<p>Permissions: ${scopes}.</p>
 <form method="POST" action="/mcp/consent?${esc(a.authorizeQuery)}">
   <input type="hidden" name="csrf" value="${esc(a.csrfToken)}">
   <button name="decision" value="approve" type="submit">Approve</button>

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -885,7 +885,6 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 				renderConsentPage({
 					clientName: plan.clientName,
 					wiki: defaultWikiSitename,
-					scopes: plan.scopes,
 					authorizeQuery: serializeAuthorizeQuery(q),
 					csrfToken,
 				}),

--- a/tests/auth/authorizationServer/authorize.test.ts
+++ b/tests/auth/authorizationServer/authorize.test.ts
@@ -131,6 +131,37 @@ describe('planAuthorize', () => {
 		const txnId = u.searchParams.get('state')!;
 		expect(store.getTransaction(txnId)?.clientCodeChallenge).toBe('CCH');
 		expect(store.getTransaction(txnId)?.proxyVerifier).toBeTruthy();
+		// Scope-agnostic: client requested scope=editpage and client.scopes=['editpage'],
+		// yet the proxy forwards an empty scope so the wiki grants the consumer's full
+		// registered grants (which include basic/read).
+		expect(u.searchParams.get('scope')).toBe('');
+		expect(store.getTransaction(txnId)?.scopes).toEqual([]);
+	});
+
+	it('always sends an empty upstream scope, ignoring any client-supplied scope', () => {
+		const { store, client } = setup();
+		const consent = { clientId: client.clientId, redirectHost: '127.0.0.1', wiki: 'w' };
+		const scopes: Array<string | undefined> = [
+			'editpage',
+			'offline_access',
+			'editpage createeditmovepage offline_access',
+			undefined,
+		];
+		for (const scope of scopes) {
+			const q: Record<string, unknown> = { ...baseQuery(client.clientId) };
+			if (scope === undefined) {
+				delete q.scope;
+			} else {
+				q.scope = scope;
+			}
+			const r = planAuthorize(q, consent, pc, store, 'Ex');
+			expect(r.kind).toBe('redirect');
+			if (r.kind !== 'redirect') break;
+			const u = new URL(r.location);
+			expect(u.searchParams.get('scope')).toBe('');
+			const txnId = u.searchParams.get('state')!;
+			expect(store.getTransaction(txnId)?.scopes).toEqual([]);
+		}
 	});
 });
 

--- a/tests/auth/authorizationServer/consent.test.ts
+++ b/tests/auth/authorizationServer/consent.test.ts
@@ -17,23 +17,23 @@ const pc = {
 } as any;
 
 describe('consent', () => {
-	it('renders the client name and scopes', () => {
+	it('renders the client name and the act-as-you line, with no permissions list', () => {
 		const html = renderConsentPage({
 			clientName: 'Claude Code',
 			wiki: 'Example',
-			scopes: ['editpage'],
 			authorizeQuery: 'txn=1',
 			csrfToken: 'nonce-abc',
 		});
 		expect(html).toContain('Claude Code');
-		expect(html).toContain('editpage');
+		expect(html).toContain('act as you on');
+		expect(html).toContain('Example');
 		expect(html).toContain('txn=1');
+		expect(html).not.toContain('Permissions:');
 	});
 	it('embeds the CSRF token as a hidden form field', () => {
 		const html = renderConsentPage({
 			clientName: 'Claude Code',
 			wiki: 'Example',
-			scopes: ['editpage'],
 			authorizeQuery: 'txn=1',
 			csrfToken: 'nonce-abc',
 		});
@@ -44,7 +44,6 @@ describe('consent', () => {
 		const html = renderConsentPage({
 			clientName: '<script>x</script>',
 			wiki: 'W',
-			scopes: [],
 			authorizeQuery: 'txn=1',
 			csrfToken: 'nonce-abc',
 		});


### PR DESCRIPTION
## What this does

Implements **follow-up #3** from the hosted OAuth proxy PR (#413): scope handling.

The proxy's `/authorize` planner no longer forwards the client's requested OAuth `scope` to the upstream MediaWiki wiki. It always sends an **empty scope**, which makes MediaWiki grant the consumer's *full registered grants* (which include `basic`, and therefore `read`/`writeapi`). Any client-supplied scope is ignored.

This closes two latent failure modes that populating `scopes_supported` (or any client that requests a narrow scope) would otherwise expose:

- **Read breakage:** a client requesting an edit-only scope without `basic` would get a token that can't read — every API read returns `readapidenied`.
- **Junk scopes:** a client appending a non-MediaWiki scope (e.g. Claude Code's `offline_access`) would forward an unknown grant to the wiki.

The consent page's `Permissions:` line is also removed: with the proxy always requesting the full grant set, that line only ever read "basic access", which *understated* the real permissions. The actual per-grant list is shown on MediaWiki's own authorization screen during the upstream leg.

## Why scope-agnostic (not "advertise scopes" / "always inject basic")

- Advertising `scopes_supported` would make spec-compliant MCP clients request that exact set; advertising `['basic']` would then break writes, and advertising more requires the operator to declare the consumer's grant set (a new env var) — deliberately out of scope here.
- "Always force `scope=basic`" would *regress writes* — `basic` lacks the `edit` right. The empty-scope request auto-adapts to whatever grants the consumer is registered for, which is exactly the behaviour #413 shipped and live-tested.

The proxy's own JWT `scope` claim was already informational (real authorization is the upstream wiki token's grants); this makes the authorization-code path mint an empty claim, matching the refresh path.

## Scope of change

`planAuthorize` (empty upstream scope + empty txn scopes) and the consent page (drop the dead `scopes` field + the `Permissions:` line). Security-critical paths — PKCE, consent binding, exact-match redirect validation, RFC 8707 resource check, token audience, refresh rotation/reuse — are untouched.

Intentionally **not** changed: `scopes_supported` stays unset; `register.ts`/`proxyStore` still record a client's requested scope (unused).

## CHANGELOG

No CHANGELOG entry: the hosted OAuth proxy itself is still unreleased (under `[Unreleased] → Added`), so this is how the feature behaves on first release rather than a change to released behaviour.

## Test plan

- [x] Unit: `planAuthorize` emits `scope=''` upstream and `scopes: []` on the txn for no-scope, `editpage`, `offline_access`, and multi-token inputs; consent render asserts the `Permissions:` line is gone.
- [x] End-to-end **without MediaWiki**: the in-process proxy e2e (`streamableHttp.proxy.test.ts`, fake upstream AS) drives register → authorize → consent → callback → token → authenticated `/mcp` — green.
- [x] Full suite: 1355 tests, lint, fmt, build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)