### PR TITLE
Clean up documentation per the documentation conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Create a `config.json` file to configure wiki connections. Use the `config.examp
 }
 ```
 
-**Internal vs public address.** The `server` you configure is the address the MCP server uses to reach the wiki's API — it may be an internal hostname (e.g. `http://mediawiki` in Docker). URLs handed back to the AI (page links, the `server` field in `list-wikis` and `mcp://wikis` resources) are built from the wiki's own public address, so internal hostnames don't leak into links. If a wiki can't be reached, links fall back to the configured `server`.
+**Internal vs public address.** The `server` you configure may be an internal hostname (e.g. `http://mediawiki` in Docker); URLs handed back to the caller are built from the wiki's public address, so internal hostnames don't leak into links. See [docs/configuration.md — per-wiki fields](docs/configuration.md#per-wiki-fields).
 
 For the full field reference, env-var substitution, secret sources, change tags, upload directories, and authentication options, see [docs/configuration.md](docs/configuration.md).
 
@@ -305,7 +305,7 @@ Defaults are safe for single-user use. Before exposing the HTTP transport to oth
 - **Trust the proxy, not the header.** The server forwards any `Authorization: Bearer` header straight to MediaWiki — authentication is the reverse proxy's job. Terminate TLS there, and don't expose the MCP port directly on an untrusted network. See [docs/deployment.md — security checklist](docs/deployment.md#security-checklist).
 - **Pair `MCP_BIND` with `MCP_ALLOWED_HOSTS` and `MCP_ALLOWED_ORIGINS`.** The HTTP transport binds to `127.0.0.1` by default. When you open it up with `MCP_BIND=0.0.0.0`, set `MCP_ALLOWED_HOSTS` to the hostnames your proxy forwards and `MCP_ALLOWED_ORIGINS` to the browser origins allowed to call the server — these block DNS-rebinding and cross-origin attacks respectively.
 - **Uploads are opt-in.** `upload-file` is disabled until you list allowed directories in `uploadDirs` or `MCP_UPLOAD_DIRS`. See [docs/configuration.md — upload directories](docs/configuration.md#upload-directories).
-- **Internal destinations need `MCP_TRUSTED_HOSTS`.** Outbound fetches — the anonymous siteinfo probe, wiki discovery, `*-file-from-url` — are SSRF-guarded: a destination resolving to a private or loopback address is refused. To deliberately run against an internal host — e.g. a Docker-network alias like `mediawiki.svc` that bypasses your public proxy — list it in `MCP_TRUSTED_HOSTS` to exempt it from the public-IP check. The host is still resolved and pinned, and the guard stays on for every other destination. This is the **outbound** counterpart to the inbound `MCP_ALLOWED_HOSTS` (Host-header) check — the two are unrelated despite the similar names.
+- **Internal destinations need `MCP_TRUSTED_HOSTS`.** Outbound fetches are SSRF-guarded: a destination resolving to a private or loopback address (e.g. a Docker-network alias like `mediawiki.svc`) is refused until you list its host in `MCP_TRUSTED_HOSTS`. See [docs/deployment.md — outbound SSRF guard](docs/deployment.md#outbound-ssrf-guard).
 
 Report a vulnerability via GitHub's [security advisory form](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/security/advisories/new) — full policy in [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The Cargo tools (`cargo-query`, `cargo-list-tables`, `cargo-describe-table`) cal
 <details>
 <summary><b>Install in Claude Desktop</b></summary>
 
-Follow the [guide](https://modelcontextprotocol.io/quickstart/user), use following configuration:
+Follow the [guide](https://modelcontextprotocol.io/quickstart/user) and use the following configuration:
 
 ```json
 {
@@ -212,7 +212,7 @@ code --add-mcp '{"name":"mediawiki-mcp-server","command":"npx","args":["@profess
 
 [![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=mediawiki-mcp-server&config=eyJjb21tYW5kIjoibnB4IEBwcm9mZXNzaW9uYWwtd2lraS9tZWRpYXdpa2ktbWNwLXNlcnZlckBsYXRlc3QifQ%3D%3D)
 
-Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, use `command` type with the command `npx @professional-wiki/mediawiki-mcp-server`. You can also verify config or add command like arguments via clicking `Edit`.
+Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name it to your liking, and use `command` type with the command `npx @professional-wiki/mediawiki-mcp-server`.
 
 ```json
 {
@@ -234,7 +234,7 @@ Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, u
 <details>
 <summary><b>Install in Windsurf</b></summary>
 
-Follow the [guide](https://docs.windsurf.com/windsurf/cascade/mcp), use following configuration:
+Follow the [guide](https://docs.windsurf.com/windsurf/cascade/mcp) and use the following configuration:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ Covers configuration topics beyond the basic `config.json` shape documented in [
 
 ## Environment variable substitution
 
-Config values support `${VAR_NAME}` syntax for referencing environment variables. This allows you to keep secrets out of your `config.json` file.
+Config values support `${VAR_NAME}` syntax for referencing environment variables, keeping secrets out of `config.json`.
 
 ```json
 {
@@ -54,7 +54,7 @@ Config values support `${VAR_NAME}` syntax for referencing environment variables
 
 If a referenced variable is not set:
 
-- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable. This surfaces authentication problems up front, not as confusing failures later.
+- **Secret fields** (`token`, `username`, `password`): the server exits at startup with an error naming the wiki, the field, and the missing variable.
 - **Non-secret fields**: the `${VAR_NAME}` text is kept as-is.
 
 ## Secret sources
@@ -134,12 +134,9 @@ Enable uploads by setting one or both of:
 }
 ```
 
-Entries from both sources are merged. Each entry is canonicalised with `fs.realpathSync` at startup — if an entry doesn't exist or isn't an absolute path, the server fails to start with a specific error.
+Entries from both sources are merged. Each entry is canonicalised with `fs.realpathSync` at startup — if an entry doesn't exist or isn't an absolute path, the server fails to start with a specific error. The allowlist is fixed for the lifetime of the process.
 
 At upload time, the supplied `filepath` must be absolute, must exist, and its symlink-resolved form must sit inside one of the configured directories. Symlinks are followed *before* the allowlist check, so a symlink pointing outside the allowlist is rejected. `..` traversal is also rejected. The resolved (canonical) path — not the caller-supplied one — is what gets uploaded.
-
-> [!NOTE]
-> Dynamic client-supplied allow-listing via the MCP Roots protocol is a planned follow-up; today the allowlist is static at startup.
 
 ## OAuth (browser-based)
 
@@ -179,13 +176,11 @@ If your wiki doesn't have an OAuth consumer set up, omit `oauth2ClientId`. Stati
 
 #### Optional environment variables
 
-- `MCP_OAUTH_CREDENTIALS_FILE` — store the credentials file somewhere other than the default path.
-- `MCP_OAUTH_NO_BROWSER` — set to `1` in headless or CI environments. The server prints the consent URL to stderr instead of trying to open a browser.
-- `MCP_PUBLIC_URL` — set when running the HTTP transport behind a reverse proxy that rewrites the request `Host`. Used in the OAuth discovery document and the `WWW-Authenticate` header so an OAuth-aware client can find its way back.
+`MCP_OAUTH_CREDENTIALS_FILE` (move the credentials file) and `MCP_OAUTH_NO_BROWSER` (print the consent URL instead of opening a browser) are in the [README environment-variable table](../README.md#environment-variables). When the HTTP transport runs behind a reverse proxy that rewrites the request `Host`, also set `MCP_PUBLIC_URL` so the OAuth discovery document and the `WWW-Authenticate` header advertise the public URL.
 
 #### HTTP transport behaviour
 
-When you run the HTTP transport with at least one OAuth-enabled wiki, the server publishes `/.well-known/oauth-protected-resource` so OAuth-aware MCP clients (Claude Desktop, mcp-remote, Claude Code) can discover the wikis and run the consent flow themselves. The discovery document lists the authorization server of every OAuth-configured wiki, so a client can pick the one it needs. Wikis without `oauth2ClientId` are unaffected.
+When you run the HTTP transport with at least one OAuth-enabled wiki, the server publishes `/.well-known/oauth-protected-resource` so OAuth-aware MCP clients can discover the wikis and run the consent flow themselves. The discovery document lists the authorization server of every OAuth-configured wiki, so a client can pick the one it needs. Wikis without `oauth2ClientId` are unaffected.
 
 A bearer-less request gets `401` with a `WWW-Authenticate` header pointing at the discovery document only when no configured wiki is usable without a token. A deployment that mixes OAuth and non-OAuth wikis still lets tokenless clients connect and use the wikis that don't require authentication.
 
@@ -197,14 +192,7 @@ If `MCP_ALLOW_STATIC_FALLBACK=true` and the wiki has static credentials, bearer-
 
 #### Hosted OAuth proxy environment variables
 
-Setting these on the HTTP transport turns the server into an OAuth Authorization Server in front of one MediaWiki consumer, so OAuth-aware MCP clients sign in with no manual token handling. See [deployment.md — hosted OAuth sign-in](deployment.md#hosted-oauth-sign-in) for the full picture; the knobs are:
-
-- `MCP_PUBLIC_URL` — the proxy's public issuer/base, set to the public `/mcp` URL (e.g. `https://wiki.example.org/mcp`). Beyond its discovery role above, this is also the AS identity from which `/authorize`, `/token`, `/register`, and the fixed `/oauth/callback` are derived. **Required** to enable the proxy.
-- `MCP_OAUTH_JWT_SIGNING_KEY` — a secret of **at least 32 characters** the proxy signs its issued JWTs and consent cookies with. **Required** to enable the proxy. Keep it **fixed**: changing it invalidates every issued token and logs all users out.
-- `MCP_OAUTH_TOKEN_TTL` — lifetime of a proxy-minted access JWT. Default `55m`; must be shorter than the upstream 30-day refresh window.
-- `MCP_OAUTH_CONSENT_TTL` — lifetime of the signed consent cookie that lets a returning user skip the consent page. Default `30d`.
-
-`MCP_OAUTH_TOKEN_TTL` and `MCP_OAUTH_CONSENT_TTL` accept a number with an optional `s`/`m`/`h`/`d` unit (e.g. `55m`, `1h`, `30d`); a bare number is seconds. The proxy activates only when `MCP_TRANSPORT=http`, both required variables are set, and the default wiki has an `oauth2ClientId` and `oauth2ClientSecret`.
+Setting `MCP_PUBLIC_URL` and `MCP_OAUTH_JWT_SIGNING_KEY` on the HTTP transport turns the server into an OAuth Authorization Server in front of one MediaWiki consumer, so OAuth-aware MCP clients sign in with no manual token handling. The variables and setup steps are in [deployment.md — hosted OAuth sign-in](deployment.md#hosted-oauth-sign-in).
 
 ### For wiki admins: registering the OAuth consumer
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,8 @@ Covers configuration topics beyond the basic `config.json` shape documented in [
 | `readOnly` | No | When `true`, hides the six 🔐 write tools from `tools/list` while this wiki is active. Pairs with `allowWikiManagement: false` for a [hosted read-only endpoint](deployment.md). Default: `false` |
 | `tags` | No | Change tag(s) to apply to every write (string or array). The tag must exist and be active at `Special:Tags` — see [change tags](#change-tags-tags) for details. |
 
+URLs returned to the caller — page links, and the `server` field in `list-wikis` and `mcp://wikis` resources — are built from the wiki's public address, so an internal `server` hostname does not leak into links. If the wiki cannot be reached, they fall back to the configured `server`.
+
 ## Environment variable substitution
 
 Config values support `${VAR_NAME}` syntax for referencing environment variables, keeping secrets out of `config.json`.
@@ -180,15 +182,7 @@ If your wiki doesn't have an OAuth consumer set up, omit `oauth2ClientId`. Stati
 
 #### HTTP transport behaviour
 
-When you run the HTTP transport with at least one OAuth-enabled wiki, the server publishes `/.well-known/oauth-protected-resource` so OAuth-aware MCP clients can discover the wikis and run the consent flow themselves. The discovery document lists the authorization server of every OAuth-configured wiki, so a client can pick the one it needs. Wikis without `oauth2ClientId` are unaffected.
-
-A bearer-less request gets `401` with a `WWW-Authenticate` header pointing at the discovery document only when no configured wiki is usable without a token. A deployment that mixes OAuth and non-OAuth wikis still lets tokenless clients connect and use the wikis that don't require authentication.
-
-An HTTP client sends the `Authorization: Bearer` token appropriate to each call's target wiki. There is no per-session bearer pin: one session can carry tokens for wikis on different authorization servers, with a different token per request. The MCP session id is the session capability, so run the HTTP transport behind TLS. Idle sessions are closed after `MCP_SESSION_IDLE_TIMEOUT`, bounding how long a leaked session id stays usable.
-
-Use `list-wikis` to retrieve the wiki-to-authorization-server mapping — it reports each OAuth wiki's `authorizationServer`.
-
-If `MCP_ALLOW_STATIC_FALLBACK=true` and the wiki has static credentials, bearer-less requests fall back to those credentials instead of returning 401. Use this only if you specifically want a hybrid where OAuth-aware clients sign in per user but unauthenticated callers still get service through a shared identity.
+Over the HTTP transport, OAuth runs through discovery and `401` challenges instead of a local browser flow, and each request carries the bearer for its target wiki. That behaviour is in [deployment.md — per-request bearer token](deployment.md#per-request-bearer-token-http-transport).
 
 #### Hosted OAuth proxy environment variables
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,7 +198,7 @@ docker build --build-arg GIT_SHA=$(git rev-parse HEAD) -t mediawiki-mcp-server .
 docker run --rm -p 8080:8080 -v "$(pwd)/config.json:/app/config.json:ro" mediawiki-mcp-server
 ```
 
-The `GIT_SHA` build arg populates the `org.opencontainers.image.revision` label so `docker inspect` reports which commit the image was built from. Omit it for ad-hoc builds; the label defaults to `unknown`.
+The `GIT_SHA` build arg populates the image's `org.opencontainers.image.revision` label; omit it for ad-hoc builds.
 
 ## Security checklist
 
@@ -256,12 +256,9 @@ Set `MCP_TRANSPORT=http` to select this transport (the Docker image defaults to 
 
 ### How the proxy works
 
-When enabled, the [hosted OAuth sign-in](#hosted-oauth-sign-in) setup turns the server into an OAuth 2.1 Authorization Server toward MCP clients. It:
+When enabled, the [hosted OAuth sign-in](#hosted-oauth-sign-in) setup makes this server the OAuth authorization server the MCP client talks to, through the endpoints routed in [step 4](#4-route-the-oauth-endpoints-through-your-proxy). The bearer a client sends to `/mcp` is a token the proxy minted, not a MediaWiki token. The user's MediaWiki token stays server-side, keyed to that bearer, and is refreshed server-to-server through the confidential consumer — this is what keeps users signed in past the wiki's ~1-hour access-token lifetime, and it is the state the [store file](#proxy-state-persistence) persists.
 
-- Serves authorization-server metadata ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)) and protected-resource metadata ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)), a Dynamic Client Registration endpoint ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)) at `/register`, an `/authorize` endpoint with a consent page, a fixed `/oauth/callback`, and a `/token` endpoint that mints the proxy's **own** audience-bound JWT. The bearer the client then sends to `/mcp` is a proxy JWT, not a MediaWiki token.
-- Brokers **one** pre-registered MediaWiki Extension:OAuth consumer as a **public + PKCE** client. When a user signs in, the proxy runs the upstream auth-code + PKCE flow against the wiki, stores the resulting MediaWiki token, and hands the client a proxy JWT keyed to it. On each `/mcp` call the server verifies the JWT and resolves it back to the stored MediaWiki token, refreshing it server-to-server when near expiry.
-
-How the sign-in challenge is issued depends on the wiki. On a **public wiki**, a tokenless request is served anonymously, and only a write tool that needs authentication returns an authentication error naming the protected-resource document; the user signs in and retries. An invalid or expired bearer is rejected with a `401` + `WWW-Authenticate` challenge. A **private wiki** (`private: true`, MediaWiki's `$wgGroupPermissions['*']['read'] = false`) answers every request, including the initial connection, with a `401` + `WWW-Authenticate`; this connection-time challenge is the broadly client-compatible trigger for sign-in at connect. It requires the wiki's `oauth2ClientId`; without it, the `401` advertises an authorization server the wiki does not, and the server logs a warning at startup.
+How the sign-in challenge is issued depends on the wiki. On a **public wiki**, a tokenless request is served anonymously; a write that needs authentication returns an authentication error, and an invalid or expired bearer gets a `401` + `WWW-Authenticate` challenge. A **private wiki** (`private: true`, MediaWiki's `$wgGroupPermissions['*']['read'] = false`) answers every request, including the initial connection, with that challenge, so a client prompts for sign-in at connect. The connection-time challenge requires the wiki's `oauth2ClientId`; without it, the `401` advertises an authorization server the wiki does not have, and the server logs a warning at startup.
 
 #### Three-base topology
 
@@ -273,7 +270,7 @@ The proxy reads three distinct URLs, which usually differ:
 | Upstream authorize host | per-wiki `publicServer` (falls back to `server`) | The **browser-facing** wiki URL the user is redirected to for the upstream MediaWiki consent screen (`…/rest.php/oauth2/authorize`). |
 | Internal API host | per-wiki `server` | The wiki API used for tool calls **and** the server→wiki token exchange/refresh (`…/rest.php/oauth2/access_token`). |
 
-The split exists because the browser must reach a **public** authorize URL (the user's browser is redirected there and back), while the server's own API traffic and the confidential token exchange should stay on the **internal** address (e.g. a Docker-network alias that bypasses the public reverse proxy). Set `publicServer` to the public wiki URL and `server` to the internal one; when there is no internal/public split, omit `publicServer` and it falls back to `server`.
+The split exists because the browser must reach a **public** authorize URL (the user's browser is redirected there and back), while the server's own API traffic and the confidential token exchange should stay on the **internal** address (e.g. a Docker-network alias that bypasses the public reverse proxy).
 
 ### Outbound SSRF guard
 
@@ -333,7 +330,7 @@ Authorization: Bearer <oauth2-access-token>
 
 Use a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed. The server forwards it to MediaWiki as that caller's token, so writes are attributable and MediaWiki's per-user rate limits apply. A bearer is scoped to a single MediaWiki OAuth2 realm, so this is single-wiki only for now.
 
-When the target wiki sets `oauth2ClientId`, the server also advertises OAuth discovery on this path, so a capable client can fetch that token itself instead of you pasting one in. It publishes `/.well-known/oauth-protected-resource` and answers a bearer-less request with `WWW-Authenticate: Bearer realm="MediaWiki MCP Server", resource_metadata="..."`. The client follows that to run the authorization-code + PKCE flow against the wiki's **own** authorization server and obtain a MediaWiki access token directly. (This differs from [Hosted OAuth sign-in](#hosted-oauth-sign-in), where the MCP server itself is the authorization server.) See [configuration.md: OAuth (browser-based)](configuration.md#oauth-browser-based) for the per-wiki opt-in.
+When the target wiki sets `oauth2ClientId`, the server also advertises OAuth discovery on this path, so a capable client can run the authorization-code flow against the wiki's **own** authorization server and fetch that token itself instead of you pasting one in. See [configuration.md: OAuth (browser-based)](configuration.md#oauth-browser-based) for the per-wiki opt-in.
 
 **Precedence:** request header → `config.json` `token` → `config.json` `username`/`password` → anonymous. The HTTP transport refuses to start with static credentials in `config.json` unless `MCP_ALLOW_STATIC_FALLBACK=true` is set; see [the Security checklist](#security-checklist) for why.
 
@@ -345,9 +342,6 @@ Example with Claude Code:
 claude mcp add --transport http my-wiki https://wiki.example.org/mcp \
   --header "Authorization: Bearer eyJhbGciOi..."
 ```
-
-> [!NOTE]
-> The MCP authorization spec envisions the server as a distinct OAuth resource server with its **own** token audience, obtaining a separate upstream token when it calls MediaWiki. This server instead uses MediaWiki's OAuth realm directly. The bearer is a MediaWiki access token, which the server forwards without re-issuing, whether you supply it or the discovery flow above fetches it. That is simpler to deploy against existing wikis but means clients hold a MediaWiki-audience token. The [hosted OAuth sign-in](#hosted-oauth-sign-in) setup is the fully spec-aligned path, where the server issues its own audience-bound token.
 
 ## Operations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -328,13 +328,13 @@ The server accepts a standard OAuth 2.1 `Authorization: Bearer` header on each r
 Authorization: Bearer <oauth2-access-token>
 ```
 
-Use a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed. The server forwards it to MediaWiki as that caller's token, so writes are attributable and MediaWiki's per-user rate limits apply. A bearer is scoped to a single MediaWiki OAuth2 realm, so this is single-wiki only for now.
+Use a MediaWiki OAuth2 access token obtained from `Special:OAuthConsumerRegistration/propose/oauth2` on the target wiki, with [Extension:OAuth](https://www.mediawiki.org/wiki/Extension:OAuth) installed. The server forwards it to MediaWiki as that caller's token, so writes are attributable and MediaWiki's per-user rate limits apply. A bearer is scoped to a single MediaWiki OAuth2 realm, and there is no per-session bearer pin: one session can address wikis on different authorization servers by sending the right token per request. `list-wikis` reports each OAuth wiki's `authorizationServer`.
 
-When the target wiki sets `oauth2ClientId`, the server also advertises OAuth discovery on this path, so a capable client can run the authorization-code flow against the wiki's **own** authorization server and fetch that token itself instead of you pasting one in. See [configuration.md: OAuth (browser-based)](configuration.md#oauth-browser-based) for the per-wiki opt-in.
+When a wiki sets `oauth2ClientId` (see [configuration.md: OAuth (browser-based)](configuration.md#oauth-browser-based)), the server also advertises OAuth discovery on this path: the protected-resource document lists every OAuth-configured wiki's authorization server, and a capable client can run the authorization-code flow against the wiki's **own** authorization server and fetch that token itself instead of you pasting one in. A bearer-less request is challenged with `401` only when no configured wiki is usable without a token; a deployment that mixes OAuth and non-OAuth wikis still serves tokenless clients on the wikis that allow anonymous access.
 
 **Precedence:** request header → `config.json` `token` → `config.json` `username`/`password` → anonymous. The HTTP transport refuses to start with static credentials in `config.json` unless `MCP_ALLOW_STATIC_FALLBACK=true` is set; see [the Security checklist](#security-checklist) for why.
 
-Each request builds an independent MediaWiki session using the supplied token. Token rotation and revocation take effect on the next MCP session started with the new token.
+Each request builds an independent MediaWiki session using the supplied token. Token rotation and revocation take effect on the next MCP session started with the new token. The MCP session id is the session's only credential, so run the transport behind TLS; idle sessions close after `MCP_SESSION_IDLE_TIMEOUT`, bounding how long a leaked session id stays usable.
 
 Example with Claude Code:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,7 @@
 # Deployment
 
 > [!WARNING]
-> **Experimental: work in progress.** Hosting the server for other people is supported for **one wiki at a time**; multi-wiki hosted deployments are on the roadmap. Do not expose the server to mutually untrusted users with a shared `config.json` token or bot password. That collapses every caller into one wiki identity, with no audit trail and no per-user rate limits. The sign-in setup below avoids that.
+> **Experimental: work in progress.** Hosting the server for other people is supported for **one wiki at a time**. Do not expose the server to mutually untrusted users with a shared `config.json` token or bot password. That collapses every caller into one wiki identity, with no audit trail and no per-user rate limits. The sign-in setup below avoids that.
 
 This guide is for administrators running the MediaWiki MCP Server as a **shared HTTP endpoint** that other people (and their AI clients) reach over the network. If you only want the server for yourself, install it locally with the default stdio transport instead; see the [README](../README.md#installation).
 
@@ -61,8 +61,6 @@ How sign-in is triggered depends on the wiki:
 
 - **Public wiki:** reads work without signing in; the client is prompted to sign in only when a write needs authentication.
 - **Private wiki** (`private: true`): nothing is readable anonymously, so the client is challenged to sign in the moment it connects rather than failing on the first tool call.
-
-[How the proxy works](#how-the-proxy-works) covers exactly how each challenge is issued.
 
 Set it up in five steps.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,7 +88,7 @@ Pass an optional `wiki` argument (a wiki key such as `en.wikipedia.org`, or the 
 
 ## Using a local build from your MCP client
 
-To point an MCP client (Claude Desktop, VS Code, Cursor, etc.) at a locally-built copy of the server:
+To point an MCP client at a locally-built copy of the server:
 
 1. [Install](../README.md#installation) the server on the client.
 2. Replace the `command` and `args` values with the ones from [`mcp.json`](../mcp.json) (or [`mcp.docker.json`](../mcp.docker.json) for Docker).
@@ -110,6 +110,8 @@ docker exec <container> php /var/www/html/maintenance/run.php createBotPassword 
   <username>
 ```
 
+(Adjust `/var/www/html` to your wiki's install path.)
+
 Then add the credentials to `config.json` (copy from `config.example.json` if it
 doesn't exist). Use environment-variable substitution to keep secrets out of the
 file:
@@ -125,14 +127,12 @@ For production authentication, use OAuth2 — see [Authentication](../README.md#
 To exercise the full browser sign-in flow of the hosted OAuth proxy end to end,
 see [End-to-end testing the hosted OAuth proxy](#end-to-end-testing-the-hosted-oauth-proxy) below.
 
-(Adjust `/var/www/html` to your wiki's install path.)
-
 ## End-to-end testing the hosted OAuth proxy
 
 A manual, repeatable walkthrough of the full browser sign-in flow — discovery,
 sign-in, upstream consent, token exchange, and an attributed write — against a
-real wiki. Written so an agent (or a person) can follow it verbatim. It needs no
-bundled environment: any MediaWiki container with Extension:OAuth works.
+real wiki. It needs no bundled environment: any MediaWiki container with
+Extension:OAuth works.
 
 ### 1. Prerequisites and the environment contract
 


### PR DESCRIPTION
A pass over the prose documentation applying [docs/documentation-conventions.md](docs/documentation-conventions.md) (#479).

- **One home per fact:** `configuration.md` restated the four hosted-proxy environment variables (semantics, defaults, duration grammar, activation conditions) and two core OAuth variables whose homes are the `deployment.md` and README tables. Both subsections are now short pointers; the `MCP_PUBLIC_URL` discovery-role fact, which had no other home, is kept.
- **Audience mismatch:** `configuration.md`'s "HTTP transport behaviour" subsection described deployment behaviour — discovery publishing, `401` challenge conditions, per-request bearer semantics, session TLS guidance — to the config-file reader. Its unique facts merge into `deployment.md`'s per-request-bearer section (also resolving the tension between "single-wiki only for now" there and the multi-wiki-per-session semantics here), with a pointer left behind. README's "Internal vs public address" paragraph shrinks to a note, its link-construction contract moving under the per-wiki fields; the README security bullet that repeated the outbound SSRF-guard reference nearly verbatim becomes a pointer.
- **Protocol narration in `deployment.md`:** "How the proxy works" is compressed to the facts an admin acts on — the `/mcp` bearer is a proxy-minted token, the MediaWiki token stays server-side and is refreshed through the confidential consumer, and the per-wiki challenge behaviour. This also removes the stale claim that the proxy brokers the upstream consumer as a public + PKCE client, which the confidential-consumer requirement obsoleted. The per-request-bearer discovery walkthrough shrinks to its contract and the spec-alignment design note is dropped.
- **Never-write register:** dropped two justification sentences, the MCP-Roots roadmap callout (its contract — the allowlist is fixed at startup — is kept as a sentence), a doc-about-itself sentence in the e2e walkthrough, and a redundant third pointer to "How the proxy works". Replaced two named-client example lists with "an MCP client" / "OAuth-aware MCP clients".
- **Mechanical:** grammar fixes in three README install blocks; moved the `/var/www/html` remark in `testing.md` next to the command it qualifies; the `GIT_SHA` build-arg explanation cut to a clause.

Considered, omitted:

- `configuration.md`'s "For wiki admins" section addresses a second reader, but it is explicitly labelled and the wiki-side half of the setup has no better home.
- `deployment.md`'s env-var tables, security checklist, Host/Origin matching edge cases, SSRF-guard rules, persistence, and v1 limitations: all actionable for the admin reader, left intact.
- `testing.md`'s e2e proxy walkthrough, `operations.md`, and `releasing.md` match their genre readers; no changes beyond the above.
- Historical CHANGELOG entries: dated snapshots, left untouched.
- README install sections naming clients: install instructions, not example lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)