### PR TITLE
Read the NeoWiki statement property type under its new name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Reading NeoWiki subjects now requires a wiki running NeoWiki from 2026-07-27 or later, when a Statement's property type was renamed to `propertyType` (ProfessionalWiki/NeoWiki#1169). This fixes `neowiki-get-subject` and `neowiki-get-page-subjects` reporting an empty type for every statement against an updated wiki, and requires one: against an earlier NeoWiki the type now reads as empty. Update the wiki before upgrading the server.
+
 ## [0.14.0] - 2026-07-23
 
 ### Breaking changes

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -24,7 +24,7 @@ interface SubjectData {
 	id?: string;
 	label?: string;
 	schema?: string;
-	statements?: Record<string, { type?: string; value?: unknown }>;
+	statements?: Record<string, { propertyType?: string; value?: unknown }>;
 }
 
 interface PageSubjectsResponse {

--- a/src/tools/extensions/neowiki/neowiki-get-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-subject.ts
@@ -14,7 +14,7 @@ const inputSchema = {
 } as const;
 
 interface SubjectStatement {
-	type?: string;
+	propertyType?: string;
 	value?: unknown;
 }
 
@@ -77,7 +77,7 @@ export function flattenSubject(
 } {
 	const statements = Object.entries(subject.statements ?? {}).map(([property, statement]) => ({
 		property,
-		type: typeof statement.type === 'string' ? statement.type : '',
+		type: typeof statement.propertyType === 'string' ? statement.propertyType : '',
 		value: statement.value,
 	}));
 	return {

--- a/tests/tools/extensions/neowiki/neowiki-get-page-subjects.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-page-subjects.test.ts
@@ -13,7 +13,7 @@ const pageSubjectsBody = {
 				id: 'sMain',
 				label: 'Rijksmuseum',
 				schema: 'Museum',
-				statements: { Founded: { type: 'number', value: 1800 } },
+				statements: { Founded: { propertyType: 'number', value: 1800 } },
 			},
 			sChild: { id: 'sChild', label: 'Rijksmuseum 2024', schema: 'Attendance', statements: {} },
 		},
@@ -39,7 +39,12 @@ describe('neowiki-get-page-subjects', () => {
 			pageId: 65,
 			mainSubjectId: 'sMain',
 			subjects: [
-				{ id: 'sMain', isMain: true, schema: 'Museum' },
+				{
+					id: 'sMain',
+					isMain: true,
+					schema: 'Museum',
+					statements: [{ property: 'Founded', type: 'number', value: 1800 }],
+				},
 				{ id: 'sChild', isMain: false, schema: 'Attendance' },
 			],
 		});

--- a/tests/tools/extensions/neowiki/neowiki-get-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-get-subject.test.ts
@@ -15,7 +15,7 @@ describe('neowiki-get-subject', () => {
 							id: 's1demo1aaaaaaa1',
 							label: 'ACME Inc',
 							schema: 'Company',
-							statements: { Status: { type: 'select', value: ['o1demo1aaaaaaa1'] } },
+							statements: { Status: { propertyType: 'select', value: ['o1demo1aaaaaaa1'] } },
 						},
 					},
 				},


### PR DESCRIPTION
NeoWiki renamed a Statement's property-type field from `type` to `propertyType` in its REST responses (ProfessionalWiki/NeoWiki#1169). Against a wiki running that change, neowiki-get-subject and neowiki-get-page-subjects returned an empty type for every statement: `flattenSubject` looked for `type` and substituted `''` when it was absent, so the failure was silent. Values were unaffected.

The empty type is not merely cosmetic for a model calling these tools. It cannot distinguish "this property has no type" from "the type was lost", and neowiki-update-subject requires `propertyType`, so a read-then-write cycle can feed the empty string back into a write.

Both read tools share `flattenSubject`, so this is one change in one place.

## Breaking, not only a fix

Every wiki deployed today still emits the old field name, so shipping this takes away behaviour that currently works for them: statement types read as empty until the wiki is updated. The changelog files it under Breaking changes rather than Fixed for that reason, and dates the requirement at 2026-07-27, when the rename landed, because NeoWiki has no tagged releases to cite.

Update wikis before publishing the server.

## Why the reader does not fall back to the old name

NeoWiki is pre-1.0 and its wire format is still moving. An accommodation for every past shape is legacy code carried indefinitely for a transition that lasts days, and the accommodations accumulate faster than the format settles. Staying on the current field name only is the cheaper position until NeoWiki is stable.

These tools also register only on a wiki that has NeoWiki installed, so the affected wikis move in step with it rather than on their own schedules.

Reading `propertyType ?? type` is a two-line change if anyone judges it necessary; nothing here forecloses it.

neowiki-get-schema is untouched. A Schema's Property Definition still uses `type` upstream; only the Statement field moved.

## Tests

The existing fixtures pinned the old wire shape, which is why the suite stayed green through the break. They now carry `propertyType`, and neowiki-get-page-subjects gained a statement assertion, which it previously lacked entirely.

Verified beyond the suite by running the built `flattenSubject` against a live wiki on the merged NeoWiki code: statement types come back populated.

## Considered, omitted

- Renaming the tools' own output field from `type` to `propertyType`, to match the write tools' input. That would align the read and write shapes this server exposes and let the seven read-vs-write warnings in the write tools' descriptions be deleted rather than maintained. It is a separate concern from which upstream field is read, so it belongs in its own change.
- Dropping the `''` substitution so an undeterminable type reads as absent rather than blank, per the empty-value convention in `docs/tool-conventions.md`. That behaviour predates this change and is what made the break silent, but it is likewise a separate concern.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; implementation requested by @malberts after a review of the upstream NeoWiki pull request, redirected three times (from filing an issue to fixing it, then from dual-key tolerance to a straight swap, then to recategorise the changelog entry as breaking); not yet human-reviewed; test-driven (fixtures failed on the new shape before the fix), full suite, typecheck, lint and format gates green locally, and behaviour confirmed against a live wiki running the merged NeoWiki code.</sub>
