### PR TITLE
Keep dependency log output off the stdio protocol channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- Clients no longer show a spurious `Expected ',' or ']' after array element in JSON` warning next to otherwise successful requests.
 - Hosted OAuth proxy: a client that identifies by a vendor-hosted URL (Client ID Metadata Document) is now rejected if any redirect URI in its document is not an `https`, loopback-`http`, or custom-scheme (for example `vscode://`) URL — notably a cleartext `http` redirect to a non-loopback host, which a network attacker on that path could intercept the authorization code at.
 - The HTTP server now logs a clear message and exits cleanly when it cannot bind its port — already in use, or permission denied — instead of terminating with an uncaught exception and a raw stack trace.
 - OAuth clients that use a loopback callback on a variable port (including clients that register a portless `http://127.0.0.1/` URI) now complete the flow instead of failing with "redirect_uri not registered", per RFC 8252.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,6 +39,16 @@ One line on server boot — a snapshot of the effective configuration that's saf
 
 Tokens, usernames, and passwords never appear.
 
+### Stray output
+
+Log output from the MediaWiki client library, relocated here so it cannot corrupt the protocol stream. Expect it on a bot-password login, an API warning, or a request retry:
+
+```json
+{"ts":"...","level":"warning","event":"stray_stdout","text":"[2026-07-23 16:48:43] [W] Warning received from API: main: ..."}
+```
+
+`text` is one line of library output, passed through unaltered, so it is neither JSON nor redacted — a login line carries the configured username.
+
 ### Health vs readiness
 
 - **`GET /health`** — liveness. Returns `200 { "status": "ok" }` whenever the process is responsive. Wire this into your orchestrator's restart policy.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
 async function main(): Promise<void> {
+	// Before anything can log: stdout belongs to the stdio transport, and a
+	// dependency writing there corrupts the JSON-RPC stream. Imported
+	// dynamically like the transports below so a failure here still reaches the
+	// fail-safe handler rather than escaping as a module-load error.
+	const { guardStdout } = await import('./runtime/stdoutGuard.js');
+	guardStdout();
+
 	const transportType = process.env.MCP_TRANSPORT || 'stdio';
 	if (transportType === 'http') {
 		const { startHttpServer } = await import('./transport/streamableHttp.js');

--- a/src/runtime/stdoutGuard.ts
+++ b/src/runtime/stdoutGuard.ts
@@ -1,0 +1,68 @@
+import { Console } from 'node:console';
+import { Writable } from 'node:stream';
+import { Mwn } from 'mwn';
+import { emitTelemetryEvent } from './logger.js';
+
+/**
+ * Under the stdio transport, stdout carries the JSON-RPC frames and nothing
+ * else: one stray line makes the client fail to parse a message. mwn writes its
+ * own diagnostics there by default — a successful login, an API warning, a
+ * retry — each prefixed with a bracketed timestamp, which a client reports as
+ * "Expected ',' or ']' after array element in JSON at position 5".
+ *
+ * The guard leaves stdout to the transport and routes everything else into the
+ * structured stderr log, so operators keep the diagnostics in the same
+ * JSON-lines stream as the rest of our output. It covers both transports: on
+ * HTTP nothing owns stdout, but raw text there is still invisible to a log
+ * pipeline that parses each line as JSON.
+ */
+export function guardStdout(): void {
+	const sink = createLogSink();
+
+	// mwn's logger writes through this stream directly. Pointing it away from
+	// process.stdout also disables its chalk colouring, which keys off the
+	// stream being stdout, so no escape sequences reach the log.
+	Mwn.setLoggingConfig({ stream: sink });
+
+	// mwn also has one hard-coded console.log (a request-failure dump) that the
+	// setting above cannot reach, so replace the stdout half of the global
+	// console as well. process.stdout itself is deliberately left alone: the
+	// SDK's StdioServerTransport writes to it directly, and patching it would
+	// break the protocol channel.
+	//
+	// inspectOptions is left at Node's defaults on purpose. Raising `depth`
+	// would expand nested objects such as an axios error's headers, putting
+	// Set-Cookie values from a failing wiki response into the log.
+	globalThis.console = new Console({ stdout: sink, stderr: process.stderr });
+}
+
+function createLogSink(): Writable {
+	return new Writable({
+		write(chunk: Buffer | string, _encoding: BufferEncoding, callback: () => void): void {
+			try {
+				report(String(chunk));
+			} finally {
+				// Node does not guard _write. Skipping the callback would leave the
+				// stream mid-write forever, buffering every later line in silence.
+				callback();
+			}
+		},
+	});
+}
+
+function report(text: string): void {
+	// Both producers terminate their writes with a newline, so splitting keeps
+	// one structured event per logical line instead of embedding raw newlines.
+	for (const line of text.split('\n')) {
+		if (line.trim() === '') {
+			continue;
+		}
+		try {
+			emitTelemetryEvent('warning', { event: 'stray_stdout', text: line });
+		} catch {
+			// Node's Console swallows sink errors, so a throwing logger would
+			// discard the line without a trace. Keep it, unstructured.
+			process.stderr.write(line + '\n');
+		}
+	}
+}

--- a/tests/runtime/stdoutGuard.test.ts
+++ b/tests/runtime/stdoutGuard.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Mwn } from 'mwn';
+import { guardStdout } from '../../src/runtime/stdoutGuard.js';
+
+interface StrayEvent {
+	event?: string;
+	text?: string;
+	level?: string;
+}
+
+describe('guardStdout', () => {
+	let originalConsole: Console;
+	let stdoutSpy: ReturnType<typeof vi.spyOn>;
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+	let stderrChunks: string[];
+
+	function strayEvents(): StrayEvent[] {
+		return stderrChunks
+			.flatMap((chunk) => chunk.split('\n'))
+			.filter((line) => line !== '')
+			.flatMap((line) => {
+				try {
+					return [JSON.parse(line) as StrayEvent];
+				} catch {
+					return [];
+				}
+			})
+			.filter((entry) => entry.event === 'stray_stdout');
+	}
+
+	beforeEach(() => {
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
+		originalConsole = globalThis.console;
+		stderrChunks = [];
+		stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+		stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+			stderrChunks.push(String(chunk));
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		globalThis.console = originalConsole;
+		// Restore mwn's process-wide logging config for other suites.
+		Mwn.setLoggingConfig({ stream: process.stdout });
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	it('keeps console.log off stdout and reports it as a stray_stdout event', () => {
+		guardStdout();
+
+		console.log('hello from a dependency');
+
+		expect(stdoutSpy).not.toHaveBeenCalled();
+		expect(strayEvents()).toEqual([
+			expect.objectContaining({ event: 'stray_stdout', text: 'hello from a dependency' }),
+		]);
+	});
+
+	it('reports each line of a multi-line write separately and drops blank lines', () => {
+		guardStdout();
+
+		console.log('first\n\nsecond');
+
+		expect(strayEvents().map((entry) => entry.text)).toEqual(['first', 'second']);
+	});
+
+	it('captures the other stdout-backed console methods', () => {
+		guardStdout();
+
+		console.info('via info');
+		console.dir({ viaDir: true });
+
+		const texts = strayEvents().map((entry) => entry.text);
+		expect(texts).toContain('via info');
+		expect(texts.some((text) => text?.includes('viaDir') === true)).toBe(true);
+		expect(stdoutSpy).not.toHaveBeenCalled();
+	});
+
+	it('leaves console.error on stderr untouched', () => {
+		guardStdout();
+
+		console.error('boom');
+
+		expect(stdoutSpy).not.toHaveBeenCalled();
+		expect(strayEvents()).toEqual([]);
+		expect(stderrChunks.join('')).toContain('boom');
+	});
+
+	it('emits stray output at warning level', () => {
+		guardStdout();
+
+		console.log('noise');
+
+		expect(strayEvents()[0]?.level).toBe('warning');
+	});
+
+	it('routes mwn log lines off stdout (#483)', () => {
+		guardStdout();
+
+		Mwn.log('[S] [mwn] Login successful: TestBot@mcp@https://example.org/w/api.php');
+		Mwn.log('[W] Warning received from API: main: Subscribe to the mediawiki-api-announce list');
+
+		expect(stdoutSpy).not.toHaveBeenCalled();
+		const texts = strayEvents().map((entry) => entry.text ?? '');
+		expect(texts.some((text) => text.includes('Login successful'))).toBe(true);
+		expect(texts.some((text) => text.includes('Warning received from API'))).toBe(true);
+	});
+
+	it('strips colour codes from redirected mwn output', () => {
+		vi.stubEnv('FORCE_COLOR', '3');
+		guardStdout();
+
+		Mwn.log('[S] [mwn] Login successful: TestBot@mcp');
+
+		const text = strayEvents()[0]?.text ?? '';
+		expect(text).not.toContain('');
+	});
+
+	it('keeps every stderr line valid JSON so log tailing still parses', () => {
+		guardStdout();
+
+		Mwn.log('[2026-07-23 16:48:43] [W] Warning received from API');
+		console.log('{ request: { method: undefined } }');
+
+		const lines = stderrChunks.flatMap((chunk) => chunk.split('\n')).filter((line) => line !== '');
+		expect(lines.length).toBeGreaterThan(0);
+		for (const line of lines) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+	});
+
+	it('is idempotent', () => {
+		guardStdout();
+		guardStdout();
+
+		console.log('once');
+
+		expect(strayEvents()).toHaveLength(1);
+		expect(stdoutSpy).not.toHaveBeenCalled();
+	});
+
+	it('falls back to raw stderr rather than losing output when logging throws', () => {
+		guardStdout();
+		// An unusable MCP_LOG_LEVEL makes the structured logger throw. Node's
+		// Console swallows sink errors, so without a fallback the line vanishes.
+		vi.stubEnv('MCP_LOG_LEVEL', 'not-a-level');
+
+		expect(() => console.log('must survive')).not.toThrow();
+
+		expect(stdoutSpy).not.toHaveBeenCalled();
+		expect(stderrChunks.join('')).toContain('must survive');
+	});
+
+	it('stays usable after a write that throws', () => {
+		guardStdout();
+		// Force the fallback path, then make it throw too. A write that leaves the
+		// stream mid-write would buffer every later line in silence.
+		vi.stubEnv('MCP_LOG_LEVEL', 'not-a-level');
+		stderrSpy.mockImplementationOnce(() => {
+			throw new Error('EPIPE');
+		});
+
+		console.log('lost to a broken stderr');
+		vi.stubEnv('MCP_LOG_LEVEL', 'debug');
+		console.log('written after the failure');
+
+		expect(strayEvents().map((entry) => entry.text)).toContain('written after the failure');
+	});
+});


### PR DESCRIPTION
Fixes #483.

## The report

A client showed `Expected ',' or ']' after array element in JSON at position 5 (line 1 column 6)` on a valid config, while the queries themselves still worked. The issue title attributes this to config parsing. It is not.

## Root cause

Under the stdio transport, stdout carries the JSON-RPC frames. The MediaWiki client library logs to stdout by default and prefixes each line with a bracketed timestamp, so a line such as

```
[2026-07-23 16:48:43] [W] Warning received from API: main: Subscribe to the mediawiki-api-announce…
```

arrives at the client as a malformed message. `JSON.parse` reads `[` as an array open and `2026` as its first element, then finds `-` at index 5, which is that error verbatim. The client's read loop catches per line and continues, so the tool result on the next line still parses. That is why one warning appears and the request still succeeds.

Two triggers, confirmed against the reporter's own wiki by driving the real built server over stdio:

1. A successful bot-password login, which is the reporter's path.
2. Any response carrying an API warning. This one needs **no credentials at all** — `get-revision` against `https://deadlock.wiki` anonymously emits two such lines.

The library also has one hard-coded write that its own logging config cannot reach, so redirecting that config alone is not sufficient.

## The fix

`guardStdout()` in `src/runtime/stdoutGuard.ts`, called first in `main()`:

- Points the library's log stream at a `Writable` sink. This also strips its colour codes, which key off the stream being stdout.
- Replaces the stdout half of the global `console` with one backed by the same sink, catching the hard-coded write.
- The sink re-emits each line as a structured `stray_stdout` event on stderr, at `warning`, so the diagnostics stay in the same JSON-lines stream as the rest of the output.

`process.stdout` is deliberately left alone. The SDK transport writes to it directly, and patching it was measured to destroy the protocol channel outright.

Applied to both transports rather than stdio only. On HTTP nothing owns stdout, but raw text there is invisible to the `jq -R 'fromjson? // empty'` tailing recipe in the operations guide, so routing it into the structured stream is right either way.

## Verification

Real built server, stdio, live against `https://deadlock.wiki`:

| | stdout lines | non-JSON-RPC | stray_stdout on stderr |
|---|---|---|---|
| before | 4 | 2 | — |
| after | 2 | 0 | 2 |

Every stderr line parses as JSON. The bot-password login trigger was verified separately against a mock wiki: the `Login successful` line no longer appears between the frames.

11 new tests. One of them asserts the sink stays usable after a write that throws; it fails without the `finally` and passes with it, checked both ways.

## Notes for review

- Captured lines are level-gated like all other logging, so `MCP_LOG_LEVEL` above `warning` hides them. Before this change they were unconditionally visible, on the wrong stream. Our own `tool_call` telemetry still reports upstream failures at `error`, so the important signal survives. Documented in the operations guide.
- Captured text is third-party output and is not redacted; a login line carries the configured bot-password username. Also documented.
- `mwn@3.0.3` is the latest release, so there is no upstream fix to pick up instead.

## Out of scope

Two pre-existing test-suite problems surfaced during review, unrelated to this change: `--sequence.shuffle` fails `tests/transport/httpFetch.test.ts:174` (within-file order dependence, reproduced with the new file excluded), and `--no-isolate` breaks 98 tests suite-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)