### PR TITLE
Style the OAuth flow's user-facing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - New per-wiki `publicServer` field: the browser-facing base URL, used when it differs from the internal `server` (e.g. a Docker-network alias). Defaults to `server`.
 - New hosted-proxy environment variables: `MCP_PUBLIC_URL` (the server's public URL), `MCP_OAUTH_JWT_SIGNING_KEY` (≥32 characters), `MCP_OAUTH2_CLIENT_ID` (the default wiki's OAuth2 client id — overrides `config.json`, so a deployment can supply the value its wiki generates at registration time), `MCP_OAUTH_TOKEN_TTL` (default `55m`), and `MCP_OAUTH_CONSENT_TTL` (default `30d`). Durations accept forms like `55m`/`1h`/`30d` or bare seconds.
 
+### Changed
+
+- The OAuth sign-in and consent pages now have a styled layout instead of bare HTML, and a failed or cancelled authorization shows a readable page rather than a raw error.
+
 ### Fixed
 
 - Extension-pack write tools (NeoWiki's `create-subject`, `update-subject`, `delete-subject`, and `set-main-subject`) are now hidden from `tools/list` and rejected by the per-call guard when the active wiki is configured `readOnly`, the same as core write tools. Previously the read-only gate covered only the core writes, so a read-only endpoint still advertised and dispatched extension-pack writes; an actual write was then stopped only by the wiki's own permissions. Write tools are identified by their `readOnlyHint: false` annotation, so future packs are covered automatically. (#411)

--- a/src/auth/authorizationServer/consent.ts
+++ b/src/auth/authorizationServer/consent.ts
@@ -1,18 +1,12 @@
 import type { ProxyConfig } from './proxyConfig.js';
 import { signConsent } from './jwt.js';
+import { esc, renderPage } from '../pageShell.js';
 
 const COOKIE = 'mcp_consent';
 const CSRF_COOKIE = 'mcp_consent_csrf';
 // Long enough for a human to read the consent page, short enough to bound the
 // window in which the anti-CSRF nonce is valid.
 const CSRF_TTL_SECONDS = 10 * 60;
-
-function esc(s: string): string {
-	return s.replace(
-		/[&<>"']/g,
-		(c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
-	);
-}
 
 export function renderConsentPage(a: {
 	clientName: string;
@@ -21,17 +15,44 @@ export function renderConsentPage(a: {
 	csrfToken: string;
 }): string {
 	// No per-permission line: the proxy always requests the consumer's full grants
-	// (see authorize.ts), so it can't accurately enumerate them here. The user sees the
-	// exact grants on MediaWiki's own authorization screen during the upstream leg.
-	return `<!doctype html><meta charset="utf-8"><title>Authorize</title>
-<body style="font-family:system-ui;max-width:32rem;margin:4rem auto">
-<h1>Authorize application</h1>
-<p><strong>${esc(a.clientName)}</strong> wants to act as you on <strong>${esc(a.wiki)}</strong>.</p>
-<form method="POST" action="/mcp/consent?${esc(a.authorizeQuery)}">
-  <input type="hidden" name="csrf" value="${esc(a.csrfToken)}">
-  <button name="decision" value="approve" type="submit">Approve</button>
-  <button name="decision" value="deny" type="submit">Deny</button>
-</form></body>`;
+	// (see authorize.ts). The user sees the exact grants on MediaWiki's own
+	// authorization screen during the upstream leg.
+	const body =
+		`<p class="pg-lead"><strong>${esc(a.clientName)}</strong> wants to act as you on <strong>${esc(a.wiki)}</strong>.</p>` +
+		`<form method="POST" action="/mcp/consent?${esc(a.authorizeQuery)}" class="pg-actions">` +
+		`<input type="hidden" name="csrf" value="${esc(a.csrfToken)}">` +
+		`<button class="pg-btn pg-primary" name="decision" value="approve" type="submit">Approve</button>` +
+		`<button class="pg-btn pg-neutral" name="decision" value="deny" type="submit">Deny</button>` +
+		`</form>` +
+		`<p class="pg-note">You'll confirm the exact permissions on ${esc(a.wiki)} in the next step.</p>`;
+	return renderPage({ title: 'Authorize application', icon: { name: 'lock' }, body });
+}
+
+// Shown when the user denies and there is no trusted client redirect to bounce to.
+export function renderCancelledPage(a: { clientName?: string }): string {
+	const who = a.clientName ? `<strong>${esc(a.clientName)}</strong>` : 'the application';
+	const body =
+		`<p class="pg-lead">You declined to authorize ${who}. Nothing was shared with it.</p>` +
+		`<p class="pg-note">You can close this window.</p>`;
+	return renderPage({
+		title: 'Authorization cancelled',
+		icon: { name: 'cancel', accent: 'subtle' },
+		body,
+	});
+}
+
+// Shown on a terminal authorization error reached in the browser (e.g. a failed
+// upstream exchange, a bad /authorize request, or a consent failure). `reason` is
+// the already-sanitized error_description.
+export function renderAuthErrorPage(a: { reason: string }): string {
+	const body =
+		`<p class="pg-lead">Something went wrong while authorizing the application. You can close this window and try connecting again.</p>` +
+		`<p class="pg-mono">${esc(a.reason)}</p>`;
+	return renderPage({
+		title: 'Authorization failed',
+		icon: { name: 'error', accent: 'error' },
+		body,
+	});
 }
 
 // Anti-CSRF nonce for the consent decision. SameSite=Strict so a cross-site POST

--- a/src/auth/browserAuth.ts
+++ b/src/auth/browserAuth.ts
@@ -9,6 +9,7 @@ import type { WikiSlice } from './metadata.js';
 import { randomVerifier, s256 } from './pkce.js';
 import { exchangeCode, OAuthFlowError } from './oauthFlow.js';
 import { createTokenStore } from './tokenStore.js';
+import { renderPage } from './pageShell.js';
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -242,36 +243,50 @@ function waitForCallback(server: http.Server, expectedState: string): Promise<st
 
 			const error = url.searchParams.get('error');
 			if (error === 'access_denied') {
-				res
-					.writeHead(200, { 'Content-Type': 'text/html' })
-					.end('<html><body><h1>Login cancelled</h1><p>You can close this tab.</p></body></html>');
+				res.writeHead(200, { 'Content-Type': 'text/html' }).end(
+					renderPage({
+						title: 'Login cancelled',
+						icon: { name: 'cancel', accent: 'subtle' },
+						body: '<p class="pg-lead">You declined the sign-in request. You can close this tab.</p>',
+					}),
+				);
 				reject(new BrowserAuthError('user_denied', 'User denied the authorization request'));
 				return;
 			}
 
 			const returnedState = url.searchParams.get('state');
 			if (!returnedState || returnedState !== expectedState) {
-				res
-					.writeHead(400, { 'Content-Type': 'text/html' })
-					.end('<html><body><h1>Possible CSRF; please retry.</h1></body></html>');
+				res.writeHead(400, { 'Content-Type': 'text/html' }).end(
+					renderPage({
+						title: 'Sign-in could not be verified',
+						icon: { name: 'error', accent: 'error' },
+						body: '<p class="pg-lead">The sign-in could not be verified (possible CSRF). Please close this tab and try again.</p>',
+					}),
+				);
 				reject(new BrowserAuthError('state_mismatch', 'State parameter mismatch — possible CSRF'));
 				return;
 			}
 
 			const code = url.searchParams.get('code');
 			if (!code) {
-				res
-					.writeHead(400, { 'Content-Type': 'text/html' })
-					.end('<html><body><h1>Missing code parameter</h1></body></html>');
+				res.writeHead(400, { 'Content-Type': 'text/html' }).end(
+					renderPage({
+						title: 'Sign-in failed',
+						icon: { name: 'error', accent: 'error' },
+						body: '<p class="pg-lead">The wiki did not return an authorization code. Please close this tab and try again.</p>',
+					}),
+				);
 				reject(new BrowserAuthError('transient', 'Missing code parameter in callback'));
 				return;
 			}
 
-			res
-				.writeHead(200, { 'Content-Type': 'text/html' })
-				.end(
-					'<html><body><h1>Login successful</h1><p>You can close this tab and return to your terminal.</p></body></html>',
-				);
+			res.writeHead(200, { 'Content-Type': 'text/html' }).end(
+				renderPage({
+					title: "You're signed in",
+					icon: { name: 'success', accent: 'success' },
+					body: '<p class="pg-lead">You can close this tab and return to your terminal.</p>',
+				}),
+			);
 			resolve(code);
 		};
 		server.on('request', handler);

--- a/src/auth/pageShell.ts
+++ b/src/auth/pageShell.ts
@@ -58,15 +58,15 @@ html,body{margin:0;height:100%}
 font-family:-apple-system,system-ui,'Segoe UI',sans-serif;
 min-height:100vh;display:flex;align-items:center;justify-content:center;
 background:var(--page-bg);padding:24px;color:var(--c-base)}
-.pg-card{max-width:400px;width:100%;background:var(--card-bg);border:1px solid var(--bd-subtle);border-radius:2px;box-shadow:0 1px 2px light-dark(rgba(0,0,0,.08),rgba(0,0,0,.4));padding:28px;text-align:center}
-.pg-icon{margin:0 0 14px;color:var(--c-base)}
+.pg-card{max-width:32rem;width:100%;background:var(--card-bg);border:1px solid var(--bd-subtle);border-radius:2px;box-shadow:0 1px 2px light-dark(rgba(0,0,0,.08),rgba(0,0,0,.4));padding:32px;text-align:center}
+.pg-icon{margin:0 0 12px;color:var(--c-base)}
 .pg-icon svg{display:block;margin:0 auto}
 .pg-icon--subtle{color:var(--c-subtle)}
 .pg-icon--error{color:var(--c-error)}
 .pg-icon--success{color:var(--c-success)}
-.pg-title{font-size:1.25rem;line-height:1.3;font-weight:700;margin:0 0 10px}
-.pg-lead{font-size:.875rem;line-height:1.57;margin:0}
-.pg-actions{display:flex;gap:10px;margin:18px 0 0}
+.pg-title{font-size:1.25rem;font-weight:700;line-height:1.875rem;margin:0 0 8px}
+.pg-lead{font-size:.875rem;line-height:1.375rem;margin:0}
+.pg-actions{display:flex;flex-wrap:wrap;gap:12px;margin:16px 0 0}
 .pg-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;min-height:32px;padding:0 11px;border:1px solid;border-radius:2px;font-size:.875rem;font-weight:700;font-family:inherit;cursor:pointer;transition:background-color .1s,color .1s,border-color .1s,box-shadow .1s}
 .pg-btn:focus-visible{outline:1px solid transparent;box-shadow:inset 0 0 0 1px var(--focus)}
 .pg-primary{background:var(--c-progressive);border-color:transparent;color:var(--c-inverted)}
@@ -74,8 +74,8 @@ background:var(--page-bg);padding:24px;color:var(--c-base)}
 .pg-primary:focus-visible{box-shadow:inset 0 0 0 1px var(--c-progressive),inset 0 0 0 2px var(--c-inverted)}
 .pg-neutral{background:var(--btn-normal-bg);border-color:var(--bd-base);color:var(--c-base)}
 .pg-neutral:hover{background:var(--btn-normal-bg-hover)}
-.pg-note{font-size:.8125rem;line-height:1.5;color:var(--c-subtle);margin:22px 0 0}
-.pg-mono{font-family:ui-monospace,'SFMono-Regular',monospace;font-size:.8125rem;color:var(--c-subtle);background:var(--inset-bg);border:1px solid var(--bd-subtle);border-radius:2px;padding:9px 10px;margin:16px 0 0;word-break:break-word}
+.pg-note{font-size:.8125rem;line-height:1.25rem;color:var(--c-subtle);margin:16px 0 0}
+.pg-mono{font-family:ui-monospace,'SFMono-Regular',monospace;font-size:.8125rem;color:var(--c-subtle);background:var(--inset-bg);border:1px solid var(--bd-subtle);border-radius:2px;padding:8px;margin:16px 0 0;word-break:break-word}
 `;
 
 export function renderPage(o: {

--- a/src/auth/pageShell.ts
+++ b/src/auth/pageShell.ts
@@ -1,0 +1,87 @@
+// Self-contained styled HTML shell for the OAuth flow's user-facing pages
+// (the hosted-proxy consent/status pages and the stdio loopback login pages).
+// No external assets: colours are hardcoded Wikimedia Codex design-token values
+// (light + dark via the CSS light-dark() function) and the icons are inlined
+// Codex (WikimediaUI) glyphs. The Codex icon set is MIT licensed
+// (https://github.com/wikimedia/codex, packages/codex-icons), so inlining the
+// raw path data here is permitted. Exact token values mirror Codex's
+// theme-wikimedia-ui tokens; re-confirm against the current Codex token
+// reference if Codex updates them.
+
+export function esc(s: string): string {
+	return s.replace(
+		/[&<>"']/g,
+		(c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+	);
+}
+
+export type IconName = 'lock' | 'cancel' | 'error' | 'success';
+export type IconAccent = 'base' | 'subtle' | 'error' | 'success';
+
+// Verbatim Codex icon path data (20x20 viewBox): cdxIconLock, cdxIconCancel,
+// cdxIconError, cdxIconSuccess.
+const ICON_PATHS: Record<IconName, string> = {
+	lock: 'M11 15H9v-3h2z M10 1a4 4 0 0 1 4 4v3h3v11H3V8h3V5a4 4 0 0 1 4-4M5 17h10v-7H5zm5-14a2 2 0 0 0-2 2v3h4V5a2 2 0 0 0-2-2',
+	cancel:
+		'M10 1a9 9 0 1 1 0 18 9 9 0 0 1 0-18M4.394 5.806A6.97 6.97 0 0 0 3 10a7 7 0 0 0 11.193 5.605l-9.8-9.8ZM10 3a6.97 6.97 0 0 0-4.191 1.392l9.797 9.798A7 7 0 0 0 10 3',
+	error: 'M19 6.4v7.199L13.6 19H6.4L1 13.599v-7.2L6.4 1h7.2zM9 14v2h2v-2zm0-9v7h2V5z',
+	success:
+		'M10 1a9 9 0 1 1 0 18 9 9 0 0 1 0-18M8.823 11.118 6.8 9.6l-1.2 1.6 2.8 2.1 1.381-.175 4.624-5.781-1.561-1.25z',
+};
+
+export function renderIcon(name: IconName, accent: IconAccent = 'base'): string {
+	return `<div class="pg-icon pg-icon--${accent}"><svg viewBox="0 0 20 20" width="56" height="56" fill="currentColor" aria-hidden="true"><path d="${ICON_PATHS[name]}"/></svg></div>`;
+}
+
+// Each colour token declares a plain light value first (the fallback for
+// browsers without light-dark()) then the light-dark() override.
+const STYLE = `
+:root{color-scheme: light dark}
+*{box-sizing:border-box}
+html,body{margin:0;height:100%}
+.pg-wrap{
+--c-base:#202122;--c-base:light-dark(#202122,#eaecf0);
+--c-subtle:#54595d;--c-subtle:light-dark(#54595d,#a2a9b1);
+--c-progressive:#3366cc;--c-progressive:light-dark(#3366cc,#88a3e8);
+--c-progressive-hover:#3056a9;--c-progressive-hover:light-dark(#3056a9,#a6bbf5);
+--c-inverted:#fff;--c-inverted:light-dark(#fff,#101418);
+--c-error:#bf3c2c;--c-error:light-dark(#bf3c2c,#fd7865);
+--c-success:#14866d;--c-success:light-dark(#14866d,#2cb491);
+--page-bg:#f8f9fa;--page-bg:light-dark(#f8f9fa,#101418);
+--card-bg:#fff;--card-bg:light-dark(#fff,#202122);
+--inset-bg:#f8f9fa;--inset-bg:light-dark(#f8f9fa,#101418);
+--bd-base:#a2a9b1;--bd-base:light-dark(#a2a9b1,#72777d);
+--bd-subtle:#c8ccd1;--bd-subtle:light-dark(#c8ccd1,#54595d);
+--btn-normal-bg:#f8f9fa;--btn-normal-bg:light-dark(#f8f9fa,#27292d);
+--btn-normal-bg-hover:#eaecf0;--btn-normal-bg-hover:light-dark(#eaecf0,#404244);
+--focus:#3366cc;--focus:light-dark(#3366cc,#6485d1);
+font-family:-apple-system,system-ui,'Segoe UI',sans-serif;
+min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:var(--page-bg);padding:24px;color:var(--c-base)}
+.pg-card{max-width:400px;width:100%;background:var(--card-bg);border:1px solid var(--bd-subtle);border-radius:2px;box-shadow:0 1px 2px light-dark(rgba(0,0,0,.08),rgba(0,0,0,.4));padding:28px;text-align:center}
+.pg-icon{margin:0 0 14px;color:var(--c-base)}
+.pg-icon svg{display:block;margin:0 auto}
+.pg-icon--subtle{color:var(--c-subtle)}
+.pg-icon--error{color:var(--c-error)}
+.pg-icon--success{color:var(--c-success)}
+.pg-title{font-size:1.25rem;line-height:1.3;font-weight:700;margin:0 0 10px}
+.pg-lead{font-size:.875rem;line-height:1.57;margin:0}
+.pg-actions{display:flex;gap:10px;margin:18px 0 0}
+.pg-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;min-height:32px;padding:0 11px;border:1px solid;border-radius:2px;font-size:.875rem;font-weight:700;font-family:inherit;cursor:pointer;transition:background-color .1s,color .1s,border-color .1s,box-shadow .1s}
+.pg-btn:focus-visible{outline:1px solid transparent;box-shadow:inset 0 0 0 1px var(--focus)}
+.pg-primary{background:var(--c-progressive);border-color:transparent;color:var(--c-inverted)}
+.pg-primary:hover{background:var(--c-progressive-hover)}
+.pg-primary:focus-visible{box-shadow:inset 0 0 0 1px var(--c-progressive),inset 0 0 0 2px var(--c-inverted)}
+.pg-neutral{background:var(--btn-normal-bg);border-color:var(--bd-base);color:var(--c-base)}
+.pg-neutral:hover{background:var(--btn-normal-bg-hover)}
+.pg-note{font-size:.8125rem;line-height:1.5;color:var(--c-subtle);margin:22px 0 0}
+.pg-mono{font-family:ui-monospace,'SFMono-Regular',monospace;font-size:.8125rem;color:var(--c-subtle);background:var(--inset-bg);border:1px solid var(--bd-subtle);border-radius:2px;padding:9px 10px;margin:16px 0 0;word-break:break-word}
+`;
+
+export function renderPage(o: {
+	title: string;
+	icon: { name: IconName; accent?: IconAccent };
+	body: string;
+}): string {
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${esc(o.title)}</title><style>${STYLE}</style></head><body><main class="pg-wrap"><div class="pg-card">${renderIcon(o.icon.name, o.icon.accent)}<h1 class="pg-title">${esc(o.title)}</h1>${o.body}</div></main></body></html>`;
+}

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -45,6 +45,8 @@ import {
 } from '../auth/authorizationServer/authorize.js';
 import {
 	renderConsentPage,
+	renderCancelledPage,
+	renderAuthErrorPage,
 	buildConsentCookie,
 	readConsentCookie,
 	buildCsrfCookie,
@@ -678,6 +680,14 @@ emitStartupBanner(
 	},
 );
 
