### PR TITLE
Let plugin installs set the configuration file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ A client that just pastes the standard configuration gets a row in the client ta
 
 A client earns its own `###` section when its configuration shape differs from the standard `mcpServers` object, as OpenCode's `mcp` key does, or when it needs install-flow prose a table row cannot carry: plugin install commands, a bundle download, install badges, or more than one configuration file location. Antigravity is an example of the latter: its configuration shape is the standard one, but it needs two file locations plus a note about importing an existing Gemini CLI setup.
 
-Never add another copy of the standard configuration block: the point is not chasing a change through one block per client, though the badge payloads and `plugins/mediawiki-mcp-server/.mcp.json` carry their own copies that must be kept in step.
+Never add another copy of the standard configuration block: the point is not chasing a change through one block per client, though the badge payloads and the two plugin server declarations (`plugins/mediawiki-mcp-server/.mcp.json` and `.codex-plugin/mcp.json`) carry their own copies that must be kept in step.
 
 Retiring or adding a committed install channel needs a `## [Unreleased]` entry in CHANGELOG.md; documenting a client that needs no committed file does not.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - Reading NeoWiki subjects now requires a wiki running NeoWiki from 2026-07-27 or later, when a Statement's property type was renamed to `propertyType` (ProfessionalWiki/NeoWiki#1169). This fixes `neowiki-get-subject` and `neowiki-get-page-subjects` reporting an empty type for every statement against an updated wiki, and requires one: against an earlier NeoWiki the type now reads as empty. Update the wiki before upgrading the server.
 
+### Added
+
+- Plugin installs can now be pointed at your own wiki. Claude Code prompts for a configuration file when the plugin is enabled, and the Codex plugin forwards the `CONFIG` environment variable from the shell Codex is launched from. Previously neither plugin offered a way to set `CONFIG`, leaving the server on English Wikipedia.
+
 ## [0.14.0] - 2026-07-23
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Add this repository as a plugin marketplace, then install the bundled server:
 /plugin install mediawiki-mcp-server@professional-wiki
 ```
 
+The plugin takes an optional configuration file, which points the server at your own wiki. Set it from the prompt when enabling the plugin, or at any time with `/plugin configure mediawiki-mcp-server@professional-wiki`. A command-line install takes the same value via `claude plugin install mediawiki-mcp-server@professional-wiki --config configPath=path/to/config.json`.
+
 When installed as a plugin, the tools are namespaced `mcp__plugin_mediawiki-mcp-server_mediawiki__<tool>`; update any tool allowlists or hooks accordingly.
 
 To configure the server directly instead, see the [Claude Code MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp). The short version:
@@ -204,6 +206,8 @@ Add this repository as a plugin marketplace, then install the bundled server:
 codex plugin marketplace add ProfessionalWiki/MediaWiki-MCP-Server
 codex plugin add mediawiki-mcp-server@professional-wiki
 ```
+
+To point the plugin at your own wiki, set `CONFIG` in the shell you launch Codex from, for example `export CONFIG=path/to/config.json`. Codex has no per-plugin configuration; if you would rather not set an environment variable, `codex mcp add mediawiki --env CONFIG=path/to/config.json -- npx -y @professional-wiki/mediawiki-mcp-server@latest` registers the server directly and takes precedence over the plugin's copy.
 
 See the [Codex plugins documentation](https://developers.openai.com/codex/plugins) for how to list, update, or remove plugins.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,7 +19,7 @@ Commit a manifest for a client only when that client installs plugins from a rep
 
 ## Plugin layout
 
-Claude Code and Codex share one plugin directory and one server declaration:
+Claude Code and Codex share one plugin directory but keep separate server declarations:
 
 ```
 .claude-plugin/marketplace.json          Claude Code catalog
@@ -27,14 +27,16 @@ Claude Code and Codex share one plugin directory and one server declaration:
 plugins/mediawiki-mcp-server/
     .claude-plugin/plugin.json           Claude Code manifest
     .codex-plugin/plugin.json            Codex manifest
-    .mcp.json                            the shared server declaration
+    .codex-plugin/mcp.json               Codex server declaration
+    .mcp.json                            Claude Code server declaration
 ```
 
-Four constraints fix this shape:
+Five constraints fix this shape:
 
 - [Claude Code](https://code.claude.com/docs/en/plugin-marketplaces) reads its catalog only from `.claude-plugin/marketplace.json` at the repository root.
 - [Codex](https://developers.openai.com/codex/plugins) rejects a plugin whose source path is the repository root, so the plugin is a subdirectory.
-- Claude Code discovers `.mcp.json` at the plugin root, so its `plugin.json` omits `mcpServers`. Codex has no such discovery and points at the same file with `"mcpServers": "./.mcp.json"`.
+- Claude Code discovers `.mcp.json` at the plugin root, so its `plugin.json` omits `mcpServers` and that file must stay the Claude Code declaration. Codex has no such discovery and points at its own file with `"mcpServers": "./.codex-plugin/mcp.json"` (the path resolves against the plugin root).
+- The declarations differ because the clients pass `CONFIG` differently, and each client's mechanism is unsafe or inert on the other. The Claude Code file substitutes `${user_config.configPath}` from the enable-time prompt declared in its manifest's `userConfig`; Codex performs no substitution and would hand the server that literal string as a path. The Codex file instead forwards `CONFIG` from the parent environment by name with `env_vars`, a key Claude Code ignores. Codex strips the environment to a small whitelist without `env_vars`, while Claude Code passes it through in full.
 - The catalogs take different `source` shapes: a bare string for Claude Code, an object for Codex.
 
 Keep `.mcp.json` inside the plugin directory. Claude Code loads a repository-root `.mcp.json` as a project server, which would start this server for anyone working in this repository.
@@ -82,7 +84,7 @@ codex plugin add mediawiki-mcp-server@professional-wiki
 codex mcp list
 ```
 
-`plugin details` and `mcp list` each report the `mediawiki` server. Remove the test install afterwards:
+`plugin details` and `mcp list` each report the `mediawiki` server. When iterating on the plugin files, the two CLIs pick up edits differently: Claude Code runs a directory-source marketplace live, while Codex runs a cached snapshot, so re-run `codex plugin add` after each edit. Remove the test install afterwards:
 
 ```bash
 claude plugin uninstall mediawiki-mcp-server@professional-wiki

--- a/plugins/mediawiki-mcp-server/.claude-plugin/plugin.json
+++ b/plugins/mediawiki-mcp-server/.claude-plugin/plugin.json
@@ -20,5 +20,13 @@
     "knowledge",
     "wikibase",
     "smw"
-  ]
+  ],
+  "userConfig": {
+    "configPath": {
+      "type": "file",
+      "title": "Configuration file",
+      "description": "Path to a config.json pointing the server at your own wiki. Optional: without it the server targets English Wikipedia.",
+      "required": false
+    }
+  }
 }

