### PR TITLE
Close an orphan-rejection crash in /ready, and harden the idle-session close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Plugin installs can now be pointed at your own wiki. Claude Code prompts for a configuration file when the plugin is enabled, and the Codex plugin forwards the `CONFIG` environment variable from the shell Codex is launched from. Previously neither plugin offered a way to set `CONFIG`, leaving the server on English Wikipedia.
 - The server now warns at startup when `CONFIG` points at a file that does not exist. It previously fell back to the default English Wikipedia configuration with no indication of the misconfiguration, so a typo in the path meant silently talking to the wrong wiki.
 
+### Fixed
+
+- The HTTP server no longer exits when a `GET /ready` probe finds the default wiki slow or unreachable. The probe now answers the documented `503 not_ready` when its three-second budget runs out, whichever stage of the check is still outstanding.
+
 ## [0.14.0] - 2026-07-23
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - The HTTP server no longer exits when a `GET /ready` probe finds the default wiki slow or unreachable. The probe now answers the documented `503 not_ready` when its three-second budget runs out, whichever stage of the check is still outstanding.
+- Readiness probes that arrive while an earlier one is still running now share its result instead of each starting another check of the wiki. A slow wiki is asked once rather than once per waiting probe, and `mcp_ready_failures_total` counts one failure per probe rather than one per waiting request.
 
 ## [0.14.0] - 2026-07-23
 

--- a/src/auth/browserAuth.ts
+++ b/src/auth/browserAuth.ts
@@ -298,6 +298,10 @@ interface TimeoutHandle {
 	cancel: () => void;
 }
 
