### PR TITLE
Add per-wiki option to make edit attribution optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - IPv6 loopback (`http://[::1]:…`) redirect URIs are now accepted at client registration, per RFC 8252.
 - Hosted OAuth proxy: support for Client ID Metadata Documents (CIMD). CIMD-capable clients connect using a stable, vendor-hosted client identity, with no per-client redirect entry to curate. The proxy trusts the verified first-party document hosts by default; add more with `MCP_OAUTH_CIMD_ALLOWED_HOSTS`.
 - Metrics: the `/metrics` endpoint now reports the hosted OAuth proxy store's size and flush cost — `mcp_proxy_store_upstream_tokens` and `mcp_proxy_store_clients` gauges, an `mcp_proxy_store_flush_duration_seconds` histogram, and an `mcp_proxy_store_flush_failures_total` counter — so operators can watch the store grow, see how long each persistence write takes, and alert when a write fails.
+- The `(via <tool> on MediaWiki MCP Server)` attribution appended to page and file edit summaries can now be turned off per wiki by setting `"attributeEdits": false` in that wiki's `config.json` entry. It stays on by default.
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Advanced configuration
 
-Covers configuration topics beyond the basic `config.json` shape documented in [README.md](../README.md#configuration): the full field reference, environment variable substitution, secret sources, plaintext fallback, and the `tags` field.
+Covers configuration topics beyond the basic `config.json` shape documented in [README.md](../README.md#configuration): the full field reference, environment variable substitution, secret sources, plaintext fallback, and the `tags` and `attributeEdits` fields.
 
 ## Configuration fields
 
@@ -30,6 +30,7 @@ Covers configuration topics beyond the basic `config.json` shape documented in [
 | `private` | No | Whether the wiki requires authentication to read (default: `false`) |
 | `readOnly` | No | When `true`, hides the six 🔐 write tools from `tools/list` while this wiki is active. Pairs with `allowWikiManagement: false` for a [hosted read-only endpoint](deployment.md). Default: `false` |
 | `tags` | No | Change tag(s) to apply to every write (string or array). The tag must exist and be active at `Special:Tags` — see [change tags](#change-tags-tags) for details. |
+| `attributeEdits` | No | Whether page and file writes carry the `(via <tool> on MediaWiki MCP Server)` suffix in their edit summary. Default: `true`. See [edit attribution](#edit-attribution-attributeedits). |
 
 URLs returned to the caller — page links, and the `server` field in `list-wikis` and `mcp://wikis` resources — are built from the wiki's public address, so an internal `server` hostname does not leak into links. If the wiki cannot be reached, they fall back to the configured `server`.
 
@@ -95,7 +96,7 @@ Plaintext credentials in `config.json` still work but print a one-line warning t
 
 ## Change tags (`tags`)
 
-The `tags` field applies one or more [change tags](https://www.mediawiki.org/wiki/Manual:Tags) to every write (create, update, delete, upload). Register and activate the tag at `Special:Tags` first — otherwise MediaWiki returns a `badtags` error and the write fails.
+The `tags` field applies one or more [change tags](https://www.mediawiki.org/wiki/Manual:Tags) to every write (create, update, delete, undelete, move, upload). Register and activate the tag at `Special:Tags` first — otherwise MediaWiki returns a `badtags` error and the write fails.
 
 Accepts a string or an array of strings:
 
@@ -118,6 +119,24 @@ Accepts a string or an array of strings:
   }
 }
 ```
+
+## Edit attribution (`attributeEdits`)
+
+Every write (create, update, delete, undelete, move, upload) appends `(via <tool> on MediaWiki MCP Server)` to its edit summary — for example `Fix typo (via update-page on MediaWiki MCP Server)`. With no caller comment, the summary is `Automated edit (via <tool> on MediaWiki MCP Server)`. This is the default (`true`).
+
+Set `attributeEdits` to `false` to drop the suffix. The write then carries only the caller's comment, or an empty summary when none was given:
+
+```json
+{
+  "wikis": {
+    "my.wiki.org": {
+      "attributeEdits": false
+    }
+  }
+}
+```
+
+A change [`tags`](#change-tags-tags) value keeps MCP writes identifiable without the suffix, and stays visible in recent changes and page history.
 
 ## Upload directories
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -91,6 +91,15 @@ export interface WikiConfig {
 	 * the action, MediaWiki returns a badtags error and the write fails.
 	 */
 	tags?: string | string[] | null;
+	/**
+	 * Whether write actions made through this MCP server carry the
+	 * `(via <tool> on MediaWiki MCP Server)` attribution suffix in their edit
+	 * summary. Defaults to true. Set to false to drop the suffix, leaving only
+	 * the caller-supplied comment — or an empty summary when none was given.
+	 * A change tag (`tags`) keeps MCP edits identifiable without the suffix when
+	 * you control the target wiki.
+	 */
+	attributeEdits?: boolean;
 }
 
 export type PublicWikiConfig = Omit<WikiConfig, 'token' | 'username' | 'password'>;

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -55,7 +55,7 @@ export const createPage: Tool<typeof inputSchema> = {
 		const result = await mwn.create(
 			title,
 			source,
-			formatEditComment('create-page', comment),
+			formatEditComment(ctx, 'create-page', comment),
 			options,
 		);
 

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -31,7 +31,7 @@ export const deletePage: Tool<typeof inputSchema> = {
 		const options = ctx.edit.applyTags<ApiDeleteParams>({});
 		const data: ApiDeleteResponse & { logid?: number } = await mwn.delete(
 			title,
-			formatEditComment('delete-page', comment),
+			formatEditComment(ctx, 'delete-page', comment),
 			options,
 		);
 		return ctx.format.ok({

--- a/src/tools/move-page.ts
+++ b/src/tools/move-page.ts
@@ -69,7 +69,7 @@ export const movePage: Tool<typeof inputSchema> = {
 		} = await mwn.move(
 			args.fromTitle,
 			args.toTitle,
-			formatEditComment('move-page', args.comment),
+			formatEditComment(ctx, 'move-page', args.comment),
 			options,
 		);
 

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -31,7 +31,7 @@ export const undeletePage: Tool<typeof inputSchema> = {
 		const options = ctx.edit.applyTags<ApiUndeleteParams>({});
 		const data: ApiUndeleteResponse & { revisions?: number } = await mwn.undelete(
 			title,
-			formatEditComment('undelete-page', comment),
+			formatEditComment(ctx, 'undelete-page', comment),
 			options,
 		);
 

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -44,7 +44,7 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 		}
 
 		const baseParams: ApiUploadParams = {
-			comment: formatEditComment('update-file-from-url', comment),
+			comment: formatEditComment(ctx, 'update-file-from-url', comment),
 			ignorewarnings: true,
 		};
 

--- a/src/tools/update-file.ts
+++ b/src/tools/update-file.ts
@@ -53,7 +53,7 @@ export const updateFile: Tool<typeof inputSchema> = {
 		}
 
 		const params: ApiUploadParams = {
-			comment: formatEditComment('update-file', comment),
+			comment: formatEditComment(ctx, 'update-file', comment),
 			ignorewarnings: true,
 		};
 		const data: ApiUploadResponse = await ctx.edit.submitUpload(

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -68,22 +68,16 @@ function validateArgs({ section, mode, sectionTitle }: UpdatePageArgs): string |
 	return undefined;
 }
 
-function buildEditParams({
-	title,
-	source,
-	latestId,
-	comment,
-	section,
-	mode,
-	sectionTitle,
-	bot,
-}: UpdatePageArgs): Record<string, string | number | boolean> {
+function buildEditParams(
+	ctx: ToolContext,
+	{ title, source, latestId, comment, section, mode, sectionTitle, bot }: UpdatePageArgs,
+): Record<string, string | number | boolean> {
 	const sourceField =
 		mode === 'append' ? 'appendtext' : mode === 'prepend' ? 'prependtext' : 'text';
 	return {
 		action: 'edit',
 		title,
-		summary: formatEditComment('update-page', comment),
+		summary: formatEditComment(ctx, 'update-page', comment),
 		nocreate: true,
 		[sourceField]: source,
 		...(latestId !== undefined ? { baserevid: latestId } : {}),
@@ -117,7 +111,9 @@ export const updatePage: Tool<typeof inputSchema> = {
 		const mwn = await ctx.mwn();
 		const response =
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
-			(await ctx.edit.submit(mwn, buildEditParams(args))) as { edit?: ApiEditResponse } | undefined;
+			(await ctx.edit.submit(mwn, buildEditParams(ctx, args))) as
+				| { edit?: ApiEditResponse }
+				| undefined;
 		const edit = response?.edit;
 		if (!edit || edit.result !== 'Success') {
 			return ctx.format.error(

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -33,7 +33,7 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 	async handle({ url, title, text, comment }, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
 		const baseParams: ApiUploadParams = {
-			comment: formatEditComment('upload-file-from-url', comment),
+			comment: formatEditComment(ctx, 'upload-file-from-url', comment),
 		};
 
 		// Server-first: fetch the bytes ourselves (SSRF-guarded, size-capped) and

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -42,7 +42,7 @@ export const uploadFile: Tool<typeof inputSchema> = {
 
 		const mwn = await ctx.mwn();
 		const params: ApiUploadParams = {
-			comment: formatEditComment('upload-file', comment),
+			comment: formatEditComment(ctx, 'upload-file', comment),
 		};
 		const data: ApiUploadResponse = await ctx.edit.submitUpload(
 			mwn,

--- a/src/wikis/utils.ts
+++ b/src/wikis/utils.ts
@@ -11,7 +11,10 @@ export async function buildPageUrl(ctx: ToolContext, title: string): Promise<str
 	return `${server}${articlepath}/${encodeURI(title.replace(/ /g, '_'))}`;
 }
 
-export function formatEditComment(tool: string, comment?: string): string {
+export function formatEditComment(ctx: ToolContext, tool: string, comment?: string): string {
+	if (ctx.activeWiki.get().config.attributeEdits === false) {
+		return comment ?? '';
+	}
 	const suffix = `(via ${tool} on MediaWiki MCP Server)`;
 	if (!comment) {
 		return `Automated edit ${suffix}`;

--- a/tests/wikis/utils.test.ts
+++ b/tests/wikis/utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { ToolContext } from '../../src/runtime/context.js';
+import { formatEditComment } from '../../src/wikis/utils.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+
+function ctxWithAttribution(attributeEdits?: boolean): ToolContext {
+	return fakeContext({
+		activeWiki: {
+			get: () =>
+				({
+					key: 'test-wiki',
+					config: {
+						sitename: 'Test',
+						server: 'https://test.wiki',
+						articlepath: '/wiki',
+						scriptpath: '/w',
+						tags: null,
+						attributeEdits,
+					},
+				}) as never,
+			getDefaultKey: () => 'test-wiki',
+		},
+	});
+}
+
+describe('formatEditComment', () => {
+	it('appends the attribution suffix to a caller comment by default', () => {
+		const result = formatEditComment(ctxWithAttribution(), 'update-page', 'Fix typo');
+		expect(result).toBe('Fix typo (via update-page on MediaWiki MCP Server)');
+	});
+
+	it('falls back to an attributed "Automated edit" when no comment is given', () => {
+		const result = formatEditComment(ctxWithAttribution(), 'update-page');
+		expect(result).toBe('Automated edit (via update-page on MediaWiki MCP Server)');
+	});
+
+	it('keeps attribution when attributeEdits is explicitly true', () => {
+		const result = formatEditComment(ctxWithAttribution(true), 'delete-page', 'Spam');
+		expect(result).toBe('Spam (via delete-page on MediaWiki MCP Server)');
+	});
+
+	it('omits the suffix and returns the bare comment when attributeEdits is false', () => {
+		const result = formatEditComment(ctxWithAttribution(false), 'update-page', 'Fix typo');
+		expect(result).toBe('Fix typo');
+	});
+
+	it('returns an empty summary when attribution is off and no comment is given', () => {
+		const result = formatEditComment(ctxWithAttribution(false), 'update-page');
+		expect(result).toBe('');
+	});
+
+	it('treats an empty-string comment like a missing one when attribution is on', () => {
+		const result = formatEditComment(ctxWithAttribution(), 'update-page', '');
+		expect(result).toBe('Automated edit (via update-page on MediaWiki MCP Server)');
+	});
+
+	it('returns an empty summary for an empty-string comment when attribution is off', () => {
+		const result = formatEditComment(ctxWithAttribution(false), 'update-page', '');
+		expect(result).toBe('');
+	});
+});


### PR DESCRIPTION
## Summary

Make the `(via <tool> on MediaWiki MCP Server)` edit-summary attribution optional per wiki, via a new `attributeEdits` config field (default `true`).

The suffix is the zero-config signal that an edit came through MCP — the one breadcrumb on a wiki where you can't register a change tag — so it stays **on by default**. Operators who don't want it (or who use a change `tag` instead) opt out per wiki. A supported toggle also makes official what a few people already do by hand-patching, keeping them on released builds and their choice visible in config rather than buried in a fork.

## Behaviour

- `attributeEdits: false` drops the suffix, leaving only the caller's comment, or an empty summary when none was given.
- Attribution shows unless the field is exactly `false` (undefined / null / true keep it on), so a missing or malformed value never silently strips the disclosure signal.
- Applies to all page and file writes (create, update, delete, undelete, move, upload). Extension-pack writes (NeoWiki, etc.) never carried the suffix and are unchanged.

## Implementation

- New `attributeEdits?: boolean` on `WikiConfig`.
- `formatEditComment(ctx, tool, comment)` now reads the flag from the active wiki's config, mirroring how `buildPageUrl` and `applyTags` read context and config; the nine page/file write tools thread `ctx` through.

## Docs / policy

- `docs/configuration.md`: field-reference row plus a dedicated section. Also corrected the adjacent change-tags list, which omitted `move` and `undelete`.
- `CHANGELOG.md`: entry under `[Unreleased] › Added`.
- No README tool-table, `server.json`, env-var table, or `Dockerfile` change — this is a `config.json` field, not an env var, and adds or renames no tool (per `AGENTS.md`).

## Testing

- `tests/wikis/utils.test.ts`: 7-case behaviour matrix (default, explicit true/false, with and without a comment, and the empty-string-vs-undefined comment boundary).
- Gate: `tsc --noEmit`, `npm run build`, and `fmt:check` clean; `npm test` 1579 passing; lint adds no new warnings.
- Live smoke on neowiki.dev: with `attributeEdits: false` a create stored the summary `smoke off` (no suffix); with the default an update stored `smoke on (via update-page on MediaWiki MCP Server)`. Both were verified by reading the summaries back from page history, and the test page was deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
