### PR TITLE
Reject unsafe redirects in CIMD documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- Hosted OAuth proxy: a client that identifies by a vendor-hosted URL (Client ID Metadata Document) is now rejected if any redirect URI in its document is not an `https`, loopback-`http`, or custom-scheme (for example `vscode://`) URL — notably a cleartext `http` redirect to a non-loopback host, which a network attacker on that path could intercept the authorization code at.
 - The HTTP server now logs a clear message and exits cleanly when it cannot bind its port — already in use, or permission denied — instead of terminating with an uncaught exception and a raw stack trace.
 - OAuth clients that use a loopback callback on a variable port (including clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.
 - Hosted OAuth proxy: an upstream token refresh the wiki rejects with `invalid_client` (client authentication failed) is now reported as an authentication failure the client re-signs-in on, instead of a retryable "temporarily unavailable" that the client would loop on.

--- a/src/auth/authorizationServer/cimd.ts
+++ b/src/auth/authorizationServer/cimd.ts
@@ -1,4 +1,5 @@
 import type { ClientRecord } from './proxyStore.js';
+import { isLoopbackHost } from './redirectPolicy.js';
 import type { CimdFetchResult } from '../../transport/cimdFetch.js';
 
 export class CimdValidationError extends Error {
@@ -110,6 +111,24 @@ export interface CimdDocument {
 	redirect_uris: string[];
 }
 
+// Each CIMD redirect_uri must be an https URL, a loopback http URL (RFC 8252:
+// http://127.0.0.1 / localhost / [::1], any port), or a custom app scheme (e.g.
+// vscode:// or com.example.app:/…). Anything else is rejected: a cleartext http
+// redirect to a NON-loopback host is interceptable by a network attacker on the
+// redirect's path, and a string that is not a parseable absolute URL is refused
+// fail-closed (every legitimate redirect form parses). The curated CIMD host allowlist
+// is the trust anchor, and MCP_OAUTH_ALLOWED_REDIRECTS does not gate CIMD clients, so
+// this is the redirect check they get.
+function isDisallowedCimdRedirect(uri: string): boolean {
+	let u: URL;
+	try {
+		u = new URL(uri);
+	} catch {
+		return true; // not a parseable absolute URL — fail closed
+	}
+	return u.protocol === 'http:' && !isLoopbackHost(u.hostname);
+}
+
 // Validates a parsed metadata document against the MCP required-field set plus the
 // IETF self-reference rule. Self-reference is a SIMPLE STRING comparison with NO
 // normalization: `https://h/c` and `https://h:443/c` are distinct. The token auth
@@ -134,7 +153,14 @@ export function validateCimdDocument(clientId: string, raw: unknown): CimdDocume
 	) {
 		throw new CimdValidationError('document is missing a non-empty redirect_uris array');
 	}
-	return { client_id: clientId, client_name: d.client_name, redirect_uris: [...d.redirect_uris] };
+	const redirectUris: string[] = [...d.redirect_uris];
+	const disallowed = redirectUris.find(isDisallowedCimdRedirect);
+	if (disallowed !== undefined) {
+		throw new CimdValidationError(
+			`redirect_uri must be a parseable https, loopback http, or custom-scheme URL; rejected "${disallowed}"`,
+		);
+	}
+	return { client_id: clientId, client_name: d.client_name, redirect_uris: redirectUris };
 }
 
 // A CIMD client is a public (PKCE) client. It is never stored in ProxyStore, so

--- a/tests/auth/authorizationServer/cimd.test.ts
+++ b/tests/auth/authorizationServer/cimd.test.ts
@@ -108,6 +108,41 @@ describe('validateCimdDocument', () => {
 	])('rejects %#', (doc) =>
 		expect(() => validateCimdDocument(URL_ID, doc)).toThrow(CimdValidationError),
 	);
+
+	it.each([
+		['http://evil.example/cb'], // cleartext http, non-loopback
+		['HTTP://EVIL.EXAMPLE/cb'], // scheme/host are case-folded before the check
+		['http://user@evil.example/cb'], // userinfo does not change the host
+		['http://127.0.0.1.evil.example/cb'], // deceptive: starts with a loopback literal but is NOT loopback
+		['//evil.example/cb'], // protocol-relative: not a parseable absolute URL
+		['not-a-url'], // unparseable
+		[''], // empty
+	])('rejects a disallowed redirect %s', (uri) => {
+		expect(() => validateCimdDocument(URL_ID, { ...goodDoc, redirect_uris: [uri] })).toThrow(
+			CimdValidationError,
+		);
+	});
+
+	it('rejects when ANY redirect_uri is disallowed', () => {
+		expect(() =>
+			validateCimdDocument(URL_ID, {
+				...goodDoc,
+				redirect_uris: ['https://vscode.dev/redirect', 'http://evil.example/cb'],
+			}),
+		).toThrow(CimdValidationError);
+	});
+
+	it.each([
+		['https://vscode.dev/redirect'],
+		['https://app.example.com:8443/cb'],
+		['http://127.0.0.1:8080/cb'],
+		['http://localhost/cb'],
+		['http://[::1]:1234/cb'],
+		['vscode://vscode.dev/callback'],
+		['com.example.app:/oauth2redirect'], // RFC 8252 private-use scheme
+	])('accepts %s (https, loopback http, or custom scheme)', (uri) => {
+		expect(() => validateCimdDocument(URL_ID, { ...goodDoc, redirect_uris: [uri] })).not.toThrow();
+	});
 });
 
 describe('synthesizeClientRecord', () => {

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -538,6 +538,40 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 		expect(fetchCalls).toBe(0);
 		expect(rejected.text).toMatch(/not a trusted CIMD host|evil\.example/);
 	});
