### PR TITLE
Report a clear error and exit cleanly when the HTTP server can't bind its port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- The HTTP server now logs a clear message and exits cleanly when it cannot bind its port — already in use, or permission denied — instead of terminating with an uncaught exception and a raw stack trace.
 - OAuth clients that use a loopback callback on a variable port (including clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.
 - Hosted OAuth proxy: an upstream token refresh the wiki rejects with `invalid_client` (client authentication failed) is now reported as an authentication failure the client re-signs-in on, instead of a retryable "temporarily unavailable" that the client would loop on.
 - Hosted OAuth proxy: a momentary wiki outage while refreshing a near-expiry token on an active connection no longer forces the client to sign in again. The request now continues with the still-valid token, or gets a retryable response, instead of a sign-in challenge the client would act on for a transient blip. Concurrent requests that both trigger a refresh now share one upstream refresh rather than racing.

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -110,6 +110,29 @@ export function resolveMcpHostValidation(
 	return undefined;
 }
 
+// Handles a fatal error from app.listen — a failed bind (EADDRINUSE / EACCES) or
+// any other listen error. The 'error' event fires asynchronously after
+// startHttpServer() has returned, so index.ts's main().catch cannot catch it and,
+// with no listener registered, a net.Server 'error' event would surface as an
+// uncaught exception with a raw stack trace. Log a clear, actionable message and
+// terminate. onFatal is injectable so tests can assert the message without exiting
+// the test process.
+export function handleListenError(
+	err: NodeJS.ErrnoException,
+	host: string,
+	port: number,
+	onFatal: (code: number) => void = (code) => process.exit(code),
+): void {
+	if (err.code === 'EADDRINUSE') {
+		logger.error(`Cannot start HTTP server: ${host}:${port} is already in use.`);
+	} else if (err.code === 'EACCES') {
+		logger.error(`Cannot start HTTP server: permission denied binding ${host}:${port}.`);
+	} else {
+		logger.error(`HTTP server failed to start on ${host}:${port}: ${err.message}`);
+	}
+	onFatal(1);
+}
+
 export type SessionEntry = {
 	readonly transport: StreamableHTTPServerTransport;
 	idleTimer?: ReturnType<typeof setTimeout>;
@@ -1347,8 +1370,14 @@ export function startHttpServer(): void {
 	});
 
 	const httpServer = app.listen(port, host, () => {
-		logger.info(`MCP Streamable HTTP Server listening on ${host}:${port}`);
+		// Express fires this callback even when the bind failed (e.g. EADDRINUSE), where
+		// httpServer.listening is false. Guard the success log so a failed start does not
+		// print a misleading "listening" line just before handleListenError reports it.
+		if (httpServer.listening) {
+			logger.info(`MCP Streamable HTTP Server listening on ${host}:${port}`);
+		}
 	});
+	httpServer.on('error', (err) => handleListenError(err, host, port));
 
 	registerShutdownHandlers({
 		transport: 'http',

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -8,6 +8,7 @@ import {
 	createMcpPostHandler,
 	createSessionRequestHandler,
 	extractBearerToken,
+	handleListenError,
 	markSessionActive,
 	markSessionIdle,
 	payloadTooLargeHandler,
@@ -16,6 +17,42 @@ import {
 	withRequestContext,
 } from '../../src/transport/streamableHttp.js';
 import { getRuntimeToken, getSessionId } from '../../src/transport/requestContext.js';
+import { logger } from '../../src/runtime/logger.js';
+
+describe('handleListenError', () => {
+	function listenErr(code: string): NodeJS.ErrnoException {
+		return Object.assign(new Error(`${code} boom`), { code });
+	}
+
+	it('reports EADDRINUSE with the address and exits non-zero', () => {
+		const onFatal = vi.fn();
+		const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+		handleListenError(listenErr('EADDRINUSE'), '127.0.0.1', 3000, onFatal);
+		expect(spy.mock.calls[0][0]).toContain('127.0.0.1:3000');
+		expect(spy.mock.calls[0][0]).toMatch(/already in use/i);
+		expect(onFatal).toHaveBeenCalledWith(1);
+		spy.mockRestore();
+	});
+
+	it('reports EACCES as a permission error and exits non-zero', () => {
+		const onFatal = vi.fn();
+		const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+		handleListenError(listenErr('EACCES'), '0.0.0.0', 80, onFatal);
+		expect(spy.mock.calls[0][0]).toContain('0.0.0.0:80');
+		expect(spy.mock.calls[0][0]).toMatch(/permission/i);
+		expect(onFatal).toHaveBeenCalledWith(1);
+		spy.mockRestore();
+	});
+
+	it('reports an unexpected listen error generically and exits non-zero', () => {
+		const onFatal = vi.fn();
+		const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+		handleListenError(listenErr('EPIPE'), '127.0.0.1', 3000, onFatal);
+		expect(spy.mock.calls[0][0]).toContain('EPIPE boom');
+		expect(onFatal).toHaveBeenCalledWith(1);
+		spy.mockRestore();
+	});
+});
 
 function req(authorization: string | undefined): Request {
 	return { headers: { authorization } } as unknown as Request;


### PR DESCRIPTION
## Summary

`app.listen` emits its `'error'` event asynchronously — after `startHttpServer()` has already returned — so `index.ts`'s `main().catch` never sees it. With no `'error'` listener, a bind failure (`EADDRINUSE`, `EACCES`) surfaced as an **uncaught exception with a raw stack trace**.

This attaches an error handler so a bind failure produces a clear, actionable message and a clean `exit(1)`:

```
Cannot start HTTP server: 127.0.0.1:3000 is already in use.
```

## What changed

- New `handleListenError(err, host, port, onFatal?)` in `streamableHttp.ts`: logs `EADDRINUSE` / `EACCES` / generic distinctly and terminates. `onFatal` is injectable so it is unit-testable without exiting the test process. Wired via `httpServer.on('error', …)` in `startHttpServer()`.
- Guard the success log: Express fires the `app.listen` callback **even when the bind failed** (`httpServer.listening` is `false` then), which would otherwise print a misleading `listening on …` line right before the failure. A bind failure now logs only the clear error.

This is the deferred follow-up from the boot-extraction (#466), now unblocked since `startHttpServer()` is on master.

## Testing

- Test-driven unit tests for `handleListenError` (EADDRINUSE / EACCES / generic → correct message + `onFatal(1)`).
- Real two-servers-on-one-port smoke: the second process exits `1`, logs only `Cannot start HTTP server: … is already in use.`, and prints **no** stack trace and **no** misleading `listening` line; a successfully-bound server still logs `listening`.
- Full gate (`fmt:check`, `lint`, `tsc`, tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)