### PR TITLE
Clarify the hosted proxy single-instance requirement and multi-replica footgun

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -312,7 +312,10 @@ When in doubt, open your deployed site in a browser and log `window.location.ori
 
 These apply to the [hosted OAuth sign-in](#hosted-oauth-sign-in) setup:
 
-- **Single instance.** The proxy runs as a single instance: there is no shared store across replicas, so horizontal scaling and zero-downtime rolling deploys are not yet supported.
+- **Single instance only.** Run exactly one proxy process. All of its sign-in state — registered clients, stored MediaWiki tokens, and the in-flight sign-in handshakes (authorization transactions, one-time codes, and refresh-rotation guards) — is held in that process's memory and mirrored to a single local file (see [Proxy state persistence](#proxy-state-persistence)). Horizontal scaling and zero-downtime rolling deploys are not yet supported. Supporting more than one instance would need **both** a shared store for that state (replacing the per-process file) **and** session affinity, so every request from a client — including the two browser legs of a single sign-in — reaches the same instance.
+
+> [!WARNING]
+> Do not run more than one instance against a shared store file. There is no runtime guard against a mis-scaled deployment: each process keeps its own in-memory copy of the sign-in state and rewrites the entire encrypted file on every change, so the instances overwrite one another silently — sign-ins and client registrations are lost with no error logged.
 
 ### Proxy state persistence
 


### PR DESCRIPTION
## Summary

The `v1 limitations` note in the deployment guide said only that horizontal scaling "is not yet supported". This spells out **why** and **what breaks**, so an operator does not reach for a naive multi-replica deploy that fails silently.

The single-instance bullet now:
- explains that all proxy sign-in state (registered clients, stored MediaWiki tokens, and the in-flight sign-in handshakes — transactions, one-time codes, refresh-rotation guards) lives in one process's memory, mirrored to a single local file;
- states there is **no runtime guard** against a mis-scaled deployment;
- names the two things a multi-instance setup would require — a **shared store** and **session affinity** (so a client's requests, including the two browser legs of one sign-in, reach the same instance);
- warns that pointing multiple instances at one shared store file **silently** overwrites sign-ins and registrations with no error logged.

## Scope

Docs-only clarification of existing behaviour — no code, tool-surface, or env-var change, so no CHANGELOG/README update per AGENTS.md. Comes from the auth architecture review's backlog (the cheap, high-value half of the single-instance-hardening item; the `flock`-on-store-file half is deliberately left until horizontal distribution is actually on the table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)