### PR TITLE
Deduplicate the MediaWiki OAuth2 endpoint URLs behind a shared helper

### DIFF
--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ProxyConfig } from './proxyConfig.js';
 import type { ClientRecord, ProxyStore } from './proxyStore.js';
 import { randomVerifier, s256 } from '../pkce.js';
+import { mwOauth2AuthorizeEndpoint } from '../mwOauth2Endpoints.js';
 import { redirectUriMatches } from './redirectPolicy.js';
 
 export interface AuthorizeQuery {
@@ -98,7 +99,7 @@ export function planAuthorize(
 		proxyVerifier,
 	});
 
-	const u = new URL(`${pc.authorizeBase}${pc.scriptpath}/rest.php/oauth2/authorize`);
+	const u = new URL(mwOauth2AuthorizeEndpoint(pc.authorizeBase, pc.scriptpath));
 	u.searchParams.set('response_type', 'code');
 	u.searchParams.set('client_id', pc.upstreamClientId);
 	u.searchParams.set('redirect_uri', pc.callbackUrl);

--- a/src/auth/authorizationServer/callback.ts
+++ b/src/auth/authorizationServer/callback.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ProxyConfig } from './proxyConfig.js';
 import type { ProxyStore } from './proxyStore.js';
 import { exchangeCode as defaultExchange } from '../oauthFlow.js';
+import { mwOauth2TokenEndpoint } from '../mwOauth2Endpoints.js';
 
 type ExchangeFn = typeof defaultExchange;
 
