### PR TITLE
Serve the still-valid token when a proactive upstream refresh fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - OAuth clients that use a loopback callback on a variable port (including clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.
 - Hosted OAuth proxy: an upstream token refresh the wiki rejects with `invalid_client` (client authentication failed) is now reported as an authentication failure the client re-signs-in on, instead of a retryable "temporarily unavailable" that the client would loop on.
+- Hosted OAuth proxy: a momentary wiki outage while refreshing a near-expiry token on an active connection no longer forces the client to sign in again. The request now continues with the still-valid token, or gets a retryable response, instead of a sign-in challenge the client would act on for a transient blip. Concurrent requests that both trigger a refresh now share one upstream refresh rather than racing.
 
 ## [0.13.1] - 2026-07-09
 

--- a/src/auth/authorizationServer/token.ts
+++ b/src/auth/authorizationServer/token.ts
@@ -3,7 +3,7 @@ import type { ProxyConfig } from './proxyConfig.js';
 import type { ProxyStore } from './proxyStore.js';
 import { s256 } from '../pkce.js';
 import { mintAccessToken, mintRefreshToken, verifyRefreshToken } from './jwt.js';
-import { refreshTokens as defaultRefresh, OAuthFlowError } from '../oauthFlow.js';
+import { refreshTokens as defaultRefresh, classifyRefreshError } from '../oauthFlow.js';
 
 type RefreshFn = typeof defaultRefresh;
 
@@ -101,7 +101,7 @@ export async function handleToken(
 			// its refresh token and force a full re-auth. invalid_grant/invalid_client
 			// (the upstream genuinely rejecting the refresh token) still map to 400.
 			store.finishRefreshRotation(claims.upstreamTokenId);
-			if (err instanceof OAuthFlowError && (err.kind === 'transient' || err.kind === 'malformed')) {
+			if (classifyRefreshError(err) === 'retryable') {
 				return {
 					status: 503,
 					body: {

--- a/src/auth/oauthFlow.ts
+++ b/src/auth/oauthFlow.ts
@@ -22,6 +22,21 @@ export class OAuthFlowError extends Error {
 	}
 }
 
+export type RefreshErrorClass = 'retryable' | 'dead';
+
+// Classifies a refresh-grant failure so every caller reacts consistently. A
+// transient or malformed upstream failure (wiki 5xx, connection blip, garbled
+// body) is `retryable`: the presented refresh token is still good, so a caller
+// should surface a retryable error rather than force a full re-authentication. A
+// genuine rejection (invalid_grant/invalid_client) — or any non-OAuth error — is
+// `dead`: the refresh token cannot be used again.
+export function classifyRefreshError(err: unknown): RefreshErrorClass {
+	if (err instanceof OAuthFlowError && (err.kind === 'transient' || err.kind === 'malformed')) {
+		return 'retryable';
+	}
+	return 'dead';
+}
+
 export interface ExchangeArgs {
 	tokenEndpoint: string;
 	code: string;

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -34,7 +34,11 @@ import { fetchMetadata, type AsMetadata } from '../auth/metadata.js';
 import { buildProtectedResource, resolvePublicBase } from '../auth/protectedResource.js';
 import { resolveProxyConfig, type ProxyConfig } from '../auth/authorizationServer/proxyConfig.js';
 import type { ProxyStore, ClientRecord } from '../auth/authorizationServer/proxyStore.js';
-import { refreshTokens as defaultRefresh, type RefreshArgs } from '../auth/oauthFlow.js';
+import {
+	refreshTokens as defaultRefresh,
+	classifyRefreshError,
+	type RefreshArgs,
+} from '../auth/oauthFlow.js';
 import { buildAsMetadata } from '../auth/authorizationServer/asMetadata.js';
 import { handleRegister } from '../auth/authorizationServer/register.js';
 import { createProxyStore } from '../auth/authorizationServer/proxyStorePersistence.js';
@@ -254,14 +258,81 @@ type RefreshFn = (a: RefreshArgs) => Promise<{
 	expires_in: number;
 }>;
 
+// Thrown by resolveUpstreamBearer when a proxy JWT cannot be resolved to a usable
+// upstream token. `retryable` distinguishes a transient upstream failure (the /mcp
+// handler answers 503 temporarily_unavailable) from a dead credential (a 401 +
+// re-auth challenge), mirroring how the /token grant maps the same refresh errors.
+export class UpstreamBearerError extends Error {
+	public constructor(
+		public readonly retryable: boolean,
+		message: string,
+	) {
+		super(message);
+		this.name = 'UpstreamBearerError';
+	}
+}
+
+// In-flight proactive refreshes keyed by upstreamTokenId. When two /mcp requests
+// both land inside the refresh-skew window they would otherwise present the SAME
+// upstream refresh token to the wiki concurrently; if the wiki rotates it on use,
+// the loser's token is revoked out from under it. Coalescing collapses them into a
+// single upstream refresh whose result both callers share. This guards proactive-
+// vs-proactive only. A proactive refresh racing a downstream /token refresh grant
+// for the same token is NOT coordinated here: beginRefreshRotation gates reuse of
+// the DOWNSTREAM refresh token on the /token path, but neither path locks the
+// UPSTREAM refresh token against the other, so both can still present it at once.
+// That race is pre-existing and left as accepted residual risk for the single-
+// process deployment; closing it needs a shared per-upstream-token refresh lock
+// held across both paths.
+const inFlightUpstreamRefresh = new Map<string, Promise<string>>();
+
+function coalesceUpstreamRefresh(id: string, run: () => Promise<string>): Promise<string> {
+	const existing = inFlightUpstreamRefresh.get(id);
+	if (existing) {
+		return existing;
+	}
+	const pending = run().finally(() => inFlightUpstreamRefresh.delete(id));
+	inFlightUpstreamRefresh.set(id, pending);
+	return pending;
+}
+
+// Performs the server-to-server upstream refresh, writes the rotated token back to
+// the store, and returns the fresh access token.
+async function performUpstreamRefresh(
+	upstreamTokenId: string,
+	currentRefreshToken: string,
+	pc: ProxyConfig,
+	store: ProxyStore,
+	refresh: RefreshFn,
+): Promise<string> {
+	const r = await refresh({
+		tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
+		refreshToken: currentRefreshToken,
+		clientId: pc.upstreamClientId,
+		clientSecret: pc.upstreamClientSecret,
+	});
+	store.updateUpstreamToken(upstreamTokenId, {
+		accessToken: r.access_token,
+		refreshToken: r.refresh_token ?? currentRefreshToken,
+		expiresAt: Date.now() + r.expires_in * 1000,
+	});
+	return r.access_token;
+}
+
 // Resolves a /mcp proxy JWT to the UPSTREAM wiki access token it stands for.
 // When the proxy is enabled the bearer is a proxy-minted JWT (aud=self), not a
 // wiki token, so mwn cannot use it directly: we verify the JWT, look up the
 // stored upstream token by its jti, and (when it is at/near expiry and a refresh
 // token exists) transparently refresh it server-to-server before returning.
 //
-// verifyAccessToken throws on an invalid/expired/mis-audienced JWT; the caller
-// (the /mcp handler) maps that throw to a 401 + WWW-Authenticate challenge.
+// A proactive refresh is a pre-expiry optimization, so its failure must not by
+// itself fail an otherwise-serviceable request: while the stored access token is
+// still valid we fall back to it regardless of why the refresh failed (a transient
+// wiki blip, or a concurrent refresh that already rotated the token). Only once the
+// token is genuinely expired does a refresh failure surface — as a retryable
+// UpstreamBearerError for a transient upstream failure, or a non-retryable one for
+// a dead refresh token. verifyAccessToken throws on an invalid/expired/mis-
+// audienced JWT; the caller maps that (and a missing upstream token) to a 401.
 export async function resolveUpstreamBearer(
 	proxyJwt: string,
 	pc: ProxyConfig,
@@ -273,22 +344,23 @@ export async function resolveUpstreamBearer(
 	if (!upstream) {
 		throw new Error('upstream token not found');
 	}
-	if (upstream.expiresAt <= Date.now() + UPSTREAM_REFRESH_SKEW_MS && upstream.refreshToken) {
-		const r = await refresh({
-			tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
-			refreshToken: upstream.refreshToken,
-			clientId: pc.upstreamClientId,
-			clientSecret: pc.upstreamClientSecret,
-		});
-		const updated = {
-			accessToken: r.access_token,
-			refreshToken: r.refresh_token ?? upstream.refreshToken,
-			expiresAt: Date.now() + r.expires_in * 1000,
-		};
-		store.updateUpstreamToken(upstreamTokenId, updated);
-		return updated.accessToken;
+	if (!(upstream.expiresAt <= Date.now() + UPSTREAM_REFRESH_SKEW_MS && upstream.refreshToken)) {
+		return upstream.accessToken;
 	}
-	return upstream.accessToken;
+	const currentRefreshToken = upstream.refreshToken;
+	try {
+		return await coalesceUpstreamRefresh(upstreamTokenId, () =>
+			performUpstreamRefresh(upstreamTokenId, currentRefreshToken, pc, store, refresh),
+		);
+	} catch (err) {
+		if (Date.now() < upstream.expiresAt) {
+			return upstream.accessToken;
+		}
+		throw new UpstreamBearerError(
+			classifyRefreshError(err) === 'retryable',
+			'upstream token refresh failed',
+		);
+	}
 }
 
 export interface McpPostHandlerOptions {
@@ -302,6 +374,9 @@ export interface McpPostHandlerOptions {
 	// unchanged.
 	getProxyConfig?: ProxyConfigGetter;
 	proxyStore?: ProxyStore;
+	// Injected for testing; production leaves it undefined so resolveUpstreamBearer
+	// uses the real server-to-server refresh.
+	refresh?: RefreshFn;
 	// The default wiki served by this transport. When that wiki is configured
 	// `private` (anonymous reads disabled upstream), a tokenless request is
 	// challenged with a connection-time 401 rather than served anonymously.
@@ -348,6 +423,21 @@ function emit401Challenge(req: Request, res: Response): void {
 	});
 }
 
+// Emitted when a proxy JWT is valid but its upstream token could not be refreshed
+// because of a transient upstream failure. Unlike emit401Challenge this carries NO
+// WWW-Authenticate header: the client should retry, not discard its session and
+// re-authenticate.
+function emit503Unavailable(res: Response): void {
+	res.status(503).json({
+		jsonrpc: '2.0',
+		error: {
+			code: -32000,
+			message: 'Upstream authorization temporarily unavailable. Please retry.',
+		},
+		id: null,
+	});
+}
+
 export function createMcpPostHandler(
 	sessions: SessionRegistry,
 	createServerFn: () => ReturnType<typeof createServer>,
@@ -359,6 +449,7 @@ export function createMcpPostHandler(
 		idleTimeoutMs = 0,
 		getProxyConfig,
 		proxyStore,
+		refresh,
 		defaultWikiKey,
 	} = options;
 	return async (req, res) => {
@@ -395,9 +486,16 @@ export function createMcpPostHandler(
 			// happens later in checkWikiCapability, not as a transport 401).
 			if (bearer) {
 				try {
-					resolvedBearer = await resolveUpstreamBearer(bearer, pc, proxyStore);
-				} catch {
-					emit401Challenge(req, res);
+					resolvedBearer = await resolveUpstreamBearer(bearer, pc, proxyStore, refresh);
+				} catch (err) {
+					// A transient upstream refresh failure is retryable: answer 503 without a
+					// re-auth challenge. Everything else (bad/expired JWT, dead refresh token)
+					// is a genuine auth failure: emit the 401 discovery challenge.
+					if (err instanceof UpstreamBearerError && err.retryable) {
+						emit503Unavailable(res);
+					} else {
+						emit401Challenge(req, res);
+					}
 					return;
 				}
 			} else {

--- a/tests/auth/oauthFlow.test.ts
+++ b/tests/auth/oauthFlow.test.ts
@@ -1,7 +1,12 @@
 // tests/auth/oauthFlow.test.ts
 import type { RequestHandler } from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
-import { exchangeCode, OAuthFlowError, refreshTokens } from '../../src/auth/oauthFlow.js';
+import {
+	classifyRefreshError,
+	exchangeCode,
+	OAuthFlowError,
+	refreshTokens,
+} from '../../src/auth/oauthFlow.js';
 import { startFakeAs, type FakeAsHandle } from '../helpers/fakeAuthorizationServer.js';
 
 let fakeAs: FakeAsHandle;
@@ -291,5 +296,27 @@ describe('confidential client secret', () => {
 			clientSecret: 'shh',
 		});
 		expect(ok.access_token).toBe('access-refreshed');
+	});
+});
+
+describe('classifyRefreshError', () => {
+	it('classifies a transient upstream failure as retryable', () => {
+		expect(classifyRefreshError(new OAuthFlowError('transient', 'wiki 503'))).toBe('retryable');
+	});
+
+	it('classifies a malformed upstream response as retryable', () => {
+		expect(classifyRefreshError(new OAuthFlowError('malformed', 'garbled'))).toBe('retryable');
+	});
+
+	it('classifies a rejected refresh token (invalid_grant) as dead', () => {
+		expect(classifyRefreshError(new OAuthFlowError('invalid_grant', 'expired'))).toBe('dead');
+	});
+
+	it('classifies a rejected client (invalid_client) as dead', () => {
+		expect(classifyRefreshError(new OAuthFlowError('invalid_client', 'bad client'))).toBe('dead');
+	});
+
+	it('classifies a non-OAuth error as dead', () => {
+		expect(classifyRefreshError(new Error('boom'))).toBe('dead');
 	});
 });

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../src/wikis/mwnProvider.js', () => ({
 }));
 
 import request from 'supertest';
+import type { RequestHandler } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
 	buildApp,
@@ -857,6 +858,175 @@ describe('operator redirect allowlist — end-to-end (config → route → handl
 		});
 		expect(authz.status).toBe(200);
 		expect(authz.text).toContain('an application on this device');
+	});
+});
+
+// Exercises the REAL proactive-refresh path on the /mcp connection: buildApp uses
+// the production refresh (defaultRefresh) against a live fake AS, so the full
+// oauthFlow.refreshTokens -> classifyRefreshError -> UpstreamBearerError chain runs
+// over HTTP — not through an injected refresh stub.
+describe('hosted OAuth proxy — upstream refresh on the /mcp path (e2e)', () => {
+	let fakeAs: FakeAsHandle | undefined;
+
+	beforeEach(() => {
+		vi.stubEnv('MCP_PUBLIC_URL', ISSUER);
+	});
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		await fakeAs?.close();
+		fakeAs = undefined;
+	});
+
+	// Mints normally on the auth-code grant but fails the refresh grant with a
+	// transient 503, standing in for a momentary wiki outage during the proactive
+	// refresh.
+	const refreshBlipsToken: RequestHandler = (req, res) => {
+		const grant = String(req.body.grant_type ?? '');
+		if (grant === 'authorization_code') {
+			res.json({
+				access_token: 'access-' + String(req.body.code),
+				refresh_token: 'refresh-' + String(req.body.code),
+				expires_in: 3600,
+				scope: 'edit',
+				token_type: 'Bearer',
+			});
+			return;
+		}
+		if (grant === 'refresh_token') {
+			res.status(503).end();
+			return;
+		}
+		res.status(400).json({ error: 'unsupported_grant_type' });
+	};
+
+	// Overrides the stored upstream token's expiry (leaving its tokens intact) so a
+	// subsequent /mcp call takes the proactive-refresh branch. Returns the stored
+	// upstream access token so a test can assert which token reaches the wiki API.
+	async function setUpstreamExpiry(
+		store: InMemoryProxyStore,
+		pc: ProxyConfig,
+		proxyAccessToken: string,
+		expiresAt: number,
+	): Promise<string> {
+		const { upstreamTokenId } = await verifyAccessToken(proxyAccessToken, pc);
+		const u = store.getUpstreamToken(upstreamTokenId);
+		if (!u) {
+			throw new Error('expected an upstream token in the store');
+		}
+		store.updateUpstreamToken(upstreamTokenId, {
+			accessToken: u.accessToken,
+			refreshToken: u.refreshToken,
+			expiresAt,
+		});
+		return u.accessToken;
+	}
+
+	// Pre-seeds a session whose fake transport calls the wiki action API with the
+	// runtime token resolved for the request, so a test can observe which bearer
+	// mwn would send upstream.
+	function seedApiCallingSession(
+		app: ReturnType<typeof buildApp>['app'],
+		sessions: SessionRegistry,
+	) {
+		const handleRequest = vi.fn(
+			async (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) => {
+				const runtimeToken = getRuntimeToken();
+				await fetch(`${fakeAs!.url}/w/api.php?action=query&meta=tokens`, {
+					headers: runtimeToken ? { Authorization: `Bearer ${runtimeToken}` } : {},
+				});
+				res.status(200).json({ ok: true });
+			},
+		);
+		sessions['sid-1'] = {
+			transport: {
+				sessionId: 'sid-1',
+				handleRequest,
+			} as unknown as SessionRegistry[string]['transport'],
+			activeRequests: 0,
+		};
+		return handleRequest;
+	}
+
+	const MCP_BODY = { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} };
+
+	it('answers 503 (retryable, no re-auth challenge) when an expired token cannot be refreshed', async () => {
+		fakeAs = await startFakeAs({ autoApproveAuthorize: true, token: refreshBlipsToken });
+		const store = new InMemoryProxyStore();
+		const pc = proxyConfig(fakeAs.url);
+		const { app } = buildApp(makeDeps(fakeAs.url, store, pc));
+		const result = await runHostedFlow({ app });
+		await setUpstreamExpiry(store, pc, result.accessToken, Date.now() - 1000);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${result.accessToken}`)
+			.send(MCP_BODY);
+
+		expect(res.status).toBe(503);
+		// A retryable failure must NOT tell the client to re-authenticate.
+		expect(res.headers['www-authenticate']).toBeUndefined();
+	});
+
+	it('serves the request with the still-valid upstream token when a proactive refresh blips', async () => {
+		fakeAs = await startFakeAs({
+			autoApproveAuthorize: true,
+			captureApi: true,
+			token: refreshBlipsToken,
+		});
+		const store = new InMemoryProxyStore();
+		const pc = proxyConfig(fakeAs.url);
+		const { app, sessions } = buildApp(makeDeps(fakeAs.url, store, pc));
+		const result = await runHostedFlow({ app });
+		// Inside the 30s skew but still valid: the refresh runs and blips, and the
+		// current token is still usable.
+		const upstreamAccess = await setUpstreamExpiry(
+			store,
+			pc,
+			result.accessToken,
+			Date.now() + 10_000,
+		);
+		const handleRequest = seedApiCallingSession(app, sessions);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${result.accessToken}`)
+			.send(MCP_BODY);
+
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(503);
+		expect(handleRequest).toHaveBeenCalledOnce();
+		// The wiki API saw the still-valid upstream token, not a re-auth.
+		expect(fakeAs.capturedApiBearers).toContain(upstreamAccess);
+	});
+
+	it('refreshes the upstream token server-to-server and the NEW token reaches the wiki API', async () => {
+		fakeAs = await startFakeAs({ autoApproveAuthorize: true, captureApi: true });
+		const store = new InMemoryProxyStore();
+		const pc = proxyConfig(fakeAs.url);
+		const { app, sessions } = buildApp(makeDeps(fakeAs.url, store, pc));
+		const result = await runHostedFlow({ app });
+		await setUpstreamExpiry(store, pc, result.accessToken, Date.now() + 10_000);
+		const handleRequest = seedApiCallingSession(app, sessions);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${result.accessToken}`)
+			.send(MCP_BODY);
+
+		expect(res.status).not.toBe(401);
+		expect(handleRequest).toHaveBeenCalledOnce();
+		// The default fake AS rotates on refresh, so the wiki API sees the refreshed
+		// token and the store now holds the rotated pair.
+		expect(fakeAs.capturedApiBearers).toContain('access-refreshed');
+		const { upstreamTokenId } = await verifyAccessToken(result.accessToken, pc);
+		expect(store.getUpstreamToken(upstreamTokenId)?.accessToken).toBe('access-refreshed');
+		expect(store.getUpstreamToken(upstreamTokenId)?.refreshToken).toBe('refresh-rotated');
 	});
 });
 

--- a/tests/transport/streamableHttp.proxyBearer.test.ts
+++ b/tests/transport/streamableHttp.proxyBearer.test.ts
@@ -40,7 +40,9 @@ import {
 	createMcpPostHandler,
 	type ProxyConfigGetter,
 	type SessionRegistry,
+	type McpPostHandlerOptions,
 } from '../../src/transport/streamableHttp.js';
+import { OAuthFlowError } from '../../src/auth/oauthFlow.js';
 import { InMemoryProxyStore } from '../../src/auth/authorizationServer/proxyStore.js';
 import { mintAccessToken } from '../../src/auth/authorizationServer/jwt.js';
 import type { ProxyConfig } from '../../src/auth/authorizationServer/proxyConfig.js';
@@ -129,6 +131,104 @@ describe('resolveUpstreamBearer', () => {
 		expect(await resolveUpstreamBearer(jwt, pc, store, refresh)).toBe('STILLGOOD');
 		expect(refresh).not.toHaveBeenCalled();
 	});
+
+	it('falls back to the still-valid token when a proactive refresh fails transiently', async () => {
+		const store = new InMemoryProxyStore();
+		// Inside the 30s refresh skew, but not yet expired: the proactive refresh runs,
+		// and when it blips the current token is still usable.
+		const id = store.putUpstreamToken({
+			accessToken: 'STILLGOOD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() + 10_000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('transient', 'wiki 503'));
+		expect(await resolveUpstreamBearer(jwt, pc, store, refresh)).toBe('STILLGOOD');
+		expect(refresh).toHaveBeenCalledOnce();
+		// The stored token is left intact for the next attempt.
+		expect(store.getUpstreamToken(id)?.accessToken).toBe('STILLGOOD');
+	});
+
+	it('throws a retryable error when an expired token cannot be refreshed transiently', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() - 1000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('transient', 'wiki 503'));
+		await expect(resolveUpstreamBearer(jwt, pc, store, refresh)).rejects.toMatchObject({
+			retryable: true,
+		});
+	});
+
+	it('throws a non-retryable error when an expired token refresh is rejected', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() - 1000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('invalid_grant', 'dead'));
+		await expect(resolveUpstreamBearer(jwt, pc, store, refresh)).rejects.toMatchObject({
+			retryable: false,
+		});
+	});
+
+	it('coalesces concurrent proactive refreshes into a single upstream call', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() - 1000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		// Slow upstream refresh so both callers are genuinely in flight at once.
+		const refresh = vi
+			.fn()
+			.mockImplementation(
+				() =>
+					new Promise((resolve) =>
+						setTimeout(
+							() => resolve({ access_token: 'NEW', refresh_token: 'WR2', expires_in: 3600 }),
+							15,
+						),
+					),
+			);
+		const [a, b] = await Promise.all([
+			resolveUpstreamBearer(jwt, pc, store, refresh),
+			resolveUpstreamBearer(jwt, pc, store, refresh),
+		]);
+		expect(a).toBe('NEW');
+		expect(b).toBe('NEW');
+		expect(refresh).toHaveBeenCalledOnce();
+	});
 });
 
 function fakeRegistry(wikis: Record<string, Partial<WikiConfig>>): WikiRegistry {
@@ -158,6 +258,7 @@ function buildMcpApp(
 	getProxyConfig: ProxyConfigGetter | undefined,
 	store: InMemoryProxyStore | undefined,
 	captured: { token?: string; seen: boolean },
+	refresh?: McpPostHandlerOptions['refresh'],
 ): Express {
 	const app = express();
 	app.use(express.json());
@@ -179,6 +280,7 @@ function buildMcpApp(
 			wikiRegistry: registry,
 			getProxyConfig,
 			proxyStore: store,
+			refresh,
 		}),
 	);
 	return app;
@@ -294,5 +396,101 @@ describe('POST /mcp proxy bearer rewire', () => {
 		expect(res.status).not.toBe(401);
 		expect(captured.seen).toBe(true);
 		expect(captured.token).toBe('raw-wiki-token');
+	});
+
+	it('returns 503 (not 401) when a proxy refresh fails transiently for an expired token', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() - 1000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('transient', 'wiki 503'));
+		const captured: { token?: string; seen: boolean } = { seen: false };
+		const app = buildMcpApp(fakeRegistry({ test: oauthWiki }), () => pc, store, captured, refresh);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${jwt}`)
+			.send(body);
+
+		expect(res.status).toBe(503);
+		// A 503 must NOT carry an invalid_token challenge, which would tell the client
+		// to throw away its session and re-authenticate for a transient upstream blip.
+		expect(res.headers['www-authenticate']).toBeUndefined();
+		expect(captured.seen).toBe(false);
+	});
+
+	it('returns 401 with a re-auth challenge when an expired token refresh is rejected as a dead credential', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() - 1000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('invalid_grant', 'dead'));
+		const captured: { token?: string; seen: boolean } = { seen: false };
+		const app = buildMcpApp(fakeRegistry({ test: oauthWiki }), () => pc, store, captured, refresh);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${jwt}`)
+			.send(body);
+
+		expect(res.status).toBe(401);
+		// A dead credential DOES carry the discovery challenge so the client re-signs-in.
+		const wwwAuth = res.headers['www-authenticate'];
+		expect(typeof wwwAuth).toBe('string');
+		expect(wwwAuth).toMatch(/error="invalid_token"/);
+		expect(captured.seen).toBe(false);
+	});
+
+	it('serves the request with the still-valid token when a proactive refresh fails transiently', async () => {
+		const store = new InMemoryProxyStore();
+		const id = store.putUpstreamToken({
+			accessToken: 'STILLGOOD',
+			refreshToken: 'WR',
+			expiresAt: Date.now() + 10_000,
+		});
+		const jwt = await mintAccessToken({
+			issuer: pc.issuer,
+			signingKey: pc.signingKey,
+			upstreamTokenId: id,
+			ttlMs: 60_000,
+			scopes: [],
+		});
+		const refresh = vi.fn().mockRejectedValue(new OAuthFlowError('transient', 'wiki 503'));
+		const captured: { token?: string; seen: boolean } = { seen: false };
+		const app = buildMcpApp(fakeRegistry({ test: oauthWiki }), () => pc, store, captured, refresh);
+
+		const res = await request(app)
+			.post('/mcp')
+			.set('Content-Type', 'application/json')
+			.set('mcp-session-id', 'sid-1')
+			.set('Authorization', `Bearer ${jwt}`)
+			.send(body);
+
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(503);
+		expect(captured.seen).toBe(true);
+		expect(captured.token).toBe('STILLGOOD');
 	});
 });


### PR DESCRIPTION
## Summary

The hosted OAuth proxy proactively refreshes a near-expiry upstream wiki token on the active `/mcp` connection (within a 30s skew), so the next wiki call uses a fresh token. Previously any failure of that refresh, including a transient wiki 5xx, was swallowed and turned into a `401 invalid_token` challenge, so a client that reads 401 as "re-authenticate" launched a full browser sign-in for a momentary blip. The downstream `/token` refresh grant already classified the same failure as a retryable 503, so the two paths disagreed. This aligns them.

## Behaviour change

- While the stored access token is still valid, a failed proactive refresh falls back to it, so the request succeeds transparently.
- Once the token is genuinely expired: a transient upstream failure returns `503 temporarily_unavailable` with no `WWW-Authenticate` header (retry, not re-auth); a rejected refresh token still returns the `401` discovery challenge.
- Concurrent `/mcp` requests that both trigger a proactive refresh now share one upstream refresh instead of racing and revoking each other's rotated refresh token.

## What changed

- `classifyRefreshError()` in `oauthFlow.ts` is now the single source of truth for retryable vs dead refresh failures; `token.ts` uses it, with behaviour unchanged.
- `resolveUpstreamBearer` gains the still-valid-token fallback, a typed `UpstreamBearerError`, and per-upstream-token coalescing; the `/mcp` handler maps the error to 503 vs 401.

## Testing

- Test-driven: unit and handler-level tests for the fallback, the 503/401 split, and coalescing.
- Three end-to-end tests drive the real refresh path over HTTP against a live fake authorization server (production refresh, no stub). The two bug-repro e2e tests were verified to fail against the pre-fix code.
- Full suite 1543 passing; `tsc`, `oxlint`, `oxfmt` clean.

## Known follow-up (out of scope)

A proactive refresh racing a downstream `/token` refresh grant for the same token is still uncoordinated: neither path locks the upstream refresh token against the other. This race is pre-existing (not introduced here) and left as accepted residual risk for the single-process deployment. Closing it needs a shared per-upstream-token refresh lock held across both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)