### PR TITLE
Require a confidential upstream OAuth consumer for the hosted proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Hosted OAuth proxy: the upstream OAuth consumer must now be **confidential**. Set `oauth2ClientSecret` (or the `MCP_OAUTH2_CLIENT_SECRET` environment variable) for the default wiki; the proxy refuses to start without it. This is what lets the proxy refresh the upstream MediaWiki token, so users stay signed in past the wiki's OAuth2 access-token lifetime (one hour by default). Deployments that used a public/PKCE consumer must register a confidential consumer and supply its secret.
+
 ### Added
 
 - Hosted OAuth proxy: verified first-party MCP clients now work with the hosted proxy out of the box — their OAuth callbacks are trusted by default, with no `MCP_OAUTH_ALLOWED_REDIRECTS` configuration.
@@ -21,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - OAuth clients that use a loopback callback on a variable port (including clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.
+- Hosted OAuth proxy: an upstream token refresh the wiki rejects with `invalid_client` (client authentication failed) is now reported as an authentication failure the client re-signs-in on, instead of a retryable "temporarily unavailable" that the client would loop on.
 
 ## [0.13.1] - 2026-07-09
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ Covers configuration topics beyond the basic `config.json` shape documented in [
 | `articlepath` | Yes | Path pattern for articles (typically `/wiki`) |
 | `scriptpath` | Yes | Path to MediaWiki scripts (typically `/w`) |
 | `oauth2ClientId` | No | Client key your wiki admin gives you when they register the MCP server's OAuth consumer. Opts the wiki into browser-based sign-in. See [OAuth (browser-based)](#oauth-browser-based). |
+| `oauth2ClientSecret` | No | Client secret for the **confidential** OAuth consumer used by the [hosted OAuth proxy](deployment.md#hosted-oauth-sign-in); required when that proxy is enabled. |
 | `oauth2CallbackPort` | No | Loopback port for the OAuth sign-in callback. Use the same port number your admin set in the consumer's callback URL. |
 | `token` | No | OAuth2 access token for authenticated operations (manual token alternative to `oauth2ClientId`) |
 | `username` | No | Bot username (fallback when OAuth2 is not available) |
@@ -203,7 +204,7 @@ Setting these on the HTTP transport turns the server into an OAuth Authorization
 - `MCP_OAUTH_TOKEN_TTL` — lifetime of a proxy-minted access JWT. Default `55m`; must be shorter than the upstream 30-day refresh window.
 - `MCP_OAUTH_CONSENT_TTL` — lifetime of the signed consent cookie that lets a returning user skip the consent page. Default `30d`.
 
-`MCP_OAUTH_TOKEN_TTL` and `MCP_OAUTH_CONSENT_TTL` accept a number with an optional `s`/`m`/`h`/`d` unit (e.g. `55m`, `1h`, `30d`); a bare number is seconds. The proxy activates only when `MCP_TRANSPORT=http`, both required variables are set, and the default wiki has an `oauth2ClientId`.
+`MCP_OAUTH_TOKEN_TTL` and `MCP_OAUTH_CONSENT_TTL` accept a number with an optional `s`/`m`/`h`/`d` unit (e.g. `55m`, `1h`, `30d`); a bare number is seconds. The proxy activates only when `MCP_TRANSPORT=http`, both required variables are set, and the default wiki has an `oauth2ClientId` and `oauth2ClientSecret`.
 
 ### For wiki admins: registering the OAuth consumer
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,11 +71,11 @@ Set it up in five steps.
 One-time, wiki-side setup, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed. At `Special:OAuthConsumerRegistration/propose/oauth2`, register **one** consumer:
 
 - **OAuth 2.0**, requesting **specific permissions** (a *full* consumer, not the owner-only "for use only by me" option), including the edit grants your users need.
-- **Public client:** leave "This consumer is confidential" unchecked. The proxy uses PKCE and no client secret.
 - **Grant types:** Authorization code and Refresh token.
 - **Callback URL:** exactly `<MCP_PUBLIC_URL>/oauth/callback`; Extension:OAuth exact-matches the redirect URI. With `MCP_PUBLIC_URL=https://wiki.example.org/mcp`, that is `https://wiki.example.org/mcp/oauth/callback`.
+- **Confidential client:** check "This consumer is confidential" and keep the **client secret** it shows. The proxy authenticates with that secret to refresh tokens and keep users signed in past the wiki's ~1-hour access-token lifetime; it refuses to start without one, so a public/PKCE consumer is not supported.
 
-Copy the resulting consumer key into the wiki's `oauth2ClientId` (next step); the consumer secret stays unused. For a field-by-field walkthrough, see [configuration.md: registering the OAuth consumer](configuration.md#for-wiki-admins-registering-the-oauth-consumer).
+Copy the resulting consumer **key** into the wiki's `oauth2ClientId` and its **secret** into `oauth2ClientSecret` (next step).
 
 ### 2. Configure the wiki
 
@@ -90,7 +90,8 @@ Copy the resulting consumer key into the wiki's `oauth2ClientId` (next step); th
       "publicServer": "https://wiki.example.org",
       "articlepath": "/wiki",
       "scriptpath": "/w",
-      "oauth2ClientId": "${WIKI_OAUTH_CLIENT_ID}"
+      "oauth2ClientId": "${WIKI_OAUTH_CLIENT_ID}",
+      "oauth2ClientSecret": "${WIKI_OAUTH_CLIENT_SECRET}"
     }
   }
 }