@@ -87,7 +88,7 @@ export async function handleCallback(
 		// uses tokenExchangeBase (the internal service URL), distinct from the
 		// public authorizeBase the browser was redirected to.
 		tokens = await exchange({
-			tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
+			tokenEndpoint: mwOauth2TokenEndpoint(pc.tokenExchangeBase, pc.scriptpath),
 			code: q.code,
 			redirectUri: pc.callbackUrl,
 			clientId: pc.upstreamClientId,

--- a/src/auth/authorizationServer/token.ts
+++ b/src/auth/authorizationServer/token.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { ProxyConfig } from './proxyConfig.js';
 import type { ProxyStore } from './proxyStore.js';
 import { s256 } from '../pkce.js';
+import { mwOauth2TokenEndpoint } from '../mwOauth2Endpoints.js';
 import { mintAccessToken, mintRefreshToken, verifyRefreshToken } from './jwt.js';
 import { refreshTokens as defaultRefresh, classifyRefreshError } from '../oauthFlow.js';
 
@@ -88,7 +89,7 @@ export async function handleToken(
 			// Server-to-server on the INTERNAL tokenExchangeBase, exactly as the
 			// /oauth/callback exchange does — distinct from the public authorizeBase.
 			refreshed = await refresh({
-				tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
+				tokenEndpoint: mwOauth2TokenEndpoint(pc.tokenExchangeBase, pc.scriptpath),
 				refreshToken: upstream.refreshToken,
 				clientId: pc.upstreamClientId,
 				clientSecret: pc.upstreamClientSecret,

--- a/src/auth/metadata.ts
+++ b/src/auth/metadata.ts
@@ -1,5 +1,6 @@
 // src/auth/metadata.ts
 import { logger } from '../runtime/logger.js';
+import { mwOauth2AuthorizeEndpoint, mwOauth2TokenEndpoint } from './mwOauth2Endpoints.js';
 
 export interface AsMetadata {
 	issuer: string;
@@ -74,8 +75,8 @@ async function doFetch(wikiKey: string, wiki: WikiSlice): Promise<AsMetadata> {
 	// Both probes failed or returned malformed docs — synthesise from conventions.
 	const synthesized: AsMetadata = {
 		issuer: wiki.server,
-		authorization_endpoint: `${wiki.server}${wiki.scriptpath}/rest.php/oauth2/authorize`,
-		token_endpoint: `${wiki.server}${wiki.scriptpath}/rest.php/oauth2/access_token`,
+		authorization_endpoint: mwOauth2AuthorizeEndpoint(wiki.server, wiki.scriptpath),
+		token_endpoint: mwOauth2TokenEndpoint(wiki.server, wiki.scriptpath),
 		source: 'synthesized',
 		synthesized: true,
 	};

--- a/src/auth/mwOauth2Endpoints.ts
+++ b/src/auth/mwOauth2Endpoints.ts
@@ -1,0 +1,13 @@
+// MediaWiki's Extension:OAuth exposes its OAuth2 endpoints under
+// `<base><scriptpath>/rest.php/oauth2/...`. These helpers are the single source of
+// truth for those paths so the proxy (tokenExchangeBase / authorizeBase) and the
+// client-side discovery fallback (wiki.server) build identical URLs. `base` and
+// `scriptpath` are caller-supplied because they differ per call site.
+
+export function mwOauth2TokenEndpoint(base: string, scriptpath: string): string {
+	return `${base}${scriptpath}/rest.php/oauth2/access_token`;
+}
+
+export function mwOauth2AuthorizeEndpoint(base: string, scriptpath: string): string {
+	return `${base}${scriptpath}/rest.php/oauth2/authorize`;
+}

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -53,6 +53,7 @@ import { buildRedirectPolicy } from '../auth/authorizationServer/redirectPolicy.
 import { buildCimdHostPredicate, CimdResolver } from '../auth/authorizationServer/cimd.js';
 import { fetchCimdDocument } from './cimdFetch.js';
 import { verifyAccessToken } from '../auth/authorizationServer/jwt.js';
+import { mwOauth2TokenEndpoint } from '../auth/mwOauth2Endpoints.js';
 import { createAppState, type AppState } from '../wikis/state.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
@@ -250,7 +251,7 @@ async function performUpstreamRefresh(
 	refresh: RefreshFn,
 ): Promise<string> {
 	const r = await refresh({
-		tokenEndpoint: `${pc.tokenExchangeBase}${pc.scriptpath}/rest.php/oauth2/access_token`,
+		tokenEndpoint: mwOauth2TokenEndpoint(pc.tokenExchangeBase, pc.scriptpath),
 		refreshToken: currentRefreshToken,
 		clientId: pc.upstreamClientId,
 		clientSecret: pc.upstreamClientSecret,

--- a/tests/auth/mwOauth2Endpoints.test.ts
+++ b/tests/auth/mwOauth2Endpoints.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+	mwOauth2AuthorizeEndpoint,
+	mwOauth2TokenEndpoint,
+} from '../../src/auth/mwOauth2Endpoints.js';
+
+describe('mwOauth2Endpoints', () => {
+	it('builds the access_token endpoint from base + scriptpath', () => {
+		expect(mwOauth2TokenEndpoint('https://wiki.example', '/w')).toBe(
+			'https://wiki.example/w/rest.php/oauth2/access_token',
+		);
+	});
+
+	it('builds the authorize endpoint from base + scriptpath', () => {
+		expect(mwOauth2AuthorizeEndpoint('http://mediawiki.svc:8080', '/w')).toBe(
+			'http://mediawiki.svc:8080/w/rest.php/oauth2/authorize',
+		);
+	});
+
+	it('handles a root scriptpath', () => {
+		expect(mwOauth2TokenEndpoint('https://wiki.example', '')).toBe(
+			'https://wiki.example/rest.php/oauth2/access_token',
+		);
+		expect(mwOauth2AuthorizeEndpoint('https://wiki.example', '')).toBe(
+			'https://wiki.example/rest.php/oauth2/authorize',
+		);
+	});
+});

--- a/tests/transport/streamableHttp.proxyBearer.test.ts
+++ b/tests/transport/streamableHttp.proxyBearer.test.ts
@@ -79,6 +79,14 @@ describe('resolveUpstreamBearer', () => {
 		expect(store.getUpstreamToken(id)?.accessToken).toBe('NEW');
 		expect(store.getUpstreamToken(id)?.refreshToken).toBe('WR2');
 		expect(refresh).toHaveBeenCalledOnce();
+		// Pin the upstream token endpoint: the proactive-refresh path builds it from
+		// tokenExchangeBase + scriptpath, and this is the only one of the shared
+		// mwOauth2TokenEndpoint call sites otherwise not asserted by URL.
+		expect(refresh).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tokenEndpoint: 'http://mediawiki.svc:80/w/rest.php/oauth2/access_token',
+			}),
+		);
 	});
 
 	it('does not refresh a still-valid token', async () => {


### PR DESCRIPTION
## What

Extension:OAuth exposes its OAuth2 endpoints at `<base><scriptpath>/rest.php/oauth2/access_token` and `.../authorize`. That template literal was hand-built at six call sites:

- `authorizationServer/token.ts` — server-to-server refresh
- `authorizationServer/callback.ts` — upstream code exchange
- `transport/streamableHttp.ts` — proactive `/mcp` refresh
- `authorizationServer/authorize.ts` — upstream authorize URL
- `auth/metadata.ts` (×2) — synthesized discovery fallback (authorize + token)

A path change or typo therefore had to land identically in six places.

This adds `mwOauth2TokenEndpoint(base, scriptpath)` and `mwOauth2AuthorizeEndpoint(base, scriptpath)` in `src/auth/mwOauth2Endpoints.ts` as the single source of truth, and routes every site through them. `base` stays a parameter because the sites legitimately differ (`tokenExchangeBase` / `authorizeBase` / `wiki.server`), so no inverted proxy↔client dependency is introduced.

The RFC 8414 *pathed well-known* discovery probe (`…/.well-known/oauth-authorization-server${scriptpath}/rest.php/oauth2`, `metadata.ts`) is a structurally different URL and keeps its own literal — folding it through an endpoint helper would force a semantically wrong "base".

## Why

Item 7 on the auth architecture-debt backlog: maintainer legibility / single-source-of-truth. No behaviour change.

## Testing

- Byte-identical output at every call site — the existing URL assertions in the token / callback / authorize / metadata suites are the safety net and stay green.
- New `tests/auth/mwOauth2Endpoints.test.ts` pins the two helper outputs (including a root scriptpath).
- Full gate: `tsc`, oxlint, oxfmt check, 1572 tests, build — all green.

Pure-internal refactor: no tool surface or user-visible behaviour changes, so no README / CHANGELOG entry per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)