### PR TITLE
Split the auth-shape classifiers out of transport into runtime/

### DIFF
--- a/src/runtime/authShape.ts
+++ b/src/runtime/authShape.ts
@@ -1,0 +1,35 @@
+import type { WikiConfig } from '../config/loadConfig.js';
+import { isCredentialConfigured } from '../config/loadConfig.js';
+
+// Pure classification of how the server authenticates to its wikis, derived from
+// config alone. A lower-layer primitive: consumed by runtime/ (banner, wiki
+// capability) and transport/ (the startup bearer guard, streamableHttp) alike, so
+// it lives here rather than in transport to keep those callers pointing down.
+
+export function hasStaticCredentials(wiki: WikiConfig): boolean {
+	if (isCredentialConfigured(wiki.token)) {
+		return true;
+	}
+	return isCredentialConfigured(wiki.username) && isCredentialConfigured(wiki.password);
+}
+
+export type AuthShape = 'anonymous' | 'static-credential' | 'bearer-passthrough' | 'oauth-proxy';
+export type Transport = 'stdio' | 'http';
+
+export function classifyAuthShape(
+	wikis: Readonly<Record<string, WikiConfig>>,
+	transport: Transport,
+	proxyEnabled = false,
+): AuthShape {
+	const anyStatic = Object.values(wikis).some(hasStaticCredentials);
+	if (anyStatic) {
+		return 'static-credential';
+	}
+	if (transport !== 'http') {
+		return 'anonymous';
+	}
+	// When the hosted OAuth proxy is active this server is itself the
+	// authorization server (minting per-user tokens), not a plain
+	// bearer-passthrough that forwards a client-supplied token verbatim.
+	return proxyEnabled ? 'oauth-proxy' : 'bearer-passthrough';
+}

--- a/src/runtime/banner.ts
+++ b/src/runtime/banner.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 import { logger } from './logger.js';
-import { classifyAuthShape } from '../transport/bearerGuard.js';
+import { classifyAuthShape } from './authShape.js';
 import type { WikiRegistry } from '../wikis/wikiRegistry.js';
 import type { ActiveWiki } from '../wikis/activeWiki.js';
 import type { UploadDirs } from '../wikis/uploadDirs.js';

--- a/src/runtime/wikiCapability.ts
+++ b/src/runtime/wikiCapability.ts
@@ -3,7 +3,7 @@ import type { ToolContext } from './context.js';
 import type { ExtensionPack } from '../tools/extensions/types.js';
 import { extensionPacks } from '../tools/extensions/index.js';
 import { getRuntimeToken } from './requestContext.js';
