### PR TITLE
Allow variable loopback ports for OAuth redirect URIs (RFC 8252 §7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - The OAuth consent page now shows where the user will be sent after approving — the client's callback host, or "an application on this device" for local clients.
 - IPv6 loopback (`http://[::1]:…`) redirect URIs are now accepted at client registration, per RFC 8252.
 
+### Fixed
+
+- OAuth clients that use a loopback callback on a variable port (VS Code's busy-port fallback, and clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.
+
 ## [0.13.1] - 2026-07-09
 
 ### Fixed

--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ProxyConfig } from './proxyConfig.js';
 import type { ProxyStore } from './proxyStore.js';
 import { randomVerifier, s256 } from '../pkce.js';
+import { redirectUriMatches } from './redirectPolicy.js';
 
 export interface AuthorizeQuery {
 	client_id?: string;
@@ -26,8 +27,9 @@ export type AuthorizePlan =
 
 /**
  * Pure planner for the proxy's /authorize endpoint. Validates the downstream
- * client + redirect_uri (exact match against the client's registered list —
- * never a loose prefix/policy re-check), the optional `resource` indicator,
+ * client + redirect_uri (byte-exact match against the client's registered list,
+ * except an http loopback request may vary its port — RFC 8252 §7.3; never a
+ * loose prefix/policy re-check), the optional `resource` indicator,
  * and the PKCE method. When consent is missing/stale it asks the caller to
  * render the consent page; when consent is present it mints a transaction with
  * a SEPARATE upstream PKCE verifier and produces the upstream authorize URL.
@@ -56,11 +58,12 @@ export function planAuthorize(
 	if (!client) {
 		return err('unknown client_id');
 	}
-	// Exact match against the registered redirect URIs — the whole string,
-	// including any query component. Never re-validate loosely (prefix, host
-	// allowlist, or the registration-time policy): a registered URI is trusted
-	// verbatim and only verbatim.
-	if (!q.redirect_uri || !client.redirectUris.includes(q.redirect_uri)) {
+	// Match against the registered redirect URIs — byte-exact, except an http
+	// loopback request may vary its port from the registered entry (RFC 8252
+	// §7.3; see redirectUriMatches). Never re-validate any more loosely than that
+	// (prefix, host allowlist, or the registration-time policy): a registered URI
+	// is otherwise trusted verbatim.
+	if (!q.redirect_uri || !client.redirectUris.some((u) => redirectUriMatches(q.redirect_uri!, u))) {
 		return err('redirect_uri not registered');
 	}
 	// RFC 8707 resource indicator. A spec-compliant client reads `resource` from
@@ -116,7 +119,7 @@ export function planAuthorize(
  * Pure planner for a denial on the proxy's own consent page ("Deny" on the first
  * screen). Aborts the flow by bouncing an OAuth error back to the downstream
  * client — but ONLY to a redirect_uri we have validated as registered for this
- * client, using the same exact-match rule as planAuthorize. Without a trusted
+ * client, using the same matching rule as planAuthorize. Without a trusted
  * redirect target we cannot safely emit a 302 (open-redirect guard), so the
  * caller falls back to a plain cancelled page. This mirrors handleCallback's
  * upstream-denial branch (RFC 6749 §4.1.2.1) for the consent step, so a client
@@ -128,7 +131,11 @@ export function planDeny(
 	store: ProxyStore,
 ): { kind: 'redirect'; location: string } | { kind: 'page' } {
 	const client = q.client_id ? store.getClient(q.client_id) : undefined;
-	if (!client || !q.redirect_uri || !client.redirectUris.includes(q.redirect_uri)) {
+	if (
+		!client ||
+		!q.redirect_uri ||
+		!client.redirectUris.some((u) => redirectUriMatches(q.redirect_uri!, u))
+	) {
 		return { kind: 'page' };
 	}
 	const u = new URL(q.redirect_uri);

--- a/src/auth/authorizationServer/redirectPolicy.ts
+++ b/src/auth/authorizationServer/redirectPolicy.ts
@@ -7,6 +7,39 @@ export function isLoopbackHost(hostname: string): boolean {
 	return LOOPBACK_HOSTNAMES.has(hostname);
 }
 
+// RFC 8252 §7.3: an http loopback redirect may vary its port at runtime, so a
+// request redirect matches a registered one when the port is the ONLY component
+// that differs — scheme, host literal, userinfo, path, query, and fragment must
+// all be identical, and both sides must be http loopback. All other URIs match
+// only byte-for-byte.
+export function redirectUriMatches(requestUri: string, registeredUri: string): boolean {
+	if (requestUri === registeredUri) {
+		return true;
+	}
+	let req: URL;
+	let reg: URL;
+	try {
+		req = new URL(requestUri);
+		reg = new URL(registeredUri);
+	} catch {
+		return false;
+	}
+	if (req.protocol !== 'http:' || reg.protocol !== 'http:') {
+		return false;
+	}
+	if (!isLoopbackHost(req.hostname) || !isLoopbackHost(reg.hostname)) {
+		return false;
+	}
+	return (
+		req.hostname === reg.hostname &&
+		req.username === reg.username &&
+		req.password === reg.password &&
+		req.pathname === reg.pathname &&
+		req.search === reg.search &&
+		req.hash === reg.hash
+	);
+}
+
 export type AllowlistEntry =
 	| { kind: 'exact'; uri: string }
 	| { kind: 'prefix'; origin: string; pathPrefix: string };

--- a/tests/auth/authorizationServer/authorize.test.ts
+++ b/tests/auth/authorizationServer/authorize.test.ts
@@ -38,16 +38,45 @@ describe('planAuthorize', () => {
 		expect(planAuthorize(baseQuery('nope'), undefined, pc, store, 'Ex').kind).toBe('error');
 	});
 	it('errors on unregistered redirect', () => {
+		// A different path is unregistered outright — loopback port relaxation
+		// (RFC 8252 §7.3) only tolerates a differing port, never a differing path.
 		const { store, client } = setup();
 		expect(
 			planAuthorize(
-				{ ...baseQuery(client.clientId), redirect_uri: 'http://127.0.0.1:9999/cb' },
+				{ ...baseQuery(client.clientId), redirect_uri: 'http://127.0.0.1:9000/other' },
 				undefined,
 				pc,
 				store,
 				'Ex',
 			).kind,
 		).toBe('error');
+	});
+	it('accepts a loopback redirect whose port differs from the portless registered URI (RFC 8252 §7.3)', () => {
+		const store = new InMemoryProxyStore();
+		const client = store.putClient({
+			redirectUris: ['http://127.0.0.1/callback'],
+			scopes: ['editpage'],
+			name: 'VS Code',
+		});
+		const q = {
+			...baseQuery(client.clientId),
+			redirect_uri: 'http://127.0.0.1:27523/callback',
+		};
+		const consent = { clientId: client.clientId, redirectHost: '127.0.0.1', wiki: 'w' };
+		expect(planAuthorize(q, consent, pc, store, 'Ex').kind).toBe('redirect');
+	});
+	it('still requires a byte-exact match for a non-loopback redirect_uri', () => {
+		const store = new InMemoryProxyStore();
+		const client = store.putClient({
+			redirectUris: ['https://vscode.dev/redirect'],
+			scopes: ['editpage'],
+			name: 'VS Code (web)',
+		});
+		const q = {
+			...baseQuery(client.clientId),
+			redirect_uri: 'https://vscode.dev/redirect/extra',
+		};
+		expect(planAuthorize(q, undefined, pc, store, 'Ex').kind).toBe('error');
 	});
 	it('errors on resource mismatch', () => {
 		const { store, client } = setup();

--- a/tests/auth/authorizationServer/redirectPolicy.test.ts
+++ b/tests/auth/authorizationServer/redirectPolicy.test.ts
@@ -4,6 +4,7 @@ import {
 	parseRedirectAllowlist,
 	buildRedirectPolicy,
 	RedirectAllowlistError,
+	redirectUriMatches,
 } from '../../../src/auth/authorizationServer/redirectPolicy.js';
 
 describe('isAllowedRedirect', () => {
@@ -84,5 +85,46 @@ describe('buildRedirectPolicy', () => {
 		['unlisted https URI', 'https://example.com/cb', false],
 	])('policy: %s → %s', (_name, uri, expected) => {
 		expect(policy(uri)).toBe(expected);
+	});
+});
+
+describe('redirectUriMatches', () => {
+	it('matches identical URIs', () => {
+		expect(redirectUriMatches('https://vscode.dev/redirect', 'https://vscode.dev/redirect')).toBe(
+			true,
+		);
+	});
+	it('matches http loopback differing only in port', () => {
+		expect(redirectUriMatches('http://127.0.0.1:3118/callback', 'http://127.0.0.1/callback')).toBe(
+			true,
+		);
+		expect(redirectUriMatches('http://127.0.0.1:27523/cb', 'http://127.0.0.1:5000/cb')).toBe(true);
+	});
+	it('rejects loopback when path/query/fragment differ', () => {
+		expect(redirectUriMatches('http://127.0.0.1:3118/evil', 'http://127.0.0.1/callback')).toBe(
+			false,
+		);
+		expect(redirectUriMatches('http://127.0.0.1:3118/cb?x=1', 'http://127.0.0.1/cb')).toBe(false);
+	});
+	it('rejects when the loopback host literal differs (127.0.0.1 vs localhost)', () => {
+		expect(redirectUriMatches('http://127.0.0.1:3118/cb', 'http://localhost/cb')).toBe(false);
+	});
+	it('does not port-relax non-loopback or https', () => {
+		expect(
+			redirectUriMatches('https://vscode.dev:8443/redirect', 'https://vscode.dev/redirect'),
+		).toBe(false);
+		expect(redirectUriMatches('http://evil.example:9/cb', 'http://evil.example/cb')).toBe(false);
+	});
+	it('matches IPv6 loopback differing only in port', () => {
+		expect(redirectUriMatches('http://[::1]:9000/cb', 'http://[::1]/cb')).toBe(true);
+	});
+	it('does not cross-match IPv6 loopback with IPv4 loopback', () => {
+		expect(redirectUriMatches('http://[::1]:9000/cb', 'http://127.0.0.1/cb')).toBe(false);
+	});
+	it('rejects when the fragment differs', () => {
+		expect(redirectUriMatches('http://127.0.0.1:3118/cb#a', 'http://127.0.0.1/cb#b')).toBe(false);
+	});
+	it('rejects when userinfo differs', () => {
+		expect(redirectUriMatches('http://evil@127.0.0.1:9000/cb', 'http://127.0.0.1/cb')).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

The hosted OAuth proxy matches a request `redirect_uri` at `/authorize` by exact string comparison against the client's registered URIs. RFC 8252 §7.3 requires an authorization server to permit a variable port for loopback redirect URIs. This adds that relaxation.

A new `redirectUriMatches(requestUri, registeredUri)` returns true when the two strings are identical, **or** when both are `http` loopback URIs (`127.0.0.1` / `localhost` / `[::1]`) that differ **only** in port — scheme, host literal, userinfo, path, query, and fragment must all be identical. `planAuthorize` and `planDeny` now use it instead of a byte-exact `.includes()`. Everything non-loopback stays byte-exact, so there is no new open-redirect surface.

## Why

- **VS Code** registers `http://127.0.0.1:33418/` but falls back to a random loopback port when 33418 is busy; that flow currently fails with "redirect_uri not registered".
- Clients that register a **portless** loopback URI (`http://127.0.0.1/`) and bind an arbitrary port at runtime (e.g. Claude Code, Zed) are affected the same way.
- This is also a **prerequisite** for Client ID Metadata Document (CIMD) support: CIMD documents publish portless loopback redirects, so the CIMD work reuses this matcher.

## What changed

- `src/auth/authorizationServer/redirectPolicy.ts` — new `redirectUriMatches`.
- `src/auth/authorizationServer/authorize.ts` — `planAuthorize`/`planDeny` use it via `.some(...)`; doc comments updated.
- Tests in `redirectPolicy.test.ts` (matcher units, incl. IPv6 loopback, host-literal/userinfo/fragment rejection, non-loopback no-relax) and `authorize.test.ts` (a `planAuthorize` accept case; the old "different-port ⇒ unregistered" case retargeted to differ by path, since a different port now legitimately matches).
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry.

## Consistency note

The **actual** request `redirect_uri` (with its runtime port) is stored at `/authorize` and re-checked byte-exact at the token endpoint (RFC 6749 §4.1.3) and used for the final callback redirect, so the varied port flows through authorize → token → callback consistently.

## Testing

- 60/60 tests in the two touched files; full suite green (1428 tests); `tsc` and `oxlint` clean.

## Known minor (non-blocking)

- No *direct* `planDeny` test for the loopback-port accept path. Its call site is textually identical to the tested `planAuthorize` one and the matcher is exhaustively unit-tested, so the risk is negligible; can add on request.

Closes #452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