--- a/plugins/mediawiki-mcp-server/.codex-plugin/mcp.json
+++ b/plugins/mediawiki-mcp-server/.codex-plugin/mcp.json
@@ -6,9 +6,9 @@
         "-y",
         "@professional-wiki/mediawiki-mcp-server@latest"
       ],
-      "env": {
-        "CONFIG": "${user_config.configPath}"
-      }
+      "env_vars": [
+        "CONFIG"
+      ]
     }
   }
 }

--- a/plugins/mediawiki-mcp-server/.codex-plugin/plugin.json
+++ b/plugins/mediawiki-mcp-server/.codex-plugin/plugin.json
@@ -20,7 +20,7 @@
     "wikibase",
     "smw"
   ],
-  "mcpServers": "./.mcp.json",
+  "mcpServers": "./.codex-plugin/mcp.json",
   "interface": {
     "displayName": "MediaWiki MCP Server",
     "category": "Developer Tools",


### PR DESCRIPTION
Closes #489.

## What changed

- **Claude Code plugin**: the manifest now declares `userConfig.configPath` (type `file`, optional), so enabling the plugin prompts for a configuration file, substituted into the server's `CONFIG` environment variable via `${user_config.configPath}`. It can also be set any time with `/plugin configure mediawiki-mcp-server@professional-wiki`, or non-interactively with `claude plugin install --config configPath=path/to/config.json`.
- **Codex plugin**: the server declaration now carries `"env_vars": ["CONFIG"]`, which forwards a shell-exported `CONFIG` through Codex's stripped MCP environment (Codex spawns servers with `env_clear()` plus a small whitelist and performs no `${VAR}` expansion). `env_vars` predates Codex plugin availability, so every plugin-capable Codex honors it.
- **The shared `.mcp.json` splits into per-client declarations**, because each client's mechanism is unsafe or inert on the other: Codex would pass `${user_config.configPath}` to the server as a literal path, and Claude Code ignores `env_vars`. `.mcp.json` stays the Claude Code file (it is auto-discovered at the plugin root); the Codex manifest now points at a new `.codex-plugin/mcp.json`.
- README plugin sections document each client's route; `docs/distribution.md` documents the split layout and the reasons.

## Verification

End-to-end installs from a local marketplace copy of these exact files, on claude 2.1.220 and codex-cli 0.145.0:

- `claude plugin validate` passes with the `userConfig` declaration; a `--config configPath=…` install delivers that value as `CONFIG` in the spawned server's environment; the real npx server connects (`claude mcp list` ✔ Connected).
- Codex resolves the new `"mcpServers": "./.codex-plugin/mcp.json"` pointer, forwards an exported `CONFIG` through the whitelist (captured server environment was exactly the whitelist plus `CONFIG`), and starts the real npx server.
- Degradation semantics were probed explicitly: an unset `${user_config.configPath}` substitutes to the empty string, which the server treats as unset (falls back to defaults, matching today's behavior). A `${user_config.X:-default}` fallback form silently drops the entire server entry on 2.1.220, which is why the plain reference is used.

Lint and format clean; `tsc --noEmit` and the full test suite (1590 tests) pass. No server code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)