### PR TITLE
Classify invalid OAuth tokens as authentication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - Trying to create, edit, or move a page in a protected namespace without the required right is now reported as a permission error rather than a generic upstream failure.
+- An expired or invalid OAuth access token is now reported as an authentication error rather than a generic upstream failure, so an OAuth-aware client can tell the token needs to be refreshed.
 
 ## [0.13.0] - 2026-06-17
 

--- a/src/errors/classifyError.ts
+++ b/src/errors/classifyError.ts
@@ -61,6 +61,11 @@ const MW_CODE_TO_CATEGORY: Record<string, ErrorCategory> = {
 	mustbeloggedin: 'authentication',
 	assertuserfailed: 'authentication',
 	assertbotfailed: 'authentication',
+	// An expired or otherwise invalid OAuth access token: MediaWiki's OAuth
+	// extension rejects the request with this code. Classifying it as
+	// authentication (not upstream_failure) lets OAuth-aware callers tell a dead
+	// token apart from a genuine upstream fault and start a token refresh.
+	'mwoauth-invalid-authorization': 'authentication',
 	// rate_limited
 	ratelimited: 'rate_limited',
 	// upstream_failure (explicit; unknown codes also fall through here)

--- a/tests/errors/classifyError.test.ts
+++ b/tests/errors/classifyError.test.ts
@@ -48,6 +48,7 @@ describe('classifyError', () => {
 			['mustbeloggedin', 'authentication'],
 			['assertuserfailed', 'authentication'],
 			['assertbotfailed', 'authentication'],
+			['mwoauth-invalid-authorization', 'authentication'],
 			['ratelimited', 'rate_limited'],
 			['readonly', 'upstream_failure'],
 		];


### PR DESCRIPTION
Fixes: #443

## What

MediaWiki's OAuth extension rejects an expired or otherwise invalid access token with the API code `mwoauth-invalid-authorization`. The error classifier had no entry for it, so it fell through to the generic `upstream_failure` category. This maps it to `authentication`.

Before:

```json
{ "category": "upstream_failure", "message": "Failed to retrieve search data: mwoauth-invalid-authorization: The authorization headers in your request are not valid: Invalid access token" }
```

After: the same failure is classified as `authentication`, so a caller can tell a dead token apart from a genuine upstream fault.

## Why

An OAuth-aware MCP client (e.g. LibreChat) needs to distinguish "your token expired, refresh it" from "the wiki is broken". Reporting token expiry as `upstream_failure` hid that distinction.

## Scope

This is the classification half only, and it is transport/auth-method agnostic — every auth method funnels through the same `classifyError`. It makes the error envelope and telemetry honest. It does **not**, on its own, emit an HTTP 401 to trigger a client-side refresh over the bearer-passthrough HTTP transport; that reactive step-up is a separate follow-up PR.

## Testing

- Added `mwoauth-invalid-authorization → authentication` to the classifier's code-mapping test (verified it failed first, then passed).
- Full suite green (1372 tests), lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)