### PR TITLE
Split environment-variable docs into core and deployment tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ Reconcile picks up the new pack automatically — no edits to `src/runtime/recon
 
 A PR that adds, removes, or renames an env var read by the server — or that changes its default or accepted values — must also update:
 
-- **`README.md`** — the environment-variable table.
-- **`server.json`** — the `environmentVariables` array in **both** the `mcpb` and `npm` package blocks.
+- **The right env-var table for the variable's tier.** Each variable lives in exactly one table: **`README.md`** for a core variable that applies to any setup; **`docs/deployment.md`** (the HTTP-transport or hosted-OAuth-proxy sub-table) for a variable that only matters when self-hosting the HTTP server or running the proxy; **`docs/configuration.md`** for a config-file substitution or upload-directory variable.
+- **`server.json`** — the `environmentVariables` array in **both** the `mcpb` and `npm` package blocks, if the variable is one the install-time prompts should surface.
 - **`CHANGELOG.md`** — an entry under `## [Unreleased]` if the change is user-visible.
 - **`Dockerfile`** — only if the var needs a default baked into the docker image.
 

--- a/README.md
+++ b/README.md
@@ -122,26 +122,19 @@ Each pack's tools register only on wikis where its extension is installed.
 </details>
 
 ### Environment variables
+
+The variables below are relevant to any setup. Variables that only apply when self-hosting the HTTP transport (ports, timeouts, session limits, Host/Origin and SSRF guards) or running the hosted OAuth proxy are in [docs/deployment.md — environment variables](docs/deployment.md#environment-variables). Config-file substitution and upload-directory variables are in [docs/configuration.md](docs/configuration.md).
+
 | Name | Description | Default |
 |---|---|---|
 | `CONFIG` | Path to your configuration file | `config.json` |
-| `MCP_ALLOW_STATIC_FALLBACK` | Set to `true` to allow HTTP startup when `config.json` has static credentials. See [docs/deployment.md — security checklist](docs/deployment.md#security-checklist). | `unset` |
+| `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
+| `MCP_LOG_LEVEL` | Minimum severity for logger output. One of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, or `silent`. | `debug` |
 | `MCP_CONTENT_MAX_BYTES` | Byte cap for content bodies (wikitext, rendered HTML, diffs). Tune to the target LLM client's tool-response budget. | `50000` |
 | `MCP_FILE_DATA_MAX_BYTES` | Hard cap on the base64-encoded size of a `get-file-data` response. A transport/safety backstop; tune the actual size per call with the tool's `width`. Over-cap calls error rather than truncate. | `1000000` |
 | `MCP_UPLOAD_MAX_BYTES` | Memory cap on the server-side fetch used by `upload-file-from-url` / `update-file-from-url`. Files larger than this are handed to the wiki's own copy-upload instead of being buffered by the server. Guards this server's memory, not the wiki's `$wgMaxUploadSize`. | `104857600` |
-| `MCP_LOG_LEVEL` | Minimum severity for logger output. One of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, or `silent`. | `debug` |
-| `MCP_OAUTH_ALLOWED_REDIRECTS` | Additional OAuth redirect URIs the hosted proxy accepts at client registration: comma-separated exact URIs (each must include a host) and `https://…/*` prefix patterns. Loopback, claude.ai, and verified first-party clients are always allowed. See [docs/deployment.md — allowing more clients](docs/deployment.md#allowing-more-clients). | `unset` |
-| `MCP_OAUTH_CIMD_ALLOWED_HOSTS` | Extra hosts to trust for clients that identify by a vendor-hosted URL (Client ID Metadata Documents): comma-separated bare hosts or `host:port`. Verified first-party clients are trusted by default. See [docs/deployment.md — allowing more clients](docs/deployment.md#allowing-more-clients). | `unset` |
 | `MCP_OAUTH_CREDENTIALS_FILE` | Override the default credentials store path. Default: `~/.config/mediawiki-mcp/credentials.json` (Linux/macOS) or `%APPDATA%\mediawiki-mcp\credentials.json` (Windows). | `unset` |
 | `MCP_OAUTH_NO_BROWSER` | Set to `1` to skip launching a browser during the OAuth flow; the auth URL is logged to stderr instead. Useful in headless environments. | `unset` |
-| `MCP_PUBLIC_URL` | Override the request-derived public URL used in OAuth protected-resource discovery. Useful for reverse-proxy setups that rewrite the `Host` header. | `unset` |
-| `MCP_MAX_REQUEST_BODY` | Maximum HTTP request body size (StreamableHTTP transport). Accepts size strings like `512kb` or `1mb`. Oversize requests get a JSON-RPC 413. | `1mb` |
-| `MCP_METRICS` | Set to `true` to expose Prometheus metrics at `GET /metrics` on the HTTP transport. | `unset` |
-| `MCP_SESSION_IDLE_TIMEOUT` | Seconds an HTTP session may sit idle before it is closed and removed (StreamableHTTP transport). Any request resets the timer. `0` disables expiry. | `1800` |
-| `MCP_SHUTDOWN_GRACE_MS` | Maximum ms to wait for in-flight `/mcp` calls to drain on `SIGTERM` / `SIGINT`. See [docs/operations.md — Graceful shutdown](docs/operations.md#graceful-shutdown). | `10000` |
-| `MCP_TRANSPORT` | Type of MCP server transport (`stdio` or `http`) | `stdio` |
-| `MCP_TRUSTED_HOSTS` | Comma-separated hosts exempt from the **outbound** SSRF guard's public-IP check — for deliberately pointing the server at an internal destination such as a Docker-network alias (`mediawiki.svc`). Distinct from the inbound `MCP_ALLOWED_HOSTS`; see [Security](#security). | `unset` |
-| `PORT` | Port used for StreamableHTTP transport | `3000` |
 
 ## Configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -221,27 +221,37 @@ Background detail for the setups above. Read it when you want the full picture o
 
 ### Environment variables
 
+These apply once you self-host the HTTP transport. The core variables common to every setup (`CONFIG`, `MCP_TRANSPORT`, `MCP_LOG_LEVEL`, the result-size caps, and local OAuth) are in the [README environment-variable table](../README.md#environment-variables); config-file substitution and upload-directory variables (`MCP_UPLOAD_DIRS`) are in [configuration.md](configuration.md).
+
+#### HTTP transport
+
+Set `MCP_TRANSPORT=http` to select this transport (the Docker image defaults to it); see the [README core table](../README.md#environment-variables).
+
 | Name | Default | Description |
 |---|---|---|
-| `MCP_TRANSPORT` | `stdio` | Set to `http` for the StreamableHTTP transport (Docker default). |
 | `PORT` | `3000` (Docker: `8080`) | Listen port. |
 | `MCP_BIND` | `127.0.0.1` (Docker: `0.0.0.0`) | Listen interface. Set to `0.0.0.0` outside Docker only when you need remote access. |
+| `MCP_MAX_REQUEST_BODY` | `1mb` | HTTP request body cap. Accepts size strings (`b`, `kb`, `mb`, `gb`). |
+| `MCP_SESSION_IDLE_TIMEOUT` | `1800` | Seconds an HTTP session may sit idle before it is closed and removed. Any request resets the timer. `0` disables expiry. |
 | `MCP_SHUTDOWN_GRACE_MS` | `10000` | Drain timeout in ms on `SIGTERM` / `SIGINT`. See [Graceful shutdown](operations.md#graceful-shutdown). |
+| `MCP_METRICS` | unset | Set to `true` to expose Prometheus metrics at `GET /metrics`. See [Metrics](operations.md#metrics). |
 | `MCP_ALLOWED_HOSTS` | auto on localhost | Comma-separated Host-header allowlist. See [Security checklist](#security-checklist). |
 | `MCP_ALLOWED_ORIGINS` | auto on localhost | Comma-separated `Origin`-header allowlist. See [Security checklist](#security-checklist). |
 | `MCP_TRUSTED_HOSTS` | unset | Comma-separated **outbound** SSRF-guard exemptions for internal destinations (e.g. `mediawiki.svc`). See [Outbound SSRF guard](#outbound-ssrf-guard). |
-| `MCP_MAX_REQUEST_BODY` | `1mb` | HTTP request body cap. Accepts size strings (`b`, `kb`, `mb`, `gb`). |
 | `MCP_ALLOW_STATIC_FALLBACK` | unset | Allow HTTP startup when a wiki has static credentials, making them a shared fallback identity. See [Security checklist](#security-checklist). |
+
+`MCP_MAX_REQUEST_BODY` matches nginx's `client_max_body_size 1m`. Raise it if `update-page` calls return 413 on legitimately large edits or your wiki has raised `$wgMaxArticleSize` (MediaWiki default 2 MB). Lower it for a tighter DoS guard.
+
+#### Hosted OAuth proxy
+
+| Name | Default | Description |
+|---|---|---|
 | `MCP_PUBLIC_URL` | unset | The proxy's public issuer/base, e.g. `https://wiki.example.org/mcp`. Enables the hosted OAuth proxy when set alongside `MCP_OAUTH_JWT_SIGNING_KEY` and a default wiki with `oauth2ClientId`. See [Hosted OAuth sign-in](#hosted-oauth-sign-in). |
 | `MCP_OAUTH_JWT_SIGNING_KEY` | unset | Secret (≥32 chars) the proxy signs its issued access/refresh JWTs and consent cookies with. Required for the proxy. Keep it **fixed** so tokens survive a restart. See [Hosted OAuth sign-in](#hosted-oauth-sign-in). |
 | `MCP_OAUTH_TOKEN_TTL` | `55m` | Lifetime of a proxy-minted access JWT. Must be shorter than the upstream 30-day refresh window. Duration grammar (`55m`/`1h`/`30d`, or bare seconds). |
 | `MCP_OAUTH_CONSENT_TTL` | `30d` | Lifetime of the signed consent cookie that lets a returning user skip the consent page. Same duration grammar. |
 | `MCP_OAUTH_ALLOWED_REDIRECTS` | unset | Additional OAuth redirect URIs the proxy accepts at client registration: comma-separated exact URIs and `https://…/*` prefix patterns. Loopback, claude.ai, and verified first-party clients are always allowed. See [Allowing more clients](#allowing-more-clients). |
 | `MCP_OAUTH_CIMD_ALLOWED_HOSTS` | unset | Extra hosts to trust for clients that identify by a vendor-hosted URL (Client ID Metadata Documents): comma-separated bare hosts or `host:port`. The first-party clients are always trusted. See [Allowing more clients](#allowing-more-clients). |
-
-`MCP_MAX_REQUEST_BODY` matches nginx's `client_max_body_size 1m`. Raise it if `update-page` calls return 413 on legitimately large edits or your wiki has raised `$wgMaxArticleSize` (MediaWiki default 2 MB). Lower it for a tighter DoS guard.
-
-For the complete list of every environment variable the server reads, see the [README environment-variable table](../README.md#environment-variables).
 
 ### How the proxy works
 


### PR DESCRIPTION
## What

Reorganizes the environment-variable documentation so each variable is documented once, in the table for its tier:

- **README** keeps the core variables relevant to any setup.
- **docs/deployment.md** owns the HTTP-transport and hosted-OAuth-proxy variables, split into two labelled sub-tables.

## Why

The README table claimed to be "the complete list of every environment variable the server reads" (deployment.md linked to it as such), but the two tables had drifted and neither was complete:

- README was missing `MCP_BIND`, `MCP_ALLOWED_HOSTS`, `MCP_ALLOWED_ORIGINS`, `MCP_OAUTH_JWT_SIGNING_KEY`, `MCP_OAUTH_TOKEN_TTL`, `MCP_OAUTH_CONSENT_TTL`.
- deployment.md was missing `MCP_SESSION_IDLE_TIMEOUT`, `MCP_METRICS`.
- `MCP_UPLOAD_DIRS` (read by the code) was in neither table; it is documented in configuration.md.

Many of the variables in the old README list only apply to the hosted proxy, cluttering the front page for the common stdio/local user.

## Changes

- README env-var table trimmed to core vars, with a lead line routing readers to deployment.md / configuration.md for the rest.
- deployment.md Reference table split into **HTTP transport** and **Hosted OAuth proxy** sub-tables; adds the two missing rows; drops the false "complete list" pointer. `MCP_TRANSPORT` is documented only in the README table, with a one-line pointer from the HTTP-transport section.
- AGENTS.md policy updated: a new variable is documented in the table for its tier, not always the README.

Docs-only: no CHANGELOG entry (no observable behavior change) and no `server.json` change (its install-time list is intentionally a subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