+// Extracts a human-readable reason string from an OAuth error body. The fields
+// are statically typed as `unknown` (the body is a Record<string, unknown>), so
+// we narrow explicitly to avoid the linter's no-base-to-string rule.
+function errorReason(body: Record<string, unknown>, fallback: string): string {
+	const v = body.error_description ?? body.error;
+	return typeof v === 'string' ? v : fallback;
+}
+
 // Reads the subset of query parameters planAuthorize cares about, coercing each
 // to a single string (Express may parse repeated/array/nested params, which the
 // OAuth params are never expected to be; only the first scalar is honoured).
@@ -873,7 +883,10 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 
 		const plan = planAuthorize(q, consent, pc, store, defaultWikiSitename);
 		if (plan.kind === 'error') {
-			res.status(plan.status).json(plan.body);
+			res
+				.status(plan.status)
+				.type('html')
+				.send(renderAuthErrorPage({ reason: errorReason(plan.body, 'invalid request') }));
 			return;
 		}
 		if (plan.kind === 'consent') {
@@ -920,15 +933,11 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 				res.redirect(302, denial.location);
 				return;
 			}
+			const client = q.client_id ? store.getClient(q.client_id) : undefined;
 			res
 				.status(200)
 				.type('html')
-				.send(
-					'<!doctype html><meta charset="utf-8"><title>Authorization cancelled</title>' +
-						'<body style="font-family:system-ui;max-width:32rem;margin:4rem auto">' +
-						'<h1>Authorization cancelled</h1>' +
-						'<p>You can close this window.</p></body>',
-				);
+				.send(renderCancelledPage({ clientName: client?.name }));
 			return;
 		}
 
