### PR TITLE
Build with TypeScript 7.0 RC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Project context for AI coding agents working on this repo. For human users, star
 - `npm run lint` — oxlint.
 - `npm run fmt` / `npm run fmt:check` — oxfmt (write / dry-run).
 - `npm run preflight` — full gate (install, lint, fmt check, validate `server.json`, test, build, bundle). Run before a release.
-- Git hooks: `lefthook` auto-installs on `npm install`. Pre-commit runs `oxfmt` (auto-fix on staged files) + `oxlint`. Pre-push runs `tsgo --noEmit` + the test suite. Bypass with `--no-verify`.
+- Git hooks: `lefthook` auto-installs on `npm install`. Pre-commit runs `oxfmt` (auto-fix on staged files) + `oxlint`. Pre-push runs `tsc --noEmit` + the test suite. Bypass with `--no-verify`.
 - `npm run inspector` — watch-mode build + MCP Inspector UI for interactive debugging.
 
 ## Tool conventions

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,8 +12,8 @@ pre-commit:
 pre-push:
   parallel: true
   jobs:
-    - name: tsgo
-      run: npx tsgo --noEmit
+    - name: tsc
+      run: npx tsc --noEmit
 
     - name: vitest
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"@types/express": "^5.0.2",
 				"@types/node": "^25.0.2",
 				"@types/supertest": "^7.2.0",
-				"@typescript/native-preview": "beta",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"concurrently": "^10.0.3",
@@ -37,7 +36,7 @@
 				"oxlint": "^1.62.0",
 				"oxlint-tsgolint": "^0.23.0",
 				"supertest": "^7.2.2",
