### PR TITLE
Add OAuth proxy end-to-end testing: provisioning script + runbook

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,7 +207,8 @@ proxy-issued bearer token.
 
 ### 6. Verify
 
-- Call `oauth-status` → expected: authenticated as the admin account.
+- Call `whoami` → expected: the signed-in admin account. (`oauth-status` is
+  stdio-only and is not exposed over the HTTP proxy.)
 - Call `create-page` (any title/text) → expected: success, and the new
   revision's author is the admin account — confirming the write is attributed to
   the signed-in user, not a shared identity.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,22 +100,120 @@ To point an MCP client (Claude Desktop, VS Code, Cursor, etc.) at a locally-buil
 
 ## Local wiki setup (for authenticated tools)
 
-Authenticated tools (create, update, delete, undelete, upload) need credentials. To create bot passwords on a local MediaWiki running in Docker:
+Authenticated tools (create, update, delete, undelete, upload) need credentials.
+To create a bot password on a local MediaWiki running in Docker:
 
 ```bash
-docker exec <container> php /var/www/html/w/maintenance/run.php createBotPassword \
+docker exec <container> php /var/www/html/maintenance/run.php createBotPassword \
   --appid mcp-server \
-  --grants 'basic,editpage,editprotected,createeditmovepage,uploadfile,highvolume,delete' \
+  --grants 'basic,highvolume,editpage,editprotected,createeditmovepage,delete,uploadfile,uploadeditmovefile' \
   <username>
 ```
 