@@ -938,16 +947,19 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 		const csrfCookie = readCsrfCookie(req.headers.cookie);
 		const csrfField = typeof body.csrf === 'string' ? body.csrf : undefined;
 		if (!csrfCookie || !csrfField || csrfCookie !== csrfField) {
-			res.status(400).json({ error: 'invalid_request', error_description: 'CSRF check failed' });
+			res
+				.status(400)
+				.type('html')
+				.send(renderAuthErrorPage({ reason: 'CSRF check failed' }));
 			return;
 		}
 
 		const redirectHost = redirectHostOf(q.redirect_uri);
 		if (!q.client_id || !redirectHost) {
-			res.status(400).json({
-				error: 'invalid_request',
-				error_description: 'missing client_id or redirect_uri',
-			});
+			res
+				.status(400)
+				.type('html')
+				.send(renderAuthErrorPage({ reason: 'missing client_id or redirect_uri' }));
 			return;
 		}
 
@@ -963,7 +975,10 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 		const consent: ConsentClaims = { clientId: q.client_id, redirectHost, wiki: defaultWikiKey };
 		const plan = planAuthorize(q, consent, pc, store, defaultWikiSitename);
 		if (plan.kind === 'error') {
-			res.status(plan.status).json(plan.body);
+			res
+				.status(plan.status)
+				.type('html')
+				.send(renderAuthErrorPage({ reason: errorReason(plan.body, 'invalid request') }));
 			return;
 		}
 		if (plan.kind === 'redirect') {
@@ -976,7 +991,8 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 		// transient error rather than re-prompting (the cookie is already set).
 		res
 			.status(400)
-			.json({ error: 'invalid_request', error_description: 'consent could not be applied' });
+			.type('html')
+			.send(renderAuthErrorPage({ reason: 'consent could not be applied' }));
 	});
 
 	// GET /mcp/oauth/callback — the upstream wiki's authorization-code redirect back