-				"typescript": "npm:@typescript/typescript6@^6",
+				"typescript": "^7.0.1-rc",
 				"vitest": "^4.1.1"
 			},
 			"engines": {
@@ -1729,29 +1728,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@typescript/native-preview": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==",
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.1-rc.tgz",
+			"integrity": "sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==",
+			"cpu": [
+				"ppc64"
+			],
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"tsgo": "bin/tsgo.js"
-			},
-			"optionalDependencies": {
-				"@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2",
-				"@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2"
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/@typescript/native-preview-darwin-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==",
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1760,12 +1757,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-darwin-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==",
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1774,12 +1774,49 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-linux-arm": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==",
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.1-rc.tgz",
+			"integrity": "sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==",
 			"cpu": [
 				"arm"
 			],
@@ -1788,12 +1825,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-linux-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==",
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1802,12 +1842,100 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-linux-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==",
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.1-rc.tgz",
+			"integrity": "sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.1-rc.tgz",
+			"integrity": "sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.1-rc.tgz",
+			"integrity": "sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.1-rc.tgz",
+			"integrity": "sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.1-rc.tgz",
+			"integrity": "sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==",
 			"cpu": [
 				"x64"
 			],
@@ -1816,12 +1944,100 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-win32-arm64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==",
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.1-rc.tgz",
+			"integrity": "sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1830,12 +2046,15 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
-		"node_modules/@typescript/native-preview-win32-x64": {
-			"version": "7.0.0-dev.20260421.2",
-			"resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260421.2.tgz",
-			"integrity": "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==",
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.1-rc.tgz",
+			"integrity": "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==",
 			"cpu": [
 				"x64"
 			],
@@ -1844,7 +2063,10 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.9",
@@ -5075,17 +5297,38 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/typescript": {
-			"name": "@typescript/typescript6",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.1.tgz",
-			"integrity": "sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==",
+			"version": "7.0.1-rc",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.1-rc.tgz",
+			"integrity": "sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"dependencies": {
-				"typescript": "^6"
-			},
 			"bin": {
-				"tsc6": "bin/tsc6"
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.1-rc",
+				"@typescript/typescript-darwin-arm64": "7.0.1-rc",
+				"@typescript/typescript-darwin-x64": "7.0.1-rc",
+				"@typescript/typescript-freebsd-arm64": "7.0.1-rc",
+				"@typescript/typescript-freebsd-x64": "7.0.1-rc",
+				"@typescript/typescript-linux-arm": "7.0.1-rc",
+				"@typescript/typescript-linux-arm64": "7.0.1-rc",
+				"@typescript/typescript-linux-loong64": "7.0.1-rc",
+				"@typescript/typescript-linux-mips64el": "7.0.1-rc",
+				"@typescript/typescript-linux-ppc64": "7.0.1-rc",
+				"@typescript/typescript-linux-riscv64": "7.0.1-rc",
+				"@typescript/typescript-linux-s390x": "7.0.1-rc",
+				"@typescript/typescript-linux-x64": "7.0.1-rc",
+				"@typescript/typescript-netbsd-arm64": "7.0.1-rc",
+				"@typescript/typescript-netbsd-x64": "7.0.1-rc",
+				"@typescript/typescript-openbsd-arm64": "7.0.1-rc",
+				"@typescript/typescript-openbsd-x64": "7.0.1-rc",
+				"@typescript/typescript-sunos-x64": "7.0.1-rc",
+				"@typescript/typescript-win32-arm64": "7.0.1-rc",
+				"@typescript/typescript-win32-x64": "7.0.1-rc"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
 	"scripts": {
 		"start": "node dist/index.js",
 		"start:http": "MCP_TRANSPORT=http node dist/index.js",
-		"dev": "tsgo --watch",
-		"build": "tsgo",
+		"dev": "tsc --watch",
+		"build": "tsc",
 		"fmt": "oxfmt src tests scripts",
 		"fmt:check": "oxfmt --check src tests scripts",
 		"test": "vitest run",
@@ -52,9 +52,9 @@
 		"validate:server-json": "node scripts/validate-server-json.cjs",
 		"preflight": "npm ci && npm run lint && npm run fmt:check && npm run validate:server-json && npm run test && npm run build && npm run bundle -- --clean",
 		"prepare": "lefthook install",
-		"inspector": "concurrently --kill-others \"tsgo --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
-		"inspector:http": "concurrently --kill-others \"tsgo --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
-		"mcpjam": "concurrently --kill-others \"tsgo --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
+		"inspector": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
+		"inspector:http": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest\" \"MCP_TRANSPORT=http node dist/index.js\"",
+		"mcpjam": "concurrently --kill-others \"tsc --watch\" \"npx -y @mcpjam/inspector@latest node $(pwd)/dist/index.js\"",
 		"bundle": "npm run build && node scripts/bundle.cjs",
 		"preversion": "npm run preflight",
 		"version": "node scripts/sync-version.cjs && node scripts/promote-changelog.cjs && git add server.json mcpb/manifest.json gemini-extension.json CHANGELOG.md"
@@ -76,7 +76,6 @@
 		"@types/express": "^5.0.2",
 		"@types/node": "^25.0.2",
 		"@types/supertest": "^7.2.0",
-		"@typescript/native-preview": "beta",
 		"ajv": "^8.17.1",
 		"ajv-formats": "^3.0.1",
 		"concurrently": "^10.0.3",
@@ -85,7 +84,7 @@
 		"oxlint": "^1.62.0",
 		"oxlint-tsgolint": "^0.23.0",
 		"supertest": "^7.2.2",
-		"typescript": "npm:@typescript/typescript6@^6",
+		"typescript": "^7.0.1-rc",
 		"vitest": "^4.1.1"
 	}
 }


### PR DESCRIPTION
## What

Move the TypeScript compiler from the `@typescript/native-preview` nightly to the TypeScript 7.0 RC. The native Go compiler now ships as the standard `typescript` package, so this is a single devDependency:

```json
"typescript": "^7.0.1-rc"
```

`tsgo` is renamed to `tsc` in the `build`, `dev`, and inspector scripts and in the pre-push `--noEmit` hook (the RC folds the native compiler back into `tsc`; `tsgo` survives only in nightlies).

## No TypeScript 6 bridge

The usual RC migration keeps `typescript` aliased to the `@typescript/typescript6` bridge for tools that import the `typescript` JS programmatic API (typescript-eslint and friends), since the RC's native API is not stable until 7.1. This repo has no such consumer:

- Nothing in `src/`, `tests/`, or `scripts/` imports `typescript`.
- No installed package declares `typescript` as a peer dependency.
- oxlint's type-aware backend (`tsgolint`) is a self-contained native binary, not a JS-API consumer.

So the bridge would be dead weight and is left out.

## Why

The repo already compiled and shipped `dist/` with the native engine, but through a floating nightly pinned to a two-month-old April dev build. The RC is more stable, more tested, and pinnable.

## Verification

- `tsc` resolves to `typescript@7.0.1-rc`; `tsgo`/`tsc6` removed; `tsgolint` (oxlint) untouched.
- Emitted `dist/` is byte-identical to the previous nightly output: 130 files, `diff -r` reports zero differences. The published artifact does not change.
- `tsc --noEmit`, `oxlint`, and the full vitest suite (1371 tests) pass.

No CHANGELOG or README entry: build-tooling change with identical published output.

## Follow-up

The `^7.0.1-rc` range auto-adopts the 7.x stable GA when it lands (~late July 2026); the only tidy-up then is dropping the `-rc` from the spec and re-locking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
