### PR TITLE
Extract the session registry and dedupe request-scheme resolution

### DIFF
--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -35,7 +35,7 @@ export type AuthorizePlan =
  * a SEPARATE upstream PKCE verifier and produces the upstream authorize URL.
  *
  * The transaction binds the downstream client's PKCE challenge + state + scopes
- * to the proxy's own verifier so the callback (Task 8) can complete both legs.
+ * to the proxy's own verifier so the /mcp/oauth/callback handler can complete both legs.
  *
  * `_wikiName` is the human-readable sitename, threaded through for symmetry with
  * the Express glue (which uses it for the consent page); the planner itself does

--- a/src/transport/sessionRegistry.ts
+++ b/src/transport/sessionRegistry.ts
@@ -1,0 +1,69 @@
+import type { RequestHandler } from 'express';
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+export type SessionEntry = {
+	readonly transport: StreamableHTTPServerTransport;
+	idleTimer?: ReturnType<typeof setTimeout>;
+	activeRequests: number;
+};
+
+export type SessionRegistry = { [sessionId: string]: SessionEntry };
+
+export interface InFlightCounter {
+	readonly middleware: RequestHandler;
+	readonly count: () => number;
+}
+
+export function createInFlightCounter(): InFlightCounter {
+	let n = 0;
+	const middleware: RequestHandler = (_req, res, next) => {
+		n++;
+		res.on('close', () => {
+			n--;
+		});
+		next();
+	};
+	return { middleware, count: () => n };
+}
+
+// Marks a session as having an in-flight request or open response stream:
+// increments the active-request count and cancels any pending idle expiry.
+// Pair every call with markSessionIdle on the response's 'close' event.
+export function markSessionActive(sessions: SessionRegistry, sessionId: string): void {
+	const entry = sessions[sessionId];
+	if (!entry) {
+		return;
+	}
+	entry.activeRequests += 1;
+	if (entry.idleTimer) {
+		clearTimeout(entry.idleTimer);
+		entry.idleTimer = undefined;
+	}
+}
+
+// Marks one request/stream finished. When the session has no remaining
+// in-flight requests, arms the idle-expiry timer; when it elapses the transport
+// is closed and its onclose handler removes the registry entry. A timeout of 0
+// disables expiry. Because this runs on response 'close', a long-lived GET SSE
+// stream keeps the session active for as long as the client holds it open.
+export function markSessionIdle(
+	sessions: SessionRegistry,
+	sessionId: string,
+	idleTimeoutMs: number,
+): void {
+	const entry = sessions[sessionId];
+	if (!entry) {
+		return;
+	}
+	entry.activeRequests = Math.max(0, entry.activeRequests - 1);
+	if (entry.activeRequests > 0 || idleTimeoutMs <= 0) {
+		return;
+	}
+	if (entry.idleTimer) {
+		clearTimeout(entry.idleTimer);
+	}
+	entry.idleTimer = setTimeout(() => {
+		void sessions[sessionId]?.transport.close();
+	}, idleTimeoutMs);
+	entry.idleTimer.unref();
+}

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -179,10 +179,7 @@ export function createOAuthProtectedResourceHandler(deps: {
 				res.status(503).json({ error: 'discovery_failed' });
 				return;
 			}
-			const protoHeader = req.headers['x-forwarded-proto'];
-			const proto = typeof protoHeader === 'string' ? protoHeader.split(',')[0]?.trim() : undefined;
-			const requestProto =
-				proto === 'https' || proto === 'http' ? proto : req.secure ? 'https' : 'http';
+			const requestProto = resolveRequestProto(req);
 			const proxyConfig = deps.getProxyConfig?.() ?? null;
 			const doc = buildProtectedResource({
 				wikis,
@@ -200,6 +197,14 @@ export function createOAuthProtectedResourceHandler(deps: {
 			next(err);
 		}
 	};
+}
+
+// Resolves the request's scheme, honouring a trusted reverse proxy's
+// x-forwarded-proto (first value) and falling back to the socket's own security.
+function resolveRequestProto(req: Request): 'http' | 'https' {
+	const protoHeader = req.headers['x-forwarded-proto'];
+	const proto = typeof protoHeader === 'string' ? protoHeader.split(',')[0]?.trim() : undefined;
+	return proto === 'https' || proto === 'http' ? proto : req.secure ? 'https' : 'http';
 }
 
 // A wiki needs auth when it is OAuth-only with no usable static fallback.
@@ -362,10 +367,7 @@ function setTxnCookie(res: Response, upstreamLocation: string): void {
 }
 
 function emit401Challenge(req: Request, res: Response): void {
-	const protoHeader = req.headers['x-forwarded-proto'];
-	const proto = typeof protoHeader === 'string' ? protoHeader.split(',')[0]?.trim() : undefined;
-	const requestProto =
-		proto === 'https' || proto === 'http' ? proto : req.secure ? 'https' : 'http';
+	const requestProto = resolveRequestProto(req);
 	const base = resolvePublicBase(req.headers.host ?? undefined, requestProto);
 	// The protected-resource document is served at the ORIGIN root (RFC 9728), not
 	// under MCP_PUBLIC_URL's path segment. Point resource_metadata at the origin so

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -25,6 +25,13 @@ import {
 	setProxyStoreStatsProvider,
 } from '../runtime/metrics.js';
 import { withRequestContext } from './requestContext.js';
+import {
+	createInFlightCounter,
+	markSessionActive,
+	markSessionIdle,
+	type SessionRegistry,
+	type InFlightCounter,
+} from './sessionRegistry.js';
 
 export { withRequestContext } from './requestContext.js';
 import { loadConfigFromFile, type WikiConfig } from '../config/loadConfig.js';
@@ -131,73 +138,6 @@ export function handleListenError(
 		logger.error(`HTTP server failed to start on ${host}:${port}: ${err.message}`);
 	}
 	onFatal(1);
-}
-
-export type SessionEntry = {
-	readonly transport: StreamableHTTPServerTransport;
-	idleTimer?: ReturnType<typeof setTimeout>;
-	activeRequests: number;
-};
-
-export type SessionRegistry = { [sessionId: string]: SessionEntry };
-
-export interface InFlightCounter {
-	readonly middleware: RequestHandler;
-	readonly count: () => number;
-}
-
-export function createInFlightCounter(): InFlightCounter {
-	let n = 0;
-	const middleware: RequestHandler = (_req, res, next) => {
-		n++;
-		res.on('close', () => {
-			n--;
-		});
-		next();
-	};
-	return { middleware, count: () => n };
-}
-
-// Marks a session as having an in-flight request or open response stream:
-// increments the active-request count and cancels any pending idle expiry.
-// Pair every call with markSessionIdle on the response's 'close' event.
-export function markSessionActive(sessions: SessionRegistry, sessionId: string): void {
-	const entry = sessions[sessionId];
-	if (!entry) {
-		return;
-	}
-	entry.activeRequests += 1;
-	if (entry.idleTimer) {
-		clearTimeout(entry.idleTimer);
-		entry.idleTimer = undefined;
-	}
-}
-
-// Marks one request/stream finished. When the session has no remaining
-// in-flight requests, arms the idle-expiry timer; when it elapses the transport
-// is closed and its onclose handler removes the registry entry. A timeout of 0
-// disables expiry. Because this runs on response 'close', a long-lived GET SSE
-// stream keeps the session active for as long as the client holds it open.
-export function markSessionIdle(
-	sessions: SessionRegistry,
-	sessionId: string,
-	idleTimeoutMs: number,
-): void {
-	const entry = sessions[sessionId];
-	if (!entry) {
-		return;
-	}
-	entry.activeRequests = Math.max(0, entry.activeRequests - 1);
-	if (entry.activeRequests > 0 || idleTimeoutMs <= 0) {
-		return;
-	}
-	if (entry.idleTimer) {
-		clearTimeout(entry.idleTimer);
-	}
-	entry.idleTimer = setTimeout(() => {
-		void sessions[sessionId]?.transport.close();
-	}, idleTimeoutMs);
-	entry.idleTimer.unref();
 }
 
 // Returns the active hosted-OAuth-proxy config, or null when the proxy is

--- a/tests/transport/streamableHttp.oauth.test.ts
+++ b/tests/transport/streamableHttp.oauth.test.ts
@@ -6,8 +6,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
 	createOAuthProtectedResourceHandler,
 	createMcpPostHandler,
-	type SessionRegistry,
 } from '../../src/transport/streamableHttp.js';
+import type { SessionRegistry } from '../../src/transport/sessionRegistry.js';
 import type { WikiRegistry } from '../../src/wikis/wikiRegistry.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
 import { _resetMetadataCacheForTesting } from '../../src/auth/metadata.js';

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -7,8 +7,8 @@ import {
 	buildApp,
 	resolveUpstreamBearer,
 	type BuildAppDeps,
-	type SessionRegistry,
 } from '../../src/transport/streamableHttp.js';
+import type { SessionRegistry } from '../../src/transport/sessionRegistry.js';
 import { createAppState } from '../../src/wikis/state.js';
 import { InMemoryProxyStore } from '../../src/auth/authorizationServer/proxyStore.js';
 import { CimdResolver } from '../../src/auth/authorizationServer/cimd.js';

--- a/tests/transport/streamableHttp.proxyBearer.test.ts
+++ b/tests/transport/streamableHttp.proxyBearer.test.ts
@@ -7,9 +7,9 @@ import {
 	resolveUpstreamBearer,
 	createMcpPostHandler,
 	type ProxyConfigGetter,
-	type SessionRegistry,
 	type McpPostHandlerOptions,
 } from '../../src/transport/streamableHttp.js';
+import type { SessionRegistry } from '../../src/transport/sessionRegistry.js';
 import { OAuthFlowError } from '../../src/auth/oauthFlow.js';
 import { InMemoryProxyStore } from '../../src/auth/authorizationServer/proxyStore.js';
 import { mintAccessToken } from '../../src/auth/authorizationServer/jwt.js';

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -4,18 +4,20 @@ import express, { type Express, type Request } from 'express';
 import request from 'supertest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-	createInFlightCounter,
 	createMcpPostHandler,
 	createSessionRequestHandler,
 	extractBearerToken,
 	handleListenError,
-	markSessionActive,
-	markSessionIdle,
 	payloadTooLargeHandler,
 	resolveMcpHostValidation,
-	type SessionRegistry,
 	withRequestContext,
 } from '../../src/transport/streamableHttp.js';