@@ -1024,7 +1040,10 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 
 		const plan = await handleCallback(q, pc, store, consentOk);
 		if (plan.kind === 'error') {
-			res.status(plan.status).json(plan.body);
+			res
+				.status(plan.status)
+				.type('html')
+				.send(renderAuthErrorPage({ reason: errorReason(plan.body, 'authorization failed') }));
 			return;
 		}
 		res.redirect(302, plan.location);

--- a/tests/auth/authorizationServer/consent.test.ts
+++ b/tests/auth/authorizationServer/consent.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
 	renderConsentPage,
+	renderCancelledPage,
+	renderAuthErrorPage,
 	buildConsentCookie,
 	readConsentCookie,
 	buildCsrfCookie,
@@ -17,38 +19,53 @@ const pc = {
 } as any;
 
 describe('consent', () => {
-	it('renders the client name and the act-as-you line, with no permissions list', () => {
+	it('renders the consent page with client, wiki, the form and CSRF field', () => {
 		const html = renderConsentPage({
 			clientName: 'Claude Code',
 			wiki: 'Example',
 			authorizeQuery: 'txn=1',
 			csrfToken: 'nonce-abc',
 		});
+		expect(html).toContain('Authorize application');
 		expect(html).toContain('Claude Code');
 		expect(html).toContain('act as you on');
 		expect(html).toContain('Example');
-		expect(html).toContain('txn=1');
-		expect(html).not.toContain('Permissions:');
-	});
-	it('embeds the CSRF token as a hidden form field', () => {
-		const html = renderConsentPage({
-			clientName: 'Claude Code',
-			wiki: 'Example',
-			authorizeQuery: 'txn=1',
-			csrfToken: 'nonce-abc',
-		});
+		expect(html).toContain('action="/mcp/consent?txn=1"');
 		expect(html).toContain('name="csrf"');
 		expect(html).toContain('value="nonce-abc"');
+		expect(html).toContain('value="approve"');
+		expect(html).toContain('value="deny"');
+		expect(html).not.toContain('Permissions:');
 	});
+
 	it('escapes HTML in the client name', () => {
 		const html = renderConsentPage({
 			clientName: '<script>x</script>',
 			wiki: 'W',
 			authorizeQuery: 'txn=1',
-			csrfToken: 'nonce-abc',
+			csrfToken: 'n',
 		});
 		expect(html).not.toContain('<script>x</script>');
 		expect(html).toContain('&lt;script&gt;');
+	});
+
+	it('renders cancelled and auth-error pages', () => {
+		const cancelled = renderCancelledPage({ clientName: 'Claude Code' });
+		expect(cancelled).toContain('Authorization cancelled');
+		expect(cancelled).toContain('Claude Code');
+
+		const err = renderAuthErrorPage({ reason: 'upstream token exchange failed' });
+		expect(err).toContain('Authorization failed');
+		expect(err).toContain('upstream token exchange failed');
+
+		// cancelled page with no client name falls back to a generic phrase
+		const cancelledNoName = renderCancelledPage({});
+		expect(cancelledNoName).toContain('the application');
+
+		// the auth-error reason is escaped (it can carry upstream error_description text)
+		const errXss = renderAuthErrorPage({ reason: '<script>alert(1)</script>' });
+		expect(errXss).not.toContain('<script>alert(1)</script>');
+		expect(errXss).toContain('&lt;script&gt;');
 	});
 	it('builds a SameSite=Strict, HttpOnly CSRF cookie and reads it back', () => {
 		const cookie = buildCsrfCookie('nonce-xyz');

--- a/tests/auth/pageShell.test.ts
+++ b/tests/auth/pageShell.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { renderPage, renderIcon, esc } from '../../src/auth/pageShell.js';
+
+describe('pageShell', () => {
+	it('escapes HTML metacharacters', () => {
+		expect(esc(`<a href="x">&'`)).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;');
+	});
+
+	it('renders a full document with the title in <title> and <h1>', () => {
+		const html = renderPage({
+			title: 'Authorize application',
+			icon: { name: 'lock' },
+			body: '<p>hi</p>',
+		});
+		expect(html.startsWith('<!doctype html>')).toBe(true);
+		expect(html).toContain('<html lang="en">');
+		expect(html).toContain('<title>Authorize application</title>');
+		expect(html).toContain('<h1 class="pg-title">Authorize application</h1>');
+		expect(html).toContain('<p>hi</p>');
+	});
+
+	it('escapes the title', () => {
+		const html = renderPage({ title: '<x>', icon: { name: 'error', accent: 'error' }, body: '' });
+		expect(html).not.toContain('<title><x></title>');
+		expect(html).toContain('&lt;x&gt;');
+	});
+
+	it('renders a 56px inline SVG icon for each name', () => {
+		for (const name of ['lock', 'cancel', 'error', 'success'] as const) {
+			const svg = renderIcon(name);
+			expect(svg).toContain('width="56" height="56"');
+			expect(svg).toContain('<path d="');
+		}
+	});
+
+	it('supports dark mode via light-dark() with a fallback and color-scheme', () => {
+		const html = renderPage({ title: 'T', icon: { name: 'success', accent: 'success' }, body: '' });
+		expect(html).toContain('color-scheme: light dark');
+		expect(html).toContain('light-dark(');
+		expect(html).toMatch(/--c-base:#202122;\s*--c-base:light-dark\(#202122,#eaecf0\)/);
+	});
+
+	it('has no external asset references', () => {
+		const html = renderPage({ title: 'T', icon: { name: 'lock' }, body: '<p>x</p>' });
+		expect(html).not.toMatch(/https?:\/\//);
+		expect(html).not.toContain('<link');
+		expect(html).not.toContain('<script');
+	});
+});

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -306,7 +306,8 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 		// transaction belonging to client B (cookie/clientId mismatch).
 		const mismatch = await callbackWithMismatchedConsent(app, store, pc);
 		expect(mismatch.status).toBe(400);
-		expect(mismatch.body.error_description).toMatch(/consent not present/);
+		expect(mismatch.headers['content-type']).toMatch(/html/);
+		expect(mismatch.text).toMatch(/consent not present/);
 	});
 
 	it('criterion 5: open-redirect — /register with a non-allowlisted redirect_uri returns 400', async () => {
@@ -368,7 +369,9 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 			.type('form')
 			.send({ decision: 'approve' });
 		expect(noCsrf.status).toBe(400);
-		expect(noCsrf.body.error_description).toMatch(/CSRF/i);
+		expect(noCsrf.headers['content-type']).toMatch(/html/);
+		expect(noCsrf.text).toMatch(/Authorization failed/);
+		expect(noCsrf.text).toMatch(/CSRF/i);
 
 		// Field present but no matching cookie (a cross-site POST can't carry the
 		// SameSite=Strict cookie) → rejected.
@@ -378,6 +381,8 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 			.type('form')
 			.send({ decision: 'approve', csrf });
 		expect(noCookie.status).toBe(400);
+		expect(noCookie.headers['content-type']).toMatch(/html/);
+		expect(noCookie.text).toMatch(/CSRF/i);
 
 		// Cookie + matching field → accepted (302 to the upstream authorize URL).
 		const ok = await request(app)
@@ -465,7 +470,8 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 			.query({ code: 'somecode' })
 			.set('Cookie', 'mcp_txn=txn-x');
 		expect(cb.status).toBe(400);
-		expect(String(cb.body.error_description)).toMatch(/missing code\/state/i);
+		expect(cb.headers['content-type']).toMatch(/html/);
+		expect(cb.text).toMatch(/missing code\/state/i);
 		// The seeded transaction was not consumed.
 		expect(store.getTransaction('txn-x')).toBeDefined();
 	});
@@ -526,7 +532,12 @@ async function callbackWithMismatchedConsent(
 	app: ReturnType<typeof buildApp>['app'],
 	store: InMemoryProxyStore,
 	pc: ProxyConfig,
-): Promise<{ status: number; body: { error_description?: string } }> {
+): Promise<{
+	status: number;
+	body: { error_description?: string };
+	text: string;
+	headers: Record<string, string>;
+}> {
 	const { buildConsentCookie } = await import('../../src/auth/authorizationServer/consent.js');
 	// A transaction owned by client "B-real".
 	store.putTransaction('txn-mismatch', {
@@ -549,5 +560,10 @@ async function callbackWithMismatchedConsent(
 		.query({ code: 'auth-txn-mismatch', state: 'txn-mismatch' })
 		.set('Cookie', cookie.split(';')[0]);
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- response body is untyped JSON
-	return { status: res.status, body: res.body as { error_description?: string } };
+	return {
+		status: res.status,
+		body: res.body as { error_description?: string },
+		text: res.text,
+		headers: res.headers as Record<string, string>,
+	};
 }


### PR DESCRIPTION

<img width="1749" height="773" alt="image" src="https://github.com/user-attachments/assets/1c4639a0-0a6e-4ec8-8258-59de3dea7a6c" />


## What this does

Implements **follow-up #1** from the hosted OAuth proxy PR (#413): the consent / status pages.

The OAuth flow's user-facing HTML pages — the hosted-proxy **consent**, **cancelled**, and **auth-failed** pages, plus the stdio loopback **sign-in** pages — now share one self-contained, styled, dark-mode-aware shell instead of bare unstyled HTML, and browser-reached errors render a readable page instead of raw JSON.

## Highlights

- **New `src/auth/pageShell.ts`** — a `renderPage()` shell with inline design-token CSS (WikimediaUI/Codex palette, light + dark via CSS `light-dark()` with a plain-light fallback for older browsers), inline MIT-licensed Codex SVG icons, and a shared `esc()`. No external requests, no client JS, no new dependency or build step.
- **Proxy pages (`consent.ts`)** — `renderConsentPage` on the shell, plus new `renderCancelledPage` and `renderAuthErrorPage`.
- **`streamableHttp.ts`** — browser-reached error/cancel paths (`GET /authorize`, `GET /oauth/callback` terminal errors, `POST /consent`) now return styled HTML; the OAuth **API** endpoints (`/token`, `/register`) keep returning JSON; the denial 302 redirect is unchanged.
- **Stdio loopback login pages (`browserAuth.ts`)** — restyled on the same shell.

## Behaviour

Presentation only. No OAuth protocol behaviour changes — PKCE, consent binding, redirect validation, token audience, refresh rotation, CSRF, and the client-signalling 302s are all untouched. The only functional change is the content-type of browser-reached **error** responses (JSON → HTML).

A denial/error the client can be redirected to is still a 302 back to the client (which renders its own error page); the styled "Authorization cancelled" page only appears in the fallback where there's no trusted `redirect_uri`.

## Test plan

- [x] Unit: new `pageShell` suite (doc structure, title escaping, per-icon SVG, the `light-dark()` fallback pattern, no external assets); updated `consent` tests (consent markup, cancelled/error pages, XSS escaping).
- [x] Updated proxy tests assert `content-type: html` + the reason text on the converted error paths; `/token` + `/register` JSON assertions unchanged.
- [x] Full suite **1361** tests, lint, fmt, and build all green.
- [x] Visual smoke: rendered all four page types and screenshotted them in **light and dark** — all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)