@@ -99,12 +100,13 @@ Copy the resulting consumer key into the wiki's `oauth2ClientId` (next step); th
 - `server`: the **internal** API address the server uses for tool calls and the confidential token exchange. In Docker this is often a network alias (here `http://mediawiki.svc`) that bypasses your public proxy; list it in `MCP_TRUSTED_HOSTS` so the [outbound SSRF guard](#outbound-ssrf-guard) permits it.
 - `publicServer`: the **browser-facing** wiki URL the user is redirected to for the MediaWiki consent screen. Omit it when your wiki has a single URL (no separate internal address); it then falls back to `server`.
 - `oauth2ClientId`: the consumer key from step 1.
+- `oauth2ClientSecret`: the consumer secret from step 1. Keep it out of `config.json` with `${MCP_OAUTH2_CLIENT_SECRET}` substitution or the `MCP_OAUTH2_CLIENT_SECRET` env var.
 
 The proxy mints a per-user token for each signed-in user, so no static credentials appear here; leave `readOnly` off so writes are available after sign-in. (Why the two hostnames differ is detailed under [How the proxy works](#how-the-proxy-works).)
 
 ### 3. Set the proxy environment
 
-Set both variables below. The proxy turns on once they are set, `MCP_TRANSPORT=http`, and the default wiki has its `oauth2ClientId` (from step 2).
+Set both variables below. The proxy turns on once they are set, `MCP_TRANSPORT=http`, and the default wiki has its `oauth2ClientId` and `oauth2ClientSecret` (from step 2).
 
 | Variable | Description |
 |---|---|

--- a/src/auth/authorizationServer/callback.ts
+++ b/src/auth/authorizationServer/callback.ts
@@ -91,6 +91,7 @@ export async function handleCallback(
 			code: q.code,
 			redirectUri: pc.callbackUrl,
 			clientId: pc.upstreamClientId,
+			clientSecret: pc.upstreamClientSecret,
 			verifier: txn.proxyVerifier,
 		});
 	} catch {

--- a/src/auth/authorizationServer/proxyConfig.ts
+++ b/src/auth/authorizationServer/proxyConfig.ts
@@ -15,6 +15,11 @@ export interface ProxyConfig {
 	scriptpath: string;
 	callbackUrl: string;
 	upstreamClientId: string;
+	// The confidential upstream consumer's client secret. resolveProxyConfig
+	// requires it — the proxy refuses to start without it — so it is always present
+	// on a resolved config. The field stays optional only so tests can build a
+	// ProxyConfig literal without one.
+	upstreamClientSecret?: string;
 	signingKey: string;
 	consentTtlMs: number;
 	tokenTtlMs: number;
@@ -30,6 +35,7 @@ interface WikiSlice {
 	server: string;
 	scriptpath: string;
 	oauth2ClientId?: string | null;
+	oauth2ClientSecret?: string | null;
 	publicServer?: string | null;
 }
 
@@ -43,6 +49,7 @@ export function resolveProxyConfig(
 	env: NodeJS.ProcessEnv,
 ): ProxyConfig | null {
 	const clientId = wiki.oauth2ClientId?.trim();
+	const clientSecret = wiki.oauth2ClientSecret?.trim() || undefined;
 	const publicUrl = env.MCP_PUBLIC_URL?.trim();
 	const signingKey = env.MCP_OAUTH_JWT_SIGNING_KEY?.trim();
 	const transport = env.MCP_TRANSPORT ?? 'stdio';
@@ -80,6 +87,17 @@ export function resolveProxyConfig(
 		throw new ProxyConfigError('MCP_OAUTH_JWT_SIGNING_KEY must be at least 32 characters.');
 	}
 
+	// The proxy must be a confidential upstream client: MediaWiki authenticates the
+	// refresh grant, so a public consumer cannot refresh the upstream token and a
+	// session would break when it expires. Require the secret up front rather than
+	// fail silently an hour into every session.
+	if (!clientSecret) {
+		throw new ProxyConfigError(
+			'The hosted OAuth proxy requires a confidential OAuth consumer: set oauth2ClientSecret ' +
+				'(or the MCP_OAUTH2_CLIENT_SECRET environment variable) for the default wiki.',
+		);
+	}
+
 	const tokenTtlMs = env.MCP_OAUTH_TOKEN_TTL
 		? parseDurationMs(env.MCP_OAUTH_TOKEN_TTL)
 		: DEFAULT_TOKEN_TTL_MS;
@@ -115,6 +133,7 @@ export function resolveProxyConfig(
 		scriptpath: wiki.scriptpath,
 		callbackUrl: `${issuer}/oauth/callback`,
 		upstreamClientId: clientId,
+		upstreamClientSecret: clientSecret,
 		signingKey,
 		consentTtlMs,
 		tokenTtlMs,

--- a/src/auth/authorizationServer/token.ts
+++ b/src/auth/authorizationServer/token.ts
@@ -91,6 +91,7 @@ export async function handleToken(
 				tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
 				refreshToken: upstream.refreshToken,
 				clientId: pc.upstreamClientId,
+				clientSecret: pc.upstreamClientSecret,
 			});
 		} catch (err) {
 			// Abandon the claim WITHOUT rotating, so the presented refresh token stays

--- a/src/auth/oauthFlow.ts
+++ b/src/auth/oauthFlow.ts
@@ -28,30 +28,58 @@ export interface ExchangeArgs {
 	verifier: string;
 	clientId: string;
 	redirectUri: string;
+	// Set only when the upstream consumer is confidential. MediaWiki requires a
+	// client secret on the refresh grant (a public client can't refresh); sending
+	// it here lets the same consumer be used confidentially for both grants.
+	clientSecret?: string;
 }
 
 export interface RefreshArgs {
 	tokenEndpoint: string;
 	refreshToken: string;
 	clientId: string;
+	// See ExchangeArgs.clientSecret. Without it, MediaWiki rejects a public
+	// client's refresh with invalid_client.
+	clientSecret?: string;
+}
+
+// Adds `client_secret` to a token-request body only when the upstream consumer
+// is confidential, keeping the public/PKCE default byte-for-byte unchanged.
+function withClientSecret(
+	body: Record<string, string>,
+	clientSecret?: string,
+): Record<string, string> {
+	return clientSecret ? { ...body, client_secret: clientSecret } : body;
 }
 
 export async function exchangeCode(a: ExchangeArgs): Promise<TokenResponse> {
-	return post(a.tokenEndpoint, {
-		grant_type: 'authorization_code',
-		code: a.code,
-		code_verifier: a.verifier,
-		client_id: a.clientId,
-		redirect_uri: a.redirectUri,
-	});
+	return post(
+		a.tokenEndpoint,
+		withClientSecret(
+			{
+				grant_type: 'authorization_code',
+				code: a.code,
+				code_verifier: a.verifier,
+				client_id: a.clientId,
+				redirect_uri: a.redirectUri,
+			},
+			a.clientSecret,
+		),
+	);
 }
 
 export async function refreshTokens(a: RefreshArgs): Promise<TokenResponse> {
-	return post(a.tokenEndpoint, {
-		grant_type: 'refresh_token',
-		refresh_token: a.refreshToken,
-		client_id: a.clientId,
-	});
+	return post(
+		a.tokenEndpoint,
+		withClientSecret(
+			{
+				grant_type: 'refresh_token',
+				refresh_token: a.refreshToken,
+				client_id: a.clientId,
+			},
+			a.clientSecret,
+		),
+	);
 }
 
 async function post(endpoint: string, body: Record<string, string>): Promise<TokenResponse> {
@@ -87,8 +115,11 @@ async function post(endpoint: string, body: Record<string, string>): Promise<Tok
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- post-JSON boundary; fields validated immediately below
 	const obj = json as Record<string, unknown>;
 
-	// 400 error responses
-	if (res.status === 400) {
+	// Any non-2xx below 500: classify by the OAuth error code. MediaWiki returns
+	// 401 invalid_client (not 400) when a public client cannot authenticate for
+	// the refresh grant, so invalid_client must be recognised regardless of status
+	// — otherwise a permanent misconfiguration reads as a retryable transient error.
+	if (!res.ok) {
 		const code = typeof obj.error === 'string' ? obj.error : '';
 		if (code === 'invalid_grant') {
 			throw new OAuthFlowError('invalid_grant', 'Token request failed: invalid_grant');
@@ -96,12 +127,7 @@ async function post(endpoint: string, body: Record<string, string>): Promise<Tok
 		if (code === 'invalid_client') {
 			throw new OAuthFlowError('invalid_client', 'Token request failed: invalid_client');
 		}
-		throw new OAuthFlowError('transient', `Token request failed: ${code}`);
-	}
-
-	// Other non-2xx
-	if (!res.ok) {
-		throw new OAuthFlowError('transient', `Token endpoint returned ${res.status}`);
+		throw new OAuthFlowError('transient', `Token request failed: ${code || res.status}`);
 	}
 
 	// 200 but missing required fields

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -40,9 +40,19 @@ export interface WikiConfig {
 	 * Presence opts the wiki into OAuth: HTTP transport advertises it in
 	 * /.well-known/oauth-protected-resource, and stdio runtime triggers
 	 * a browser-based login when no live token is stored.
-	 * Public client (PKCE only) — no client secret needed.
+	 * A public (PKCE) consumer needs no secret; set `oauth2ClientSecret` to use a
+	 * confidential consumer (required for the proxy's upstream token refresh).
 	 */
 	oauth2ClientId?: string | null;
+	/**
+	 * OAuth 2.0 client secret for a CONFIDENTIAL upstream consumer. Optional: omit
+	 * for a public (PKCE) consumer. MediaWiki requires client authentication on the
+	 * refresh grant, so without a confidential consumer + this secret the hosted
+	 * proxy cannot refresh the upstream token and a session ends when the upstream
+	 * access token expires. Being a secret, prefer `${MCP_OAUTH2_CLIENT_SECRET}`
+	 * substitution or the `MCP_OAUTH2_CLIENT_SECRET` env override over config.json.
+	 */
+	oauth2ClientSecret?: string | null;
 	/**
 	 * Public base URL of the wiki (e.g. https://wiki.example) used ONLY to build the
 	 * browser-facing upstream OAuth authorize URL when the hosted proxy is enabled.
@@ -328,6 +338,7 @@ function resolveConfig(parsed: unknown): Config {
 		wikis[key] = resolveWiki(rawWiki, key);
 	}
 	applyOAuth2ClientIdOverride(wikis, defaultWiki);
+	applyOAuth2ClientSecretOverride(wikis, defaultWiki);
 	return { defaultWiki, wikis, allowWikiManagement, uploadDirs };
 }
 
@@ -343,6 +354,22 @@ function applyOAuth2ClientIdOverride(wikis: Record<string, WikiConfig>, defaultW
 	const fromEnv = process.env.MCP_OAUTH2_CLIENT_ID?.trim();
 	if (fromEnv && wikis[defaultWiki]) {
 		wikis[defaultWiki].oauth2ClientId = fromEnv;
+	}
+}
+
+/**
+ * `MCP_OAUTH2_CLIENT_SECRET` overrides the DEFAULT wiki's `oauth2ClientSecret`,
+ * mirroring the client-id override. A confidential consumer's secret is deploy-time
+ * data best kept out of config.json; the env value wins over the file and a blank
+ * value is ignored so it can't blank out a configured secret.
+ */
+function applyOAuth2ClientSecretOverride(
+	wikis: Record<string, WikiConfig>,
+	defaultWiki: string,
+): void {
+	const fromEnv = process.env.MCP_OAUTH2_CLIENT_SECRET?.trim();
+	if (fromEnv && wikis[defaultWiki]) {
+		wikis[defaultWiki].oauth2ClientSecret = fromEnv;
 	}
 }
 

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -278,6 +278,7 @@ export async function resolveUpstreamBearer(
 			tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
 			refreshToken: upstream.refreshToken,
 			clientId: pc.upstreamClientId,
+			clientSecret: pc.upstreamClientSecret,
 		});
 		const updated = {
 			accessToken: r.access_token,

--- a/tests/auth/authorizationServer/proxyConfig.test.ts
+++ b/tests/auth/authorizationServer/proxyConfig.test.ts
@@ -8,6 +8,7 @@ const wiki = {
 	server: 'http://mediawiki.svc:80',
 	scriptpath: '/w',
 	oauth2ClientId: 'abc123',
+	oauth2ClientSecret: 'sekret',
 	publicServer: 'https://wiki.example',
 };
 const env = {
@@ -29,6 +30,20 @@ describe('resolveProxyConfig', () => {
 		expect(c.callbackUrl).toBe('https://wiki.example/mcp/oauth/callback');
 		expect(c.authorizeBase).toBe('https://wiki.example');
 		expect(c.tokenExchangeBase).toBe('http://mediawiki.svc:80');
+	});
+	it('populates upstreamClientSecret from the confidential wiki config', () => {
+		const c = resolveProxyConfig('w', { ...wiki, oauth2ClientSecret: 'shh' }, env)!;
+		expect(c.upstreamClientSecret).toBe('shh');
+	});
+	it('throws when the proxy is enabled without a client secret', () => {
+		expect(() => resolveProxyConfig('w', { ...wiki, oauth2ClientSecret: undefined }, env)).toThrow(
+			ProxyConfigError,
+		);
+	});
+	it('throws on a blank client secret', () => {
+		expect(() => resolveProxyConfig('w', { ...wiki, oauth2ClientSecret: '  ' }, env)).toThrow(
+			ProxyConfigError,
+		);
 	});
 	it('falls back to server when publicServer unset', () => {
 		const c = resolveProxyConfig('w', { ...wiki, publicServer: undefined }, env)!;

--- a/tests/auth/oauthFlow.test.ts
+++ b/tests/auth/oauthFlow.test.ts
@@ -1,4 +1,5 @@
 // tests/auth/oauthFlow.test.ts
+import type { RequestHandler } from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 import { exchangeCode, OAuthFlowError, refreshTokens } from '../../src/auth/oauthFlow.js';
 import { startFakeAs, type FakeAsHandle } from '../helpers/fakeAuthorizationServer.js';
@@ -203,5 +204,92 @@ describe('refreshTokens', () => {
 		await expect(
 			refreshTokens({ tokenEndpoint, refreshToken: 'r', clientId: 'c' }),
 		).rejects.toMatchObject({ kind: 'transient' });
+	});
+
+	it('throws OAuthFlowError(invalid_client) on 401 invalid_client (public-client refresh)', async () => {
+		// MediaWiki returns 401 (not 400) when a public client cannot authenticate
+		// for the refresh grant; it must classify as invalid_client, not transient.
+		fakeAs = await startFakeAs({
+			token: (_req, res) => {
+				res
+					.status(401)
+					.json({ error: 'invalid_client', error_description: 'Client authentication failed' });
+			},
+		});
+		const tokenEndpoint = `${fakeAs.url}/w/rest.php/oauth2/access_token`;
+		await expect(
+			refreshTokens({ tokenEndpoint, refreshToken: 'r', clientId: 'c' }),
+		).rejects.toMatchObject({ kind: 'invalid_client' });
+	});
+});
+
+describe('confidential client secret', () => {
+	// Records the parsed form body the fake token endpoint received.
+	function bodyRecorder(): { body: Record<string, unknown> | undefined; token: RequestHandler } {
+		const rec: { body: Record<string, unknown> | undefined; token: RequestHandler } = {
+			body: undefined,
+			token: (req, res) => {
+				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test capture of the parsed form body
+				rec.body = req.body as Record<string, unknown>;
+				res.json({ access_token: 'a', expires_in: 3600 });
+			},
+		};
+		return rec;
+	}
+
+	it('exchangeCode sends client_secret when configured', async () => {
+		const rec = bodyRecorder();
+		fakeAs = await startFakeAs({ token: rec.token });
+		await exchangeCode({
+			tokenEndpoint: `${fakeAs.url}/w/rest.php/oauth2/access_token`,
+			code: 'c',
+			verifier: 'v',
+			clientId: 'c',
+			redirectUri: 'r',
+			clientSecret: 'shh',
+		});
+		expect(rec.body?.client_secret).toBe('shh');
+	});
+
+	it('exchangeCode omits client_secret when not configured', async () => {
+		const rec = bodyRecorder();
+		fakeAs = await startFakeAs({ token: rec.token });
+		await exchangeCode({
+			tokenEndpoint: `${fakeAs.url}/w/rest.php/oauth2/access_token`,
+			code: 'c',
+			verifier: 'v',
+			clientId: 'c',
+			redirectUri: 'r',
+		});
+		expect(rec.body).not.toHaveProperty('client_secret');
+	});
+
+	it('refreshTokens sends client_secret when configured', async () => {
+		const rec = bodyRecorder();
+		fakeAs = await startFakeAs({ token: rec.token });
+		await refreshTokens({
+			tokenEndpoint: `${fakeAs.url}/w/rest.php/oauth2/access_token`,
+			refreshToken: 'r',
+			clientId: 'c',
+			clientSecret: 'shh',
+		});
+		expect(rec.body?.client_secret).toBe('shh');
+	});
+
+	it('refresh against a wiki that authenticates the grant: fails as a public client, succeeds with the secret', async () => {
+		fakeAs = await startFakeAs({ refreshRequiresClientSecret: 'shh' });
+		const tokenEndpoint = `${fakeAs.url}/w/rest.php/oauth2/access_token`;
+		// Public client (no secret) — the MediaWiki-style rejection the old fake masked.
+		await expect(
+			refreshTokens({ tokenEndpoint, refreshToken: 'r', clientId: 'c' }),
+		).rejects.toMatchObject({ kind: 'invalid_client' });
+		// Confidential client (correct secret) — refresh now works.
+		const ok = await refreshTokens({
+			tokenEndpoint,
+			refreshToken: 'r',
+			clientId: 'c',
+			clientSecret: 'shh',
+		});
+		expect(ok.access_token).toBe('access-refreshed');
 	});
 });

--- a/tests/config/loadConfig.test.ts
+++ b/tests/config/loadConfig.test.ts
@@ -191,6 +191,41 @@ describe('loadConfigFromFile', () => {
 		});
 	});
 
+	describe('MCP_OAUTH2_CLIENT_SECRET override', () => {
+		it('overrides the default wiki oauth2ClientSecret from the environment', async () => {
+			vi.stubEnv('MCP_OAUTH2_CLIENT_SECRET', 'env-secret');
+			setConfigFile({
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, oauth2ClientSecret: 'config-secret' } },
+			});
+			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile().wikis.w.oauth2ClientSecret).toBe('env-secret');
+		});
+
+		it('sets oauth2ClientSecret on the default wiki when config has none', async () => {
+			vi.stubEnv('MCP_OAUTH2_CLIENT_SECRET', 'env-secret');
+			setConfigFile({ defaultWiki: 'w', wikis: { w: { ...baseWiki } } });
+			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile().wikis.w.oauth2ClientSecret).toBe('env-secret');
+		});
+
+		it('ignores a blank env value (does not blank out a configured secret)', async () => {
+			vi.stubEnv('MCP_OAUTH2_CLIENT_SECRET', '   ');
+			setConfigFile({
+				defaultWiki: 'w',
+				wikis: { w: { ...baseWiki, oauth2ClientSecret: 'config-secret' } },
+			});
+			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile().wikis.w.oauth2ClientSecret).toBe('config-secret');
+		});
+
+		it('leaves an absent secret undefined (public consumer)', async () => {
+			setConfigFile({ defaultWiki: 'w', wikis: { w: { ...baseWiki } } });
+			const { loadConfigFromFile } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile().wikis.w.oauth2ClientSecret).toBeUndefined();
+		});
+	});
+
 	describe('passthrough cases', () => {
 		it('passes through null secret fields unchanged', async () => {
 			setConfigFile({

--- a/tests/helpers/fakeAuthorizationServer.ts
+++ b/tests/helpers/fakeAuthorizationServer.ts
@@ -18,6 +18,12 @@ export interface FakeAsOptions {
 	// receives (see capturedApiBearers) so a test can assert the UPSTREAM wiki
 	// token — not the proxy JWT — is what reaches the wiki action API.
 	captureApi?: boolean;
+	// When set, the default token endpoint requires this exact `client_secret` on
+	// the refresh_token grant, else it returns 401 invalid_client. This mirrors
+	// MediaWiki's Extension:OAuth, whose refresh grant demands client authentication
+	// even for a public consumer (unlike the auth-code+PKCE grant) — the behaviour
+	// the earlier permissive fake masked.
+	refreshRequiresClientSecret?: string;
 }
 
 export interface FakeAsHandle {
@@ -77,7 +83,7 @@ export async function startFakeAs(opts: FakeAsOptions = {}): Promise<FakeAsHandl
 	}
 	// 'absent': don't register either route.
 
-	app.post('/w/rest.php/oauth2/access_token', opts.token ?? defaultTokenHandler);
+	app.post('/w/rest.php/oauth2/access_token', opts.token ?? makeDefaultTokenHandler(opts));
 
 	const oneQuery = (v: unknown): string => (typeof v === 'string' ? v : '');
 	const autoApprove: RequestHandler = (req, res) => {
@@ -120,27 +126,41 @@ export async function startFakeAs(opts: FakeAsOptions = {}): Promise<FakeAsHandl
 	return handle;
 }
 
-function defaultTokenHandler(req: express.Request, res: express.Response): void {
-	const grant = String(req.body.grant_type ?? '');
-	if (grant === 'authorization_code') {
-		res.json({
-			access_token: 'access-' + String(req.body.code),
-			refresh_token: 'refresh-' + String(req.body.code),
-			expires_in: 3600,
-			scope: 'edit',
-			token_type: 'Bearer',
-		});
-		return;
-	}
-	if (grant === 'refresh_token') {
-		res.json({
-			access_token: 'access-refreshed',
-			refresh_token: 'refresh-rotated',
-			expires_in: 3600,
-			scope: 'edit',
-			token_type: 'Bearer',
-		});
-		return;
-	}
-	res.status(400).json({ error: 'unsupported_grant_type' });
+function makeDefaultTokenHandler(opts: FakeAsOptions): RequestHandler {
+	return (req, res) => {
+		const grant = String(req.body.grant_type ?? '');
+		if (grant === 'authorization_code') {
+			res.json({
+				access_token: 'access-' + String(req.body.code),
+				refresh_token: 'refresh-' + String(req.body.code),
+				expires_in: 3600,
+				scope: 'edit',
+				token_type: 'Bearer',
+			});
+			return;
+		}
+		if (grant === 'refresh_token') {
+			// Mirror MediaWiki: the refresh grant authenticates the client. A public
+			// consumer (no/wrong secret) is rejected with 401 invalid_client.
+			if (
+				opts.refreshRequiresClientSecret !== undefined &&
+				String(req.body.client_secret ?? '') !== opts.refreshRequiresClientSecret
+			) {
+				res.status(401).json({
+					error: 'invalid_client',
+					error_description: 'Client authentication failed',
+				});
+				return;
+			}
+			res.json({
+				access_token: 'access-refreshed',
+				refresh_token: 'refresh-rotated',
+				expires_in: 3600,
+				scope: 'edit',
+				token_type: 'Bearer',
+			});
+			return;
+		}
+		res.status(400).json({ error: 'unsupported_grant_type' });
+	};
 }


### PR DESCRIPTION
## Problem

The hosted OAuth proxy registered a **public** (PKCE) upstream consumer, so it could not refresh the upstream MediaWiki token: MediaWiki's Extension:OAuth answers the `refresh_token` grant with `401 invalid_client`. A signed-in session therefore broke when the wiki's OAuth2 access token expired — **one hour by default** — regardless of `MCP_OAUTH_TOKEN_TTL` or the on-disk persistence added in #458. This surfaced while live-testing the persistence work against a real MediaWiki (the first time an upstream refresh actually ran against a real wiki rather than the permissive test double).

## Root cause

The `league/oauth2-server` bundled with MediaWiki 1.43 validates the client **unconditionally** on the refresh grant (`RefreshTokenGrant::respondToAccessTokenRequest` → `validateClient`), whereas `AuthCodeGrant` skips it for public clients (`if ($client->isConfidential())`). So a public client authenticates fine for the code exchange (PKCE) but is rejected on refresh. RFC 6749 §6 permits public-client refresh without authentication, and newer league versions add the same guard to `RefreshTokenGrant` — but the MCP server can't change the wiki's bundled version.

## Fix

Make the proxy a **confidential** upstream client, and require it:

- New per-wiki **`oauth2ClientSecret`**, resolvable from **`MCP_OAUTH2_CLIENT_SECRET`** — mirroring how `oauth2ClientId` / `MCP_OAUTH2_CLIENT_ID` already work. Threads into `ProxyConfig.upstreamClientSecret`.
- `exchangeCode` and `refreshTokens` send `client_secret` on the token request. Both token-write sites (`callback.ts`, `token.ts`, and the per-request lazy refresh in `resolveUpstreamBearer`) pass it through.
- **`resolveProxyConfig` now refuses to start the proxy without a secret** — a public/PKCE consumer is no longer supported. This is a single, reliable setup that keeps users signed in across the wiki's access-token TTL, rather than one that silently drops sessions after an hour. It's a **breaking change** for deployments that registered a public consumer: they must register a confidential one and supply its secret.

Also in this PR (directly related):

- **Error classification:** a `401` with `error=invalid_client` was misread as `transient` → the client got a retryable `503` and would loop. It's now the permanent `invalid_client`, so a genuinely-unauthenticatable refresh surfaces as "re-authenticate."
- **Test hardening:** the fake authorization server can now require a client secret on the refresh grant (`refreshRequiresClientSecret`), mirroring MediaWiki. The earlier permissive fake is exactly why this gap hid — a test drives the realistic path: a public client's refresh fails with `invalid_client`, and the same refresh succeeds once the secret is sent.

## Docs

`deployment.md` step 1 now instructs registering a confidential consumer (no public/confidential choice); step 2 marks `oauth2ClientSecret` required; the startup-failure note and `configuration.md` are updated to match.

## Testing

- Unit tests across `oauthFlow`, `loadConfig`, `proxyConfig` (including "refuses to start without a secret"); full suite **1528 passing**, `tsc` + lint + format clean.
- The realistic round-trip is covered: refresh against a fake AS that authenticates the grant fails as a public client and succeeds with the secret.

## Verification

Unit-verified (full suite **1528**), and confirmed **live** against real MediaWiki 1.43 + Extension:OAuth with a **confidential** consumer:

- **Root cause + fix, direct against the wiki's token endpoint:** the confidential consumer's `refresh_token` grant returns `401 invalid_client` ("Client authentication failed") **without** the client secret, and `200` + a new access token **with** it. (This is also exactly the `401 invalid_client` the classifier fix now treats as permanent.)
- **Hard requirement:** the proxy binary refuses to start when the proxy is enabled without `oauth2ClientSecret` — `ProxyConfigError`, non-zero exit.
- **Proxy code exchange:** a full sign-in through the proxy against the confidential consumer succeeds (a confidential consumer's code exchange only works if the proxy sends the secret); `whoami` and an attributed page write both succeeded.
- **Proxy on-expiry refresh:** with the wiki's upstream access-token TTL shortened to 40s, a tool call made past that expiry still succeeds — the proxy refreshed the upstream token server-to-server with the secret (confirmed by the encrypted store being rewritten on each refresh, and not on the pre-expiry baseline call), and an attributed write after the refresh also succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