-Then add the credentials to `config.json` (copy from `config.example.json` if it doesn't exist):
+Then add the credentials to `config.json` (copy from `config.example.json` if it
+doesn't exist). Use environment-variable substitution to keep secrets out of the
+file:
 
 ```json
 {
-  "username": "<username>@mcp-server",
-  "password": "<generated-password>"
+  "username": "${MW_BOT_USER}",
+  "password": "${MW_BOT_PASSWORD}"
 }
 ```
 
-For production authentication, use OAuth2 — see [Authentication](../README.md#authentication) in the README.
+For production authentication, use OAuth2 — see [Authentication](../README.md#authentication).
+To exercise the full browser sign-in flow of the hosted OAuth proxy end to end,
+see [End-to-end testing the hosted OAuth proxy](#end-to-end-testing-the-hosted-oauth-proxy) below.
+
+(Adjust `/var/www/html` to your wiki's install path.)
+
+## End-to-end testing the hosted OAuth proxy
+
+A manual, repeatable walkthrough of the full browser sign-in flow — discovery,
+sign-in, upstream consent, token exchange, and an attributed write — against a
+real wiki. Written so an agent (or a person) can follow it verbatim. It needs no
+bundled environment: any MediaWiki container with Extension:OAuth works.
+
+### 1. Prerequisites and the environment contract
+
+You need a reachable MediaWiki container with **Extension:OAuth installed and
+OAuth2 enabled** (OAuth2 signing keys configured on the wiki), a known admin
+account, and a local build of this repo (`npm run build`). Any environment that
+satisfies the contract below works.
+
+| Variable | Meaning | Source |
+|---|---|---|
+| `OAUTH2_CLIENT_ID` | Consumer key → `config.json` `oauth2ClientId` | provisioning script |
+| `MW_DEV_BOT_USER` / `MW_DEV_BOT_PASSWORD` | Static credentials for non-proxy auth tests | provisioning script |
+| `MCP_TRUSTED_HOSTS` | Outbound SSRF-guard exemption for a loopback/private wiki | provisioning script |
+| `MCP_PUBLIC_URL`, `MCP_OAUTH_JWT_SIGNING_KEY`, `PORT`, `MCP_TRANSPORT` | Proxy configuration | you |
+| wiki URL + admin credentials | The environment itself | you |
+
+### 2. Provision the consumer and bot password
+
+```bash
+set -a; eval "$( scripts/provision-dev-wiki.sh <container> )"; set +a
+```
+
+This registers an approved OAuth 2.0 public (PKCE) consumer whose callback
+matches `${MCP_PUBLIC_URL}/oauth/callback`, creates a bot password, and exports
+`OAUTH2_CLIENT_ID`, `MW_DEV_BOT_USER`, `MW_DEV_BOT_PASSWORD`, and (for a loopback
+wiki) `MCP_TRUSTED_HOSTS`. Override the proxy base with `--public-url` if you run
+the server on a non-default port.
+
+### 3. Configure the wiki entry
+
+In `config.json`, point the wiki at the provisioned consumer (adjust
+`articlepath`/`scriptpath` to your wiki's layout):
+
+```json
+{
+  "defaultWiki": "localhost:8080",
+  "wikis": {
+    "localhost:8080": {
+      "sitename": "Dev MediaWiki",
+      "server": "http://localhost:8080",
+      "articlepath": "/wiki",
+      "scriptpath": "/w",
+      "oauth2ClientId": "${OAUTH2_CLIENT_ID}"
+    }
+  }
+}
+```
+
+### 4. Start the proxy
+
+```bash
+export MCP_TRANSPORT=http PORT=3000 MCP_PUBLIC_URL=http://localhost:3000/mcp
+export MCP_OAUTH_JWT_SIGNING_KEY="$(openssl rand -hex 32)"   # keep this FIXED across restarts
+node dist/index.js
+```
+
+`MCP_TRUSTED_HOSTS` (from step 2) is already exported for a loopback wiki. A
+changed signing key invalidates every issued token.
+
+### 5. Walk the sign-in flow
+
+Point an OAuth-aware MCP client at `http://localhost:3000/mcp` (the MCP
+Inspector's HTTP mode works) and start sign-in, or drive the endpoints directly:
+`GET /.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`
+(discovery) → `POST /mcp/register` (dynamic client registration) →
+open `/mcp/authorize?…` in a browser → `POST /mcp/token`.
+
+At the authorize step, **using your browser or a browser-automation tool**, sign
+in as the admin account and approve the consent screen(s). Expected: the browser
+returns to `http://localhost:3000/mcp/oauth/callback` and the client receives a
+proxy-issued bearer token.
+
+### 6. Verify
+
+- Call `oauth-status` → expected: authenticated as the admin account.
+- Call `create-page` (any title/text) → expected: success, and the new
+  revision's author is the admin account — confirming the write is attributed to
+  the signed-in user, not a shared identity.
+
+### 7. Reset
+
+- `oauth-logout` (stdio) or restart the server to drop stored tokens.
+- Re-run step 2 to register a fresh consumer.
+- Rotating `MCP_OAUTH_JWT_SIGNING_KEY` signs everyone out on the next start.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -155,11 +155,19 @@ satisfies the contract below works.
 set -a; eval "$( scripts/provision-dev-wiki.sh <container> )"; set +a
 ```
 
-This registers an approved OAuth 2.0 public (PKCE) consumer whose callback
-matches `${MCP_PUBLIC_URL}/oauth/callback`, creates a bot password, and exports
-`OAUTH2_CLIENT_ID`, `MW_DEV_BOT_USER`, `MW_DEV_BOT_PASSWORD`, and (for a loopback
-wiki) `MCP_TRUSTED_HOSTS`. Override the proxy base with `--public-url` if you run
-the server on a non-default port.
+On a wiki whose Extension:OAuth is recent enough to register OAuth2 consumers
+from the command line, this registers an approved OAuth 2.0 public (PKCE)
+consumer whose callback matches `${MCP_PUBLIC_URL}/oauth/callback`, creates a bot
+password, and exports `OAUTH2_CLIENT_ID`, `MW_DEV_BOT_USER`, `MW_DEV_BOT_PASSWORD`,
+and (for a loopback wiki) `MCP_TRUSTED_HOSTS`. Override the proxy base with
+`--public-url` if you run the server on a non-default port.
+
+On an older Extension:OAuth — for example the copy bundled with the MediaWiki
+1.43 LTS, whose `createOAuthConsumer.php` is OAuth1-only — the script cannot
+register the consumer from the command line. It prints step-by-step instructions
+to register it once in the browser at
+`Special:OAuthConsumerRegistration/propose/oauth2`, after which you set
+`OAUTH2_CLIENT_ID` yourself before starting the proxy.
 
 ### 3. Configure the wiki entry
 

--- a/scripts/provision-dev-wiki.sh
+++ b/scripts/provision-dev-wiki.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# provision-dev-wiki.sh — register an OAuth 2.0 consumer (and optional bot
+# password) on a MediaWiki container running Extension:OAuth, for local
+# end-to-end testing of the hosted OAuth proxy.
+#
+# The environment — a running MediaWiki container with Extension:OAuth and
+# OAuth2 enabled — is the caller's responsibility. This script only provisions
+# credentials against a container that already exists.
+#
+# Usage:  scripts/provision-dev-wiki.sh <container> [options]
+#
+# Credential lines print to STDOUT in env-file format; capture them with:
+#   set -a; eval "$( scripts/provision-dev-wiki.sh <container> )"; set +a
+# All human-readable progress goes to STDERR, keeping STDOUT clean.
+
+set -euo pipefail
+
+# --- defaults ---------------------------------------------------------------
+PUBLIC_URL='http://localhost:3000/mcp'
+WIKI_URL='http://localhost:8080'
+MW_PATH='/var/www/html'
+ADMIN_USER='Admin'
+GRANTS='basic,highvolume,editpage,editprotected,createeditmovepage,delete,uploadfile,uploadeditmovefile'
+WITH_BOT=1
+DRY_RUN=0
+CONTAINER=''
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+	cat <<'EOF'
+provision-dev-wiki.sh — register an OAuth 2.0 consumer (+ optional bot password)
+on a MediaWiki container running Extension:OAuth, for local OAuth-proxy testing.
+
+Usage: scripts/provision-dev-wiki.sh <container> [options]
+
+  <container>          Docker container name or id running MediaWiki (required).
+
+Options:
+  --public-url <url>   Proxy public base (MCP_PUBLIC_URL). Default: http://localhost:3000/mcp
+                       Consumer callback is derived as <public-url>/oauth/callback.
+  --wiki-url <url>     Browser/API base of the wiki. Default: http://localhost:8080
+  --mw-path <path>     MediaWiki install path inside the container. Default: /var/www/html
+  --admin-user <name>  Wiki account that owns the consumer/bot password. Default: Admin
+  --grants <csv>       Comma-separated grant ids. Default covers every write tool.
+  --no-bot             Skip bot-password creation.
+  --dry-run            Print the docker commands that would run, then exit.
+  -h, --help           Show this help.
+
+Output (stdout, env-file format): OAUTH2_CLIENT_ID, MW_DEV_BOT_USER,
+MW_DEV_BOT_PASSWORD, and (for loopback wikis) MCP_TRUSTED_HOSTS.
+EOF
+}
+
+# --- parse args -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--public-url) PUBLIC_URL="${2:?--public-url needs a value}"; shift 2 ;;
+		--wiki-url)   WIKI_URL="${2:?--wiki-url needs a value}"; shift 2 ;;
+		--mw-path)    MW_PATH="${2:?--mw-path needs a value}"; shift 2 ;;
+		--admin-user) ADMIN_USER="${2:?--admin-user needs a value}"; shift 2 ;;
+		--grants)     GRANTS="${2:?--grants needs a value}"; shift 2 ;;
+		--no-bot)     WITH_BOT=0; shift ;;
+		--bot)        WITH_BOT=1; shift ;;
+		--dry-run)    DRY_RUN=1; shift ;;
+		-h|--help)    usage; exit 0 ;;
+		-*)           usage >&2; die "unknown option: $1" ;;
+		*)            if [ -z "$CONTAINER" ]; then CONTAINER="$1"; else die "unexpected argument: $1"; fi; shift ;;
+	esac
+done
+
+[ -n "$CONTAINER" ] || { usage >&2; die "missing <container> argument"; }
+
+CALLBACK_URL="${PUBLIC_URL%/}/oauth/callback"
+CONSUMER_NAME="MCP dev proxy (${PUBLIC_URL})"
+RUN_PHP="${MW_PATH%/}/maintenance/run.php"
+OAUTH_SCRIPT="${MW_PATH%/}/extensions/OAuth/maintenance/createOAuthConsumer.php"
+
+# --- assemble commands as arrays (safe quoting for both run and print) ------
+consumer_argv=(docker exec "$CONTAINER" php "$RUN_PHP" "$OAUTH_SCRIPT"
+	--user "$ADMIN_USER" --name "$CONSUMER_NAME"
+	--description 'MediaWiki MCP Server dev proxy' --version '1.0'
+	--oauthVersion 2 --oauth2IsNotConfidential
+	--oauth2GrantTypes authorization_code --oauth2GrantTypes refresh_token
+	--callbackUrl "$CALLBACK_URL" --approve --jsonOnSuccess)
+IFS=',' read -ra grant_arr <<< "$GRANTS"
+for g in "${grant_arr[@]}"; do consumer_argv+=(--grants "$g"); done
+
+botpw_argv=(docker exec "$CONTAINER" php "$RUN_PHP" createBotPassword
+	--appid mcp-dev --grants "$GRANTS" "$ADMIN_USER")
+
+# --- dry-run: print the commands and exit (no Docker contact) ---------------
+if [ "$DRY_RUN" -eq 1 ]; then
+	printf '%q ' "${consumer_argv[@]}"; printf '\n'
+	if [ "$WITH_BOT" -eq 1 ]; then printf '%q ' "${botpw_argv[@]}"; printf '\n'; fi
+	exit 0
+fi
+
+# --- preflight --------------------------------------------------------------
+command -v docker >/dev/null 2>&1 || die "docker not found on PATH"
+running="$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || true)"
+[ "$running" = "true" ] || die "container '$CONTAINER' is not running"
+docker exec "$CONTAINER" test -f "$RUN_PHP" \
+	|| die "MediaWiki not found at $MW_PATH in '$CONTAINER' (set --mw-path)"
+docker exec "$CONTAINER" test -f "$OAUTH_SCRIPT" \
+	|| die "Extension:OAuth not found at $MW_PATH/extensions/OAuth (install it and enable OAuth2)"
+
+# --- register consumer ------------------------------------------------------
+log "Registering OAuth 2.0 consumer '${CONSUMER_NAME}'"
+log "  callback: ${CALLBACK_URL}"
+consumer_json="$("${consumer_argv[@]}")" || die "consumer registration failed (see above)"
+client_id="$(printf '%s' "$consumer_json" | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')"
+[ -n "$client_id" ] || die "could not parse consumer key from output: $consumer_json"
+
+# --- optional bot password --------------------------------------------------
+bot_user=''; bot_pw=''
+if [ "$WITH_BOT" -eq 1 ]; then
+	log "Creating bot password (appid mcp-dev) for ${ADMIN_USER}"
+	bot_out="$("${botpw_argv[@]}")" || die "bot password creation failed (see above)"
+	bot_pw="$(printf '%s' "$bot_out" | sed -n "s/.*password:'\([^']*\)'.*/\1/p")"
+	bot_user="$(printf '%s' "$bot_out" | sed -n "s/.*username:'\([^']*\)'.*/\1/p")"
+	[ -n "$bot_pw" ] || die "could not parse bot password from output: $bot_out"
+fi
+
+# --- emit credentials (stdout) ----------------------------------------------
+printf 'OAUTH2_CLIENT_ID=%s\n' "$client_id"
+if [ "$WITH_BOT" -eq 1 ]; then
+	printf 'MW_DEV_BOT_USER=%s\n' "$bot_user"
+	printf 'MW_DEV_BOT_PASSWORD=%s\n' "$bot_pw"
+fi
+
+wiki_host="${WIKI_URL#*://}"; wiki_host="${wiki_host%%/*}"   # host[:port]
+host_only="${wiki_host%%:*}"
+case "$host_only" in
+	localhost|127.*|::1|0.0.0.0)
+		printf 'MCP_TRUSTED_HOSTS=%s\n' "$wiki_host" ;;
+	*)
+		log "note: if ${host_only} resolves to a private/internal address, also set MCP_TRUSTED_HOSTS=${wiki_host}" ;;
+esac
+
+log "Done. Set oauth2ClientId to \$OAUTH2_CLIENT_ID and start the proxy (see docs/testing.md)."

--- a/scripts/provision-dev-wiki.sh
+++ b/scripts/provision-dev-wiki.sh
@@ -141,22 +141,30 @@ if [ "$WITH_BOT" -eq 1 ]; then
 	bot_pw="$(printf '%s' "$bot_out" | sed -n "s/.*password:'\([^']*\)'.*/\1/p")"
 	bot_user="$(printf '%s' "$bot_out" | sed -n "s/.*username:'\([^']*\)'.*/\1/p")"
 	[ -n "$bot_pw" ] || die "could not parse bot password from output: $bot_out"
+	[ -n "$bot_user" ] || die "could not parse bot username from output: $bot_out"
 fi
 
 # --- emit credentials (stdout) ----------------------------------------------
+# %q-quote every value so `set -a; eval "$( ... )"; set +a` is safe even when a
+# value contains shell metacharacters — MediaWiki usernames may contain spaces,
+# so `MW_DEV_BOT_USER=First Last@mcp-dev` must be quoted.
 if [ -n "$client_id" ]; then
-	printf 'OAUTH2_CLIENT_ID=%s\n' "$client_id"
+	printf 'OAUTH2_CLIENT_ID=%q\n' "$client_id"
 fi
 if [ "$WITH_BOT" -eq 1 ]; then
-	printf 'MW_DEV_BOT_USER=%s\n' "$bot_user"
-	printf 'MW_DEV_BOT_PASSWORD=%s\n' "$bot_pw"
+	printf 'MW_DEV_BOT_USER=%q\n' "$bot_user"
+	printf 'MW_DEV_BOT_PASSWORD=%q\n' "$bot_pw"
 fi
 
-wiki_host="${WIKI_URL#*://}"; wiki_host="${wiki_host%%/*}"   # host[:port]
-host_only="${wiki_host%%:*}"
+wiki_host="${WIKI_URL#*://}"; wiki_host="${wiki_host%%/*}"   # host[:port] or [ipv6]:port
+if [ "${wiki_host#\[}" != "$wiki_host" ]; then
+	host_only="${wiki_host#\[}"; host_only="${host_only%%\]*}"   # bare host inside [ ]
+else
+	host_only="${wiki_host%%:*}"
+fi
 case "$host_only" in
-	localhost|127.*|::1|0.0.0.0)
-		printf 'MCP_TRUSTED_HOSTS=%s\n' "$wiki_host" ;;
+	localhost | *.localhost | 127.* | ::1 | 0.0.0.0)
+		printf 'MCP_TRUSTED_HOSTS=%q\n' "$wiki_host" ;;
 	*)
 		log "note: if ${host_only} resolves to a private/internal address, also set MCP_TRUSTED_HOSTS=${wiki_host}" ;;
 esac

--- a/scripts/provision-dev-wiki.sh
+++ b/scripts/provision-dev-wiki.sh
@@ -107,12 +107,31 @@ docker exec "$CONTAINER" test -f "$RUN_PHP" \
 docker exec "$CONTAINER" test -f "$OAUTH_SCRIPT" \
 	|| die "Extension:OAuth not found at $MW_PATH/extensions/OAuth (install it and enable OAuth2)"
 
-# --- register consumer ------------------------------------------------------
-log "Registering OAuth 2.0 consumer '${CONSUMER_NAME}'"
-log "  callback: ${CALLBACK_URL}"
-consumer_json="$("${consumer_argv[@]}")" || die "consumer registration failed (see above)"
-client_id="$(printf '%s' "$consumer_json" | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')"
-[ -n "$client_id" ] || die "could not parse consumer key from output: $consumer_json"
+# --- register consumer (only if the stock CLI supports OAuth2) ---------------
+# The --oauthVersion / --oauth2IsNotConfidential flags exist only in newer
+# Extension:OAuth. The copy bundled with some releases (e.g. the MediaWiki 1.43
+# LTS) ships an OAuth1-only createOAuthConsumer.php, so CLI registration of an
+# OAuth2 public client is impossible there and must be done in the browser.
+# Detect by looking for the public-client flag in the script itself.
+client_id=''
+if docker exec "$CONTAINER" grep -q 'oauth2IsNotConfidential' "$OAUTH_SCRIPT" 2>/dev/null; then
+	log "Registering OAuth 2.0 consumer '${CONSUMER_NAME}'"
+	log "  callback: ${CALLBACK_URL}"
+	consumer_json="$("${consumer_argv[@]}")" || die "consumer registration failed (see above)"
+	client_id="$(printf '%s' "$consumer_json" | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')"
+	[ -n "$client_id" ] || die "could not parse consumer key from output: $consumer_json"
+else
+	log "This wiki's Extension:OAuth createOAuthConsumer.php is OAuth1-only (no CLI"
+	log "flag for OAuth2 public clients), so the consumer can't be registered from"
+	log "the command line here. Register it once in the browser instead:"
+	log "  1. On the wiki, open Special:OAuthConsumerRegistration/propose/oauth2"
+	log "  2. Callback URL (exact): ${CALLBACK_URL}"
+	log "  3. Leave 'This consumer is confidential' UNCHECKED (public + PKCE)."
+	log "  4. Grant types: tick Authorization code and Refresh token."
+	log "  5. Request the grants your tools need (default set: ${GRANTS})."
+	log "  6. Copy the client application key into OAUTH2_CLIENT_ID."
+	log "See docs/deployment.md for the field-by-field walkthrough."
+fi
 
 # --- optional bot password --------------------------------------------------
 bot_user=''; bot_pw=''
@@ -125,7 +144,9 @@ if [ "$WITH_BOT" -eq 1 ]; then
 fi
 
 # --- emit credentials (stdout) ----------------------------------------------
-printf 'OAUTH2_CLIENT_ID=%s\n' "$client_id"
+if [ -n "$client_id" ]; then
+	printf 'OAUTH2_CLIENT_ID=%s\n' "$client_id"
+fi
 if [ "$WITH_BOT" -eq 1 ]; then
 	printf 'MW_DEV_BOT_USER=%s\n' "$bot_user"
 	printf 'MW_DEV_BOT_PASSWORD=%s\n' "$bot_pw"
@@ -140,4 +161,9 @@ case "$host_only" in
 		log "note: if ${host_only} resolves to a private/internal address, also set MCP_TRUSTED_HOSTS=${wiki_host}" ;;
 esac
 
-log "Done. Set oauth2ClientId to \$OAUTH2_CLIENT_ID and start the proxy (see docs/testing.md)."
+if [ -n "$client_id" ]; then
+	log "Done. Set oauth2ClientId to \$OAUTH2_CLIENT_ID and start the proxy (see docs/testing.md)."
+else
+	log "Done. After registering the consumer in the browser (steps above), set"
+	log "OAUTH2_CLIENT_ID to its client key and start the proxy (see docs/testing.md)."
+fi


### PR DESCRIPTION
## What

Adds a paved, agent-executable way to end-to-end test the hosted OAuth proxy against any MediaWiki container running Extension:OAuth — without bundling a wiki environment in this repo.

- **`scripts/provision-dev-wiki.sh`** — container-agnostic. Against a running MediaWiki + Extension:OAuth container it registers an approved OAuth 2.0 public (PKCE) consumer and an optional bot password, printing credentials as `eval`-safe env lines (progress/errors go to stderr). Has `--dry-run` and `--help`.
- **`docs/testing.md`** — a new "End-to-end testing the hosted OAuth proxy" runbook (prerequisites/env contract, provision, configure, run, browser sign-in, verify, reset), plus a modernized "Local wiki setup" section.

## Why

OAuth-proxy work increasingly needs real end-to-end verification — browser sign-in, upstream token exchange, attributed writes — that unit tests can't cover. This makes that repeatable for humans and agents while keeping the wiki environment itself out of the repo. Published artifacts are unaffected: `scripts/` is already excluded from the npm package, the Docker image, and the mcpb bundle.

## Validation

Ran the full flow end-to-end against a real MediaWiki 1.43.9 wiki: dynamic client registration → PKCE → proxy consent → wiki login/consent → upstream token exchange → proxy JWT → authenticated `create-page`, with the new revision attributed to the signed-in user. That run caught two real defects, both fixed here:

- The runbook now verifies with **`whoami`** — `oauth-status` is stdio-only and is not exposed over the HTTP proxy.
- The provisioning script **detects OAuth1-only Extension:OAuth** (the stock `createOAuthConsumer.php` bundled with the MediaWiki 1.43 LTS has no OAuth2 CLI flags) and falls back to printing browser-registration steps, instead of failing on the current LTS.

Code review additionally hardened credential output to be `eval`-safe (`%q`-quoted, since MediaWiki usernames may contain spaces) and widened loopback auto-detection (`*.localhost`, bracketed IPv6).

No tool or server-read environment variable is added, so no README/CHANGELOG changes are needed (per `AGENTS.md`).

Draft — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