+import {
+	createInFlightCounter,
+	markSessionActive,
+	markSessionIdle,
+	type SessionRegistry,
+} from '../../src/transport/sessionRegistry.js';
 import { getRuntimeToken, getSessionId } from '../../src/transport/requestContext.js';
 import { logger } from '../../src/runtime/logger.js';
 


### PR DESCRIPTION
## Commits

**Extract the MCP session registry into `sessionRegistry.ts`** — moves `SessionEntry` / `SessionRegistry`, `InFlightCounter` / `createInFlightCounter`, and `markSessionActive` / `markSessionIdle` into a self-contained module. Pure code move; the four transport test suites that used these symbols import them from the new module. `shutdown.ts` was unaffected (it has its own `ShutdownSessionRegistry`).

**Deduplicate request-scheme resolution; drop a stale plan-step comment** — the `x-forwarded-proto` resolution was copy-pasted verbatim in the protected-resource handler and the 401 challenge (a real drift hazard); extracted into `resolveRequestProto(req)`. Also replaced `authorize.ts`'s internal "Task 8" plan reference with the real handler name.

## Testing

Behaviour-preserving, so the existing suite is the safety net: full suite green, `tsc` / `oxlint` / `oxfmt` clean. No tool-surface, env-var, or behaviour change, so no CHANGELOG/README update per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)