+// A rejecting deadline, and so safe only while every caller attaches a handler
+// in the same tick it is created, as doBrowserAuth does: Node ends the process
+// over a rejection nobody is subscribed to. A new deadline is better built to
+// resolve instead, as the /ready probe's is, since that needs no guard at all.
 function timeout(ms: number): TimeoutHandle {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	const promise = new Promise<never>((_, reject) => {

--- a/src/transport/sessionRegistry.ts
+++ b/src/transport/sessionRegistry.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express';
 import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { logger } from '../runtime/logger.js';
 
 export type SessionEntry = {
 	readonly transport: StreamableHTTPServerTransport;
@@ -63,7 +64,17 @@ export function markSessionIdle(
 		clearTimeout(entry.idleTimer);
 	}
 	entry.idleTimer = setTimeout(() => {
-		void sessions[sessionId]?.transport.close();
+		// Nothing awaits this close, and Node ends the process over a rejection
+		// nothing is subscribed to. The transport calls onclose last, after every
+		// stream's cleanup, so a close that fails also skips the entry removal —
+		// drop it here rather than keep a session no later timer will revisit.
+		sessions[sessionId]?.transport.close().catch((error: unknown) => {
+			delete sessions[sessionId];
+			logger.warning('Closing an idle session failed; dropped it from the registry', {
+				session_id: sessionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		});
 	}, idleTimeoutMs);
 	entry.idleTimer.unref();
 }

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -591,9 +591,14 @@ const READY_CACHE_TTL_MS = 5_000;
 // Exported so the probe tests can size their fixtures against the real budget.
 export const READY_PROBE_TIMEOUT_MS = 3_000;
 let readyCache: ReadyCacheEntry | null = null;
+// The probe currently running, shared by every request that arrives while it is
+// still going. The cache alone cannot do this: it only fills once a probe
+// finishes, which is the whole window a slow wiki spends in.
+let readyProbeInFlight: Promise<ReadyCacheEntry> | null = null;
 
 export function __resetReadyCacheForTesting(): void {
 	readyCache = null;
+	readyProbeInFlight = null;
 }
 
 // Both halves of the check as one promise, so the race spans the whole of it:
@@ -669,16 +674,32 @@ export function mountReadyEndpoint(
 	},
 ): void {
 	app.get('/ready', async (_req, res) => {
-		if (!readyCache || Date.now() >= readyCache.expiresAt) {
-			readyCache = await probeDefaultWiki(deps.activeWiki, deps.mwnProvider);
-			// Count distinct probe failures, not cached replays — K8s readiness
-			// probes that fire every second would otherwise inflate the counter
-			// 5x against a 5s cache for the same underlying outage.
-			if (readyCache.httpStatus !== 200) {
-				recordReadyFailure();
+		let entry = readyCache;
+		if (!entry || Date.now() >= entry.expiresAt) {
+			if (readyProbeInFlight) {
+				entry = await readyProbeInFlight;
+			} else {
+				const probe = probeDefaultWiki(deps.activeWiki, deps.mwnProvider);
+				readyProbeInFlight = probe;
+				try {
+					entry = await probe;
+				} finally {
+					// Retire only our own probe. Nothing can replace it mid-flight
+					// today, but clearing blind would discard a successor's.
+					if (readyProbeInFlight === probe) {
+						readyProbeInFlight = null;
+					}
+				}
+				readyCache = entry;
+				// Count distinct probe failures, not cached replays or the requests
+				// that merely waited on this probe — K8s readiness probes that fire
+				// every second would otherwise inflate the counter for one outage.
+				if (entry.httpStatus !== 200) {
+					recordReadyFailure();
+				}
 			}
 		}
-		res.status(readyCache.httpStatus).json(readyCache.payload);
+		res.status(entry.httpStatus).json(entry.payload);
 	});
 }
 

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -588,11 +588,24 @@ interface ReadyCacheEntry {
 }
 
 const READY_CACHE_TTL_MS = 5_000;
-const READY_PROBE_TIMEOUT_MS = 3_000;
+// Exported so the probe tests can size their fixtures against the real budget.
+export const READY_PROBE_TIMEOUT_MS = 3_000;
 let readyCache: ReadyCacheEntry | null = null;
 
 export function __resetReadyCacheForTesting(): void {
 	readyCache = null;
+}
+
+// Both halves of the check as one promise, so the race spans the whole of it:
+// resolving the provider can log in, which alone can outlast the budget.
+async function probeSiteInfo(mwnProvider: MwnProvider): Promise<void> {
+	const mwn = await mwnProvider.get();
+	await mwn.request({
+		action: 'query',
+		meta: 'siteinfo',
+		format: 'json',
+		siprop: 'general',
+	});
 }
 
 async function probeDefaultWiki(
@@ -601,25 +614,19 @@ async function probeDefaultWiki(
 ): Promise<ReadyCacheEntry> {
 	const wiki = activeWiki.getDefaultKey();
 	const checkedAt = new Date().toISOString();
+	// Resolves rather than rejects, so arming it before the race cannot orphan a
+	// rejection.
+	const timedOut = Symbol('probe timed out');
 	let timer: ReturnType<typeof setTimeout> | undefined;
-	const timeout = new Promise<never>((_, reject) => {
-		timer = setTimeout(
-			() => reject(new Error('probe timeout after 3000ms')),
-			READY_PROBE_TIMEOUT_MS,
-		);
+	const deadline = new Promise<typeof timedOut>((resolve) => {
+		timer = setTimeout(() => resolve(timedOut), READY_PROBE_TIMEOUT_MS);
 	});
 
 	try {
-		const mwn = await mwnProvider.get();
-		await Promise.race([
-			mwn.request({
-				action: 'query',
-				meta: 'siteinfo',
-				format: 'json',
-				siprop: 'general',
-			}),
-			timeout,
-		]);
+		const outcome = await Promise.race([probeSiteInfo(mwnProvider), deadline]);
+		if (outcome === timedOut) {
+			throw new Error(`probe timeout after ${READY_PROBE_TIMEOUT_MS}ms`);
+		}
 		return {
 			expiresAt: Date.now() + READY_CACHE_TTL_MS,
 			payload: { status: 'ready', wiki, checked_at: checkedAt },

--- a/tests/helpers/unhandledRejections.ts
+++ b/tests/helpers/unhandledRejections.ts
@@ -1,0 +1,18 @@
+import { onTestFinished } from 'vitest';
+
+// Collects unhandled rejections for the duration of the calling test, removing
+// the listener however the test ends. Vitest reports run-level unhandled errors
+// without attributing them to a test, so a test that asserts one of its own
+// watches for it here. The production symptom is a dead process, which never
+// reaches an assertion at all.
+export function watchUnhandledRejections(): unknown[] {
+	const seen: unknown[] = [];
+	const listener = (reason: unknown) => {
+		seen.push(reason);
+	};
+	process.on('unhandledRejection', listener);
+	onTestFinished(() => {
+		process.off('unhandledRejection', listener);
+	});
+	return seen;
+}

--- a/tests/transport/metrics.test.ts
+++ b/tests/transport/metrics.test.ts
@@ -90,6 +90,30 @@ describe('GET /metrics — enabled', () => {
 		expect(metrics.text).toMatch(/mcp_ready_failures_total 1/);
 	});
 
+	it('mcp_ready_failures_total counts one failure for concurrent probes', async () => {
+		// One outage, three simultaneous readiness probes: they share a single
+		// probe, so only the request that started it records the failure. The
+		// failure has to be slower than the requests take to arrive, or the first
+		// probe finishes and fills the cache before the others reach the handler.
+		mockRequest.mockImplementation(
+			() =>
+				new Promise((_resolve, reject) => {
+					setTimeout(() => reject(new Error('upstream down')), 50);
+				}),
+		);
+		const app = makeApp();
+		const responses = await Promise.all([
+			request(app).get('/ready'),
+			request(app).get('/ready'),
+			request(app).get('/ready'),
+		]);
+		for (const res of responses) {
+			expect(res.status).toBe(503);
+		}
+		const metrics = await request(app).get('/metrics');
+		expect(metrics.text).toMatch(/mcp_ready_failures_total 1/);
+	});
+
 	it('mcp_ready_failures_total does not double-count cached 503 replays', async () => {
 		mockRequest.mockRejectedValue(new Error('upstream down'));
 		const app = makeApp();

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -87,6 +87,30 @@ describe('/ready', () => {
 		expect(res.body.reason).toContain('connection refused');
 	});
 
+	it('shares one probe between requests that arrive before the first finishes', async () => {
+		// The cache only fills once a probe finishes, so without in-flight sharing
+		// every request arriving during a slow probe starts another one. Slow here
+		// means slower than the requests take to arrive, but well inside the budget.
+		mockRequest.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(() => resolve({ query: { general: {} } }), 50);
+				}),
+		);
+		const app = makeApp();
+
+		const responses = await Promise.all([
+			request(app).get('/ready'),
+			request(app).get('/ready'),
+			request(app).get('/ready'),
+		]);
+
+		for (const res of responses) {
+			expect(res.status).toBe(200);
+		}
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+	});
+
 	it('caches the result for 5 seconds', async () => {
 		vi.useFakeTimers();
 		mockRequest.mockResolvedValue({ query: { general: {} } });

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach, onTestFinished } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { watchUnhandledRejections } from '../helpers/unhandledRejections.js';
 
 const mockRequest = vi.fn();
 
@@ -41,20 +42,6 @@ function makeApp() {
 	const app = express();
 	mountReadyEndpoint(app, { activeWiki: mockActiveWiki, mwnProvider: mockMwnProvider });
 	return app;
-}
-
-// Vitest reports run-level unhandled errors without attributing them to a test,
-// so a test that cares about one collects it here.
-function watchUnhandledRejections(): unknown[] {
-	const seen: unknown[] = [];
-	const listener = (reason: unknown) => {
-		seen.push(reason);
-	};
-	process.on('unhandledRejection', listener);
-	onTestFinished(() => {
-		process.off('unhandledRejection', listener);
-	});
-	return seen;
 }
 
 // Resolving the wiki logs in and fetches site info, so it can outlast the
@@ -155,6 +142,7 @@ describe('/ready', () => {
 		const entry = await probe;
 
 		expect(rejections.map(String)).toEqual([]);
+		expect(entry.httpStatus).toBe(503);
 		// The deadline answered, so the later login failure had no one waiting on it.
 		expect(entry.payload.reason).toMatch(/timeout/i);
 	});

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, onTestFinished } from 'vitest';
 
 const mockRequest = vi.fn();
 
@@ -13,6 +13,7 @@ import {
 	mountReadyEndpoint,
 	__resetReadyCacheForTesting,
 	__probeDefaultWikiForTesting,
+	READY_PROBE_TIMEOUT_MS,
 } from '../../src/transport/streamableHttp.js';
 import type { ActiveWiki } from '../../src/wikis/activeWiki.js';
 import type { MwnProvider } from '../../src/wikis/mwnProvider.js';
@@ -40,6 +41,36 @@ function makeApp() {
 	const app = express();
 	mountReadyEndpoint(app, { activeWiki: mockActiveWiki, mwnProvider: mockMwnProvider });
 	return app;
+}
+
+// Vitest reports run-level unhandled errors without attributing them to a test,
+// so a test that cares about one collects it here.
+function watchUnhandledRejections(): unknown[] {
+	const seen: unknown[] = [];
+	const listener = (reason: unknown) => {
+		seen.push(reason);
+	};
+	process.on('unhandledRejection', listener);
+	onTestFinished(() => {
+		process.off('unhandledRejection', listener);
+	});
+	return seen;
+}
+
+// Resolving the wiki logs in and fetches site info, so it can outlast the
+// deadline before mwn.request is reached.
+function providerTaking(
+	ms: number,
+	settle: () => unknown = () => ({ request: mockRequest }),
+): MwnProvider {
+	return {
+		get: async () => {
+			await new Promise((resolve) => setTimeout(resolve, ms));
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Mwn has 100+ methods; tests only use request().
+			return settle() as never;
+		},
+		invalidate: () => {},
+	};
 }
 
 describe('/ready', () => {
@@ -93,6 +124,55 @@ describe('/ready', () => {
 
 		expect(entry.httpStatus).toBe(503);
 		expect(entry.payload.status).toBe('not_ready');
+		expect(entry.payload.reason).toMatch(/timeout/i);
+	});
+
+	it('times out while still resolving the wiki, without an orphan rejection', async () => {
+		vi.useFakeTimers();
+		const rejections = watchUnhandledRejections();
+		mockRequest.mockResolvedValue({ query: { general: { sitename: 'X' } } });
+
+		const probe = __probeDefaultWikiForTesting(mockActiveWiki, providerTaking(5_000));
+		await vi.advanceTimersByTimeAsync(5001);
+		const entry = await probe;
+
+		expect(rejections.map(String)).toEqual([]);
+		expect(entry.httpStatus).toBe(503);
+		expect(entry.payload.status).toBe('not_ready');
+		expect(entry.payload.reason).toMatch(/timeout/i);
+	});
+
+	it('stays quiet when resolving the wiki fails after the deadline has passed', async () => {
+		vi.useFakeTimers();
+		const rejections = watchUnhandledRejections();
+		const provider = providerTaking(5_000, () => {
+			throw new Error('login failed');
+		});
+
+		const probe = __probeDefaultWikiForTesting(mockActiveWiki, provider);
+		// Past the deadline, then past the failure that lands after it.
+		await vi.advanceTimersByTimeAsync(5001);
+		const entry = await probe;
+
+		expect(rejections.map(String)).toEqual([]);
+		// The deadline answered, so the later login failure had no one waiting on it.
+		expect(entry.payload.reason).toMatch(/timeout/i);
+	});
+
+	// Guards the shared budget rather than the crash: this is the case that fails
+	// if the two halves are ever given a deadline each. Both delays are derived
+	// from the real budget so that retuning it cannot quietly void the premise.
+	it('spends one budget across resolving the wiki and the site-info request', async () => {
+		vi.useFakeTimers();
+		// Neither half exceeds the budget alone; together they do.
+		const half = READY_PROBE_TIMEOUT_MS * 0.6;
+		mockRequest.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, half)));
+
+		const probe = __probeDefaultWikiForTesting(mockActiveWiki, providerTaking(half));
+		await vi.advanceTimersByTimeAsync(READY_PROBE_TIMEOUT_MS * 2);
+		const entry = await probe;
+
+		expect(entry.httpStatus).toBe(503);
 		expect(entry.payload.reason).toMatch(/timeout/i);
 	});
 });

--- a/tests/transport/streamableHttp.test.ts
+++ b/tests/transport/streamableHttp.test.ts
@@ -23,6 +23,7 @@ import {
 	withRequestContext,
 } from '../../src/runtime/requestContext.js';
 import { logger } from '../../src/runtime/logger.js';
+import { watchUnhandledRejections } from '../helpers/unhandledRejections.js';
 
 describe('handleListenError', () => {
 	function listenErr(code: string): NodeJS.ErrnoException {
@@ -573,6 +574,40 @@ describe('markSessionActive / markSessionIdle (idle expiry)', () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	// close is a plain function rather than a vi.fn on purpose: a spy subscribes to
+	// the promise it returns in order to record the settled result, which counts as
+	// handling the rejection and hides the very thing under test. Real timers keep
+	// the test to one 1ms hop, so there is no time to travel.
+	it('survives a transport that fails to close, and still drops the entry', async () => {
+		const rejections = watchUnhandledRejections();
+		const sessions: SessionRegistry = {};
+		let closeCalls = 0;
+		// Mirrors the real transport, which calls onclose only after every stream's
+		// cleanup: a close that fails never reaches the handler that would have
+		// removed the entry, so reaching onclose here would mean the test proved
+		// nothing about the catch.
+		const transport = {
+			close: () => {
+				closeCalls++;
+				return Promise.reject(new Error('socket already destroyed'));
+			},
+			onclose: () => {
+				throw new Error('onclose must not run when close fails');
+			},
+		} as unknown as SessionRegistry[string]['transport'];
+		sessions['sid-1'] = { transport, activeRequests: 0 };
+
+		markSessionActive(sessions, 'sid-1');
+		markSessionIdle(sessions, 'sid-1', 1);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(closeCalls).toBe(1);
+		// Nothing awaits this close, so an unhandled rejection ends the process
+		// rather than failing a request.
+		expect(rejections.map(String)).toEqual([]);
+		expect(sessions['sid-1']).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Fixes #491, plus three follow-ups in the same area kept as separate commits so any of them can be dropped by rebase.

The first three commits all concern **a promise rejection that nothing is subscribed to.** There is no `unhandledRejection` handler anywhere in this project, so Node promotes such a rejection to an uncaught exception and the process exits. That makes the failure mode a dead server on exactly the slow paths a server should survive.

## 1. `GET /ready` crashed on a slow wiki (#491)

`probeDefaultWiki` armed a three-second **rejecting** timer, then `await mwnProvider.get()`, and only afterwards reached the `Promise.race` that observes that timer. A default wiki slow to connect rejected the timeout into the void and killed the process.

`probeSiteInfo()` folds provider resolution and the site-info request into one promise so the race spans the whole check. The deadline now **resolves** with a sentinel instead of rejecting: a rejecting timer is safe only while nothing awaits between arming it and subscribing to it, an invariant no type and no test can enforce and whose violation is silent process death. Resolving removes the failure mode rather than avoiding it.

The issue suggested resolving the provider first and building the timeout immediately before the race. Not taken — that leaves the provider unbounded, which the issue itself calls a different bug in the next sentence.

**What actually changed, stated precisely.** The budget was always *armed* before the provider call, so it already spanned both halves; what was missing is that nothing *observed* the deadline until the provider resolved.

| case | before | after |
|---|---|---|
| provider fast, request hangs | `not_ready` at 3s | `not_ready` at 3s |
| provider + request together over budget | `not_ready` at 3s | `not_ready` at 3s |
| **provider alone over budget** | **unhandled rejection, process exits** | `not_ready` at 3s |
| both fast | `ready` | `ready` |

Exactly one row changed. No user saw a late `200` from that row, because the process died before any status was written.

## 2. The idle-session close — hardening, not an observed crash

`markSessionIdle` armed a timer that did `void sessions[sessionId]?.transport.close()`, discarding a promise with **no handler for its entire life**. `src/runtime/shutdown.ts` already wraps the identical call in try/catch because it treats it as fallible.

With the SDK version pinned today that close cannot actually reject: each stream `cleanup()` guards its own `streamController.close()`, the one unguarded cleanup is a bare `Map.delete`, and both `onclose` handlers only clear a timer and delete an entry. The dependency is a caret range, nothing awaits this call, and no request is in flight to absorb a failure — so this is prudence, not a fix for something users have hit, and it carries no CHANGELOG entry for that reason.

It also deletes the registry entry, because the transport calls `onclose` **last**, after every cleanup: a close that did fail would skip the entry removal it is responsible for, and leaving the entry would quietly unbound the idle-session lifetime `docs/deployment.md` documents. It logs a warning so a close that starts failing is not silent.

Residual, deliberately not chased: on a failing close the transport keeps its stream entries and `unregisterServer` never runs, so this bounds the *registry*, not the underlying stream. The SDK offers no force-close, and the alternative breaks the documented bound.

## 3. Concurrent readiness probes each ran their own check

The ready cache only fills once a probe *finishes*, so it could not damp the window a slow wiki spends inside one. A readiness probe every second against a wiki that takes the whole budget started a fresh probe per request until the first landed: three concurrent checks of the same wiki, three deadlines, and three increments of `mcp_ready_failures_total` for one outage — contradicting that counter's stated intent of counting distinct failures rather than cached replays.

Requests arriving while a probe runs now await it, and only the request that started it records the failure and fills the cache. Verified on a real server: three concurrent probes against a hanging wiki return identical bodies with the same `checked_at`, and `mcp_ready_failures_total` reads `1`.

## 4. A note on which deadline shape to copy

The sweep found a third idiom for this hazard: `src/auth/browserAuth.ts`'s `timeout(ms)` helper returns a rejecting promise nothing is subscribed to yet, safe only because its single caller attaches a handler two lines later. That invariant lived at the call site, where a second caller would never see it, and it is the exact shape #491 came from. The helper now states it and points at the resolving deadline. No behaviour change; the existing guards are correct and stay.

## A follow-up I dropped after measuring it

An earlier review reported that each abandoned probe retains ~820 bytes because `MwnProviderImpl` caches the *pending* `create()` promise, extrapolating to roughly 14 MB/day against a black-hole wiki. That measurement used a promise that never settles, which is not what happens: `Mwn.init` carries axios' 60-second timeout and mwn retries three times with a five-second pause, so the cached promise **rejects** after ~195s and `MwnProviderImpl` evicts it, releasing every reaction attached to it.

Measured against a real hanging wiki, probing `/ready` every 10 seconds for four minutes:

| elapsed | RSS | mwn retries logged |
|---|---|---|
| 0s | 125 848 kB | 0 |
| 60s | 127 716 kB | 1 |
| 120s | 99 316 kB | 2 |
| 180s | 98 408 kB | 3 |
| 240s | 98 920 kB | 3 |

Resident memory ends 27 MB **below** where it started. There is no leak to fix, so there is no commit for it.

## Verification

Locally: lint, `fmt:check`, `validate:server-json`, `tsc --noEmit`, build all exit 0; 1598 tests pass.

Every behavioural commit has a test that fails without it, each confirmed by reverting just that change in a scratch copy:

- `expected [ 'Error: probe timeout after 3000ms' ] to deeply equal []`
- `expected [ 'Error: socket already destroyed' ] to deeply equal []`
- `expected "vi.fn()" to be called 1 times, but got 3 times`, and the metric asserting `1` against an actual `3`

Wrong-but-plausible fixes were built to check the tests discriminate: both non-fixes #491 rejects are caught; a per-half deadline is caught only by the shared-budget test, which is why that test exists despite passing on both revisions; and a catch that delegates to `onclose` instead of deleting trips the idle-close test's `onclose` tripwire.

Two test traps worth recording, both of which produced a confidently wrong result first:

- The idle-close test uses a **plain function, not `vi.fn()`**, because a vitest spy subscribes to the promise it returns to record the settled result — which counts as handling the rejection. With `vi.fn` the listener saw zero rejections and the test silently proved nothing.
- `request(app).get(…)` is **lazy**: it only dispatches when awaited. A first version of the concurrency test resolved the probe before any request had been sent, so it failed for the wrong reason.

End to end on the HTTP transport, against a wiki that accepts TCP and never answers:

- before: process exits, `curl` gets a connection reset, stack trace matches the issue exactly.
- after: `503 {"status":"not_ready",…,"reason":"probe timeout after 3000ms"}` in 3.01s, alive across repeated timed-out probes, `/health` still 200.
- healthy wiki: `200 ready` in 0.24s.
- idle expiry with `MCP_SESSION_IDLE_TIMEOUT=3`: session initialises, serves `tools/list`, is reclaimed after the timeout (`400 No valid session ID provided`), server alive, no close-failure warning on the happy path.

The rest of the sweep is clean: `src/` has no other `void`-discarded promises, no async timer callbacks, and every `.then(` chain terminates in a guard. The `AbortController` / `AbortSignal.timeout` sites are immune by construction, since an abort is a signal mutation rather than a rejection.

`READY_PROBE_TIMEOUT_MS` is now exported so tests size fixtures against the real budget; without it, lowering the constant silently voided the shared-budget test's premise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)