-import { hasStaticCredentials } from '../transport/bearerGuard.js';
+import { hasStaticCredentials } from './authShape.js';
 
 const CORE_WRITE_TOOL_NAMES: readonly string[] = [
 	'create-page',

--- a/src/transport/bearerGuard.ts
+++ b/src/transport/bearerGuard.ts
@@ -1,5 +1,5 @@
 import type { WikiConfig } from '../config/loadConfig.js';
-import { isCredentialConfigured } from '../config/loadConfig.js';
+import { hasStaticCredentials } from '../runtime/authShape.js';
 
 export interface BearerGuardEnv {
 	MCP_ALLOW_STATIC_FALLBACK?: string;
@@ -9,13 +9,6 @@ export type BearerGuardResult =
 	| { readonly kind: 'ok' }
 	| { readonly kind: 'override'; readonly wikis: readonly string[] }
 	| { readonly kind: 'block'; readonly wikis: readonly string[] };
-
-export function hasStaticCredentials(wiki: WikiConfig): boolean {
-	if (isCredentialConfigured(wiki.token)) {
-		return true;
-	}
-	return isCredentialConfigured(wiki.username) && isCredentialConfigured(wiki.password);
-}
 
 export function evaluateBearerGuard(
 	wikis: Readonly<Record<string, WikiConfig>>,
@@ -32,25 +25,4 @@ export function evaluateBearerGuard(
 		return { kind: 'override', wikis: offenders };
 	}
 	return { kind: 'block', wikis: offenders };
-}
-
-export type AuthShape = 'anonymous' | 'static-credential' | 'bearer-passthrough' | 'oauth-proxy';
-export type Transport = 'stdio' | 'http';
-
-export function classifyAuthShape(
-	wikis: Readonly<Record<string, WikiConfig>>,
-	transport: Transport,
-	proxyEnabled = false,
-): AuthShape {
-	const anyStatic = Object.values(wikis).some(hasStaticCredentials);
-	if (anyStatic) {
-		return 'static-credential';
-	}
-	if (transport !== 'http') {
-		return 'anonymous';
-	}
-	// When the hosted OAuth proxy is active this server is itself the
-	// authorization server (minting per-user tokens), not a plain
-	// bearer-passthrough that forwards a client-supplied token verbatim.
-	return proxyEnabled ? 'oauth-proxy' : 'bearer-passthrough';
 }

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -13,7 +13,8 @@ import {
 } from '@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { evaluateBearerGuard, hasStaticCredentials } from './bearerGuard.js';
+import { evaluateBearerGuard } from './bearerGuard.js';
+import { hasStaticCredentials } from '../runtime/authShape.js';
 import { LOCALHOST_HOSTS, resolveHttpConfig } from './httpConfig.js';
 import { logger } from '../runtime/logger.js';
 import {

--- a/tests/runtime/authShape.test.ts
+++ b/tests/runtime/authShape.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { classifyAuthShape, hasStaticCredentials } from '../../src/runtime/authShape.js';
+import type { WikiConfig } from '../../src/config/loadConfig.js';
+
+function wiki(overrides: Partial<WikiConfig> = {}): WikiConfig {
+	return {
+		sitename: 'Example',
+		server: 'https://example.org',
+		articlepath: '/wiki',
+		scriptpath: '/w',
+		...overrides,
+	};
+}
+
+describe('hasStaticCredentials', () => {
+	it('is false for a wiki with no credential fields', () => {
+		expect(hasStaticCredentials(wiki())).toBe(false);
+	});
+
+	it.each([null, ''])('is false when token is %p', (value) => {
+		expect(hasStaticCredentials(wiki({ token: value }))).toBe(false);
+	});
+
+	it('is true when token is a non-empty string', () => {
+		expect(hasStaticCredentials(wiki({ token: 'abc' }))).toBe(true);
+	});
+
+	it('is true when both username and password are non-empty strings', () => {
+		expect(hasStaticCredentials(wiki({ username: 'u', password: 'p' }))).toBe(true);
+	});
+
+	it('is false when only username is set', () => {
+		expect(hasStaticCredentials(wiki({ username: 'u' }))).toBe(false);
+	});
+
+	it('is false when only password is set', () => {
+		expect(hasStaticCredentials(wiki({ password: 'p' }))).toBe(false);
+	});
+
+	it('is false when username or password is empty string', () => {
+		expect(hasStaticCredentials(wiki({ username: '', password: 'p' }))).toBe(false);
+		expect(hasStaticCredentials(wiki({ username: 'u', password: '' }))).toBe(false);
+	});
+
+	it('is true when token and bot-password fields are all set', () => {
+		expect(hasStaticCredentials(wiki({ token: 't', username: 'u', password: 'p' }))).toBe(true);
+	});
+
+	it('is true when token is an ExecSecret object', () => {
+		const execToken = { exec: { command: 'op', args: ['read', 'x'] } };
+		expect(hasStaticCredentials(wiki({ token: execToken }))).toBe(true);
+	});
+
+	it('is true when username and password are both ExecSecret objects', () => {
+		const execUser = { exec: { command: 'op', args: ['read', 'user'] } };
+		const execPass = { exec: { command: 'op', args: ['read', 'pass'] } };
+		expect(hasStaticCredentials(wiki({ username: execUser, password: execPass }))).toBe(true);
+	});
+});
+
+describe('classifyAuthShape', () => {
+	const baseWiki: WikiConfig = {
+		sitename: 'X',
+		server: 'https://x',
+		articlepath: '/wiki',
+		scriptpath: '/w',
+	};
+
+	it('returns static-credential when any wiki has a token', () => {
+		const wikis = { a: { ...baseWiki, token: 't' } };
+		expect(classifyAuthShape(wikis, 'http')).toBe('static-credential');
+		expect(classifyAuthShape(wikis, 'stdio')).toBe('static-credential');
+	});
+
+	it('returns static-credential when any wiki has username and password', () => {
+		const wikis = { a: { ...baseWiki, username: 'u', password: 'p' } };
+		expect(classifyAuthShape(wikis, 'http')).toBe('static-credential');
+	});
+
+	it('returns bearer-passthrough on http when no static creds', () => {
+		const wikis = { a: baseWiki };
+		expect(classifyAuthShape(wikis, 'http')).toBe('bearer-passthrough');
+	});
+
+	it('returns anonymous on stdio when no static creds', () => {
+		const wikis = { a: baseWiki };
+		expect(classifyAuthShape(wikis, 'stdio')).toBe('anonymous');
+	});
+
+	it('returns oauth-proxy on http when the hosted proxy is enabled', () => {
+		const wikis = { a: baseWiki };
+		expect(classifyAuthShape(wikis, 'http', true)).toBe('oauth-proxy');
+	});
+
+	it('static credentials take precedence over the proxy flag', () => {
+		const wikis = { a: { ...baseWiki, token: 't' } };
+		expect(classifyAuthShape(wikis, 'http', true)).toBe('static-credential');
+	});
+
+	it('proxy flag is ignored on stdio', () => {
+		const wikis = { a: baseWiki };
+		expect(classifyAuthShape(wikis, 'stdio', true)).toBe('anonymous');
+	});
+
+	it('is unaffected by partial credentials (username only or password only)', () => {
+		const wikisU = { a: { ...baseWiki, username: 'u' } };
+		const wikisP = { a: { ...baseWiki, password: 'p' } };
+		expect(classifyAuthShape(wikisU, 'http')).toBe('bearer-passthrough');
+		expect(classifyAuthShape(wikisP, 'http')).toBe('bearer-passthrough');
+	});
+});

--- a/tests/transport/bearerGuard.test.ts
+++ b/tests/transport/bearerGuard.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-	evaluateBearerGuard,
-	hasStaticCredentials,
-	classifyAuthShape,
-} from '../../src/transport/bearerGuard.js';
+import { evaluateBearerGuard } from '../../src/transport/bearerGuard.js';
 import type { WikiConfig } from '../../src/config/loadConfig.js';
 
 function wiki(overrides: Partial<WikiConfig> = {}): WikiConfig {
@@ -15,52 +11,6 @@ function wiki(overrides: Partial<WikiConfig> = {}): WikiConfig {
 		...overrides,
 	};
 }
-
-describe('hasStaticCredentials', () => {
-	it('is false for a wiki with no credential fields', () => {
-		expect(hasStaticCredentials(wiki())).toBe(false);
-	});
-
-	it.each([null, ''])('is false when token is %p', (value) => {
-		expect(hasStaticCredentials(wiki({ token: value }))).toBe(false);
-	});
-
-	it('is true when token is a non-empty string', () => {
-		expect(hasStaticCredentials(wiki({ token: 'abc' }))).toBe(true);
-	});
-
-	it('is true when both username and password are non-empty strings', () => {
-		expect(hasStaticCredentials(wiki({ username: 'u', password: 'p' }))).toBe(true);
-	});
-
-	it('is false when only username is set', () => {
-		expect(hasStaticCredentials(wiki({ username: 'u' }))).toBe(false);
-	});
-
-	it('is false when only password is set', () => {
-		expect(hasStaticCredentials(wiki({ password: 'p' }))).toBe(false);
-	});
-
-	it('is false when username or password is empty string', () => {
-		expect(hasStaticCredentials(wiki({ username: '', password: 'p' }))).toBe(false);
-		expect(hasStaticCredentials(wiki({ username: 'u', password: '' }))).toBe(false);
-	});
-
-	it('is true when token and bot-password fields are all set', () => {
-		expect(hasStaticCredentials(wiki({ token: 't', username: 'u', password: 'p' }))).toBe(true);
-	});
-
-	it('is true when token is an ExecSecret object', () => {
-		const execToken = { exec: { command: 'op', args: ['read', 'x'] } };
-		expect(hasStaticCredentials(wiki({ token: execToken }))).toBe(true);
-	});
-
-	it('is true when username and password are both ExecSecret objects', () => {
-		const execUser = { exec: { command: 'op', args: ['read', 'user'] } };
-		const execPass = { exec: { command: 'op', args: ['read', 'pass'] } };
-		expect(hasStaticCredentials(wiki({ username: execUser, password: execPass }))).toBe(true);
-	});
-});
 
 describe('evaluateBearerGuard', () => {
 	it('returns ok when there are no wikis', () => {
@@ -133,57 +83,5 @@ describe('evaluateBearerGuard', () => {
 			kind: 'block',
 			wikis: ['a'],
 		});
-	});
-});
-
-describe('classifyAuthShape', () => {
-	const baseWiki: WikiConfig = {
-		sitename: 'X',
-		server: 'https://x',
-		articlepath: '/wiki',
-		scriptpath: '/w',
-	};
-
-	it('returns static-credential when any wiki has a token', () => {
-		const wikis = { a: { ...baseWiki, token: 't' } };
-		expect(classifyAuthShape(wikis, 'http')).toBe('static-credential');
-		expect(classifyAuthShape(wikis, 'stdio')).toBe('static-credential');
-	});
-
-	it('returns static-credential when any wiki has username and password', () => {
-		const wikis = { a: { ...baseWiki, username: 'u', password: 'p' } };
-		expect(classifyAuthShape(wikis, 'http')).toBe('static-credential');
-	});
-
-	it('returns bearer-passthrough on http when no static creds', () => {
-		const wikis = { a: baseWiki };
-		expect(classifyAuthShape(wikis, 'http')).toBe('bearer-passthrough');
-	});
-
-	it('returns anonymous on stdio when no static creds', () => {
-		const wikis = { a: baseWiki };
-		expect(classifyAuthShape(wikis, 'stdio')).toBe('anonymous');
-	});
-
-	it('returns oauth-proxy on http when the hosted proxy is enabled', () => {
-		const wikis = { a: baseWiki };
-		expect(classifyAuthShape(wikis, 'http', true)).toBe('oauth-proxy');
-	});
-
-	it('static credentials take precedence over the proxy flag', () => {
-		const wikis = { a: { ...baseWiki, token: 't' } };
-		expect(classifyAuthShape(wikis, 'http', true)).toBe('static-credential');
-	});
-
-	it('proxy flag is ignored on stdio', () => {
-		const wikis = { a: baseWiki };
-		expect(classifyAuthShape(wikis, 'stdio', true)).toBe('anonymous');
-	});
-
-	it('is unaffected by partial credentials (username only or password only)', () => {
-		const wikisU = { a: { ...baseWiki, username: 'u' } };
-		const wikisP = { a: { ...baseWiki, password: 'p' } };
-		expect(classifyAuthShape(wikisU, 'http')).toBe('bearer-passthrough');
-		expect(classifyAuthShape(wikisP, 'http')).toBe('bearer-passthrough');
 	});
 });


### PR DESCRIPTION
Follow-up lead surfaced by the #476 review: two more `runtime → transport` inverted import edges, this time for auth-shape classification rather than request context.

## What

`hasStaticCredentials` and `classifyAuthShape` (plus the `AuthShape`/`Transport` types) are pure, config-derived classification with no request or transport state — but they lived in `src/transport/bearerGuard.ts`, so `runtime/banner.ts` and `runtime/wikiCapability.ts` imported *up* into transport to reach them.

- Moved them to a new `src/runtime/authShape.ts`, a lower-layer primitive.
- `transport/bearerGuard.ts` keeps only the boot-time guard (`evaluateBearerGuard` + `BearerGuardEnv`/`BearerGuardResult`) and now imports `hasStaticCredentials` *down* from `runtime/authShape`.
- Repointed `banner.ts`, `wikiCapability.ts`, and split `streamableHttp.ts`'s import (`evaluateBearerGuard` from `./bearerGuard.js`, `hasStaticCredentials` from `../runtime/authShape.js`).
- Split the test file to mirror the source tree: `hasStaticCredentials` + `classifyAuthShape` describes → new `tests/runtime/authShape.test.ts`; `evaluateBearerGuard` stays in `tests/transport/bearerGuard.test.ts`.

After this, the entire `runtime → transport` inverted-edge class is gone (zero edges).

## Testing

Pure move, no behaviour change. Verified:

- 1572 tests green (27 original bearerGuard cases preserved exactly once across the split); `tsc`, oxlint, oxfmt, build all pass.
- Boot smoke: the startup banner's `auth_shape` comes straight from the moved `classifyAuthShape` — http-proxy boot logs `oauth-proxy`, stdio boot logs `anonymous` (two distinct classifier branches, both correct at runtime).
- Adversarially verified from four independent angles (completeness / byte-level move fidelity / layering + cycle / test preservation) — all pass, no cycle, byte-identical relocation.

Pure-internal refactor: no tool surface or user-visible behaviour change, so no README / CHANGELOG entry per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)