+
+	it('CIMD: rejects a document that lists a cleartext http non-loopback redirect', async () => {
+		const store = new InMemoryProxyStore();
+		const pc = proxyConfig('https://test.example');
+		const clientId = 'https://vscode.dev/oauth/client-metadata.json';
+		const badRedirect = 'http://evil.example/cb';
+		// Allowlisted host, but the fetched document declares a cleartext http redirect to
+		// a non-loopback host — validateCimdDocument rejects it, so resolve fails and
+		// /authorize renders the 400 auth-error page. No code is ever minted.
+		const fetcher = async (url: string): Promise<CimdFetchResult> => ({
+			status: 200,
+			body: JSON.stringify({
+				client_id: url,
+				client_name: 'VS Code',
+				redirect_uris: [badRedirect],
+			}),
+			cacheControl: null,
+		});
+		const cimdResolver = new CimdResolver((h) => h === 'vscode.dev', fetcher);
+		const { app } = buildApp({ ...makeDeps('https://test.example', store, pc), cimdResolver });
+
+		const res = await request(app).get('/mcp/authorize').query({
+			response_type: 'code',
+			client_id: clientId,
+			code_challenge: 'abc123',
+			code_challenge_method: 'S256',
+			redirect_uri: badRedirect,
+			state: 's',
+			resource: ISSUER,
+		});
+		expect(res.status).toBe(400);
+		expect(res.headers['content-type']).toMatch(/html/);
+		expect(res.text).toMatch(/Authorization failed/);
+	});
 });
 
 describe('private wiki — connection-time auth challenge', () => {


### PR DESCRIPTION
## Summary

A client that identifies by a vendor-hosted URL (a **Client ID Metadata Document**, CIMD) supplies its own `redirect_uris` in that document. `MCP_OAUTH_ALLOWED_REDIRECTS` does **not** gate CIMD clients — the curated CIMD host allowlist (`MCP_OAUTH_CIMD_ALLOWED_HOSTS` + shipped first-party hosts) is their trust anchor. `validateCimdDocument` checked only that `redirect_uris` was a non-empty array of strings, so an allowlisted host whose document listed a **cleartext `http` redirect to a non-loopback host** would have it honored — a target a network attacker on that path could intercept the authorization code at.

## What changed

`validateCimdDocument` now requires each `redirect_uri` to be one of:
- an `https` URL,
- a loopback `http` URL (RFC 8252: `127.0.0.1` / `localhost` / `[::1]`, any port — reusing `isLoopbackHost`), or
- a custom app scheme (e.g. `vscode://`, `com.example.app:/…`).

Everything else is rejected: cleartext `http` to a non-loopback host, and any string that is not a parseable absolute URL (fail-closed — every legitimate redirect form parses). No shipped first-party client (vscode.dev, chatgpt.com, claude.ai, zed.dev) is affected. `deployment.md` documents that the CIMD host set grants redirect authority independent of the redirect allowlist.

## Testing

- Test-driven. The reject matrix pins the security-load-bearing cases: `http://evil.example`, uppercase scheme, userinfo, the **deceptive `http://127.0.0.1.evil.example`** (starts with a loopback literal but is not loopback), protocol-relative `//evil.example`, and unparseable/empty. Accept cases cover https (incl. nonstandard port), all three loopback hosts, and custom schemes (incl. the RFC 8252 private-use form).
- An e2e test drives the real `/authorize` route: a bad-redirect CIMD doc yields a **400** auth-error page with no code minted.
- Independently verified 14 adversarial URL forms against WHATWG `URL`; full gate (`fmt:check`, `lint`, `tsc`, tests) green.

## Review

Reviewed by a code-review agent (verdict: merge). Folded in its recommendations: pinned the deceptive-subdomain regression test, and moved from "leave unparseable alone" (which produced a 500 for a trusted host's garbage redirect) to rejecting unparseable at validation (clean 400, fail-closed) — safe because every legitimate redirect form parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)