### PR TITLE
Require stable typescript 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"oxlint": "^1.62.0",
 				"oxlint-tsgolint": "^0.24.0",
 				"supertest": "^7.2.2",
-				"typescript": "^7.0.1-rc",
+				"typescript": "^7.0.2",
 				"vitest": "^4.1.1"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"oxlint": "^1.62.0",
 		"oxlint-tsgolint": "^0.24.0",
 		"supertest": "^7.2.2",
-		"typescript": "^7.0.1-rc",
+		"typescript": "^7.0.2",
 		"vitest": "^4.1.1"
 	}
 }


### PR DESCRIPTION
## What

Point the `typescript` devDependency range at stable `^7.0.2`.

## Why

Dependabot's #440 bumped the lockfile to the 7.0.2 stable release, but left the `package.json` range at `^7.0.1-rc` — the caret range already accepted 7.0.2, so the manifest was never updated. As a result a fresh `package.json` still named the release candidate, and the installed `node_modules` copy lagged at `7.0.1-rc` until a manual `npm install`.

This changes the range to `^7.0.2` and resyncs, so the manifest, lockfile, and installed copy all agree on stable.

## Verification

- `npm run build` — clean
- `npm test` — 1372 passed
- `npm run lint` — exits 0 (the 50 pre-existing `no-unnecessary-type-assertion` warnings are unchanged; they come from `oxlint-tsgolint`'s bundled checker and are identical under both 7.0.1-rc and 7.0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)