### PR TITLE
Fail the release when a synced manifest is not staged

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -68,6 +68,8 @@ Adding a manifest to the sync takes three edits:
 - a `targets` entry in `scripts/sync-manifests.cjs`
 - the file added to the `git add` list in the `version` script in `package.json`, so the bump lands in the release commit
 
+The sync script checks that last edit was made, and stops on the first target missing from the `git add` list, because an unstaged manifest is synced on disk yet left out of the tag.
+
 ## Testing an install
 
 Both CLIs accept a local directory as a marketplace source, so an install can be exercised before publishing. From the repository root:

--- a/scripts/sync-manifests.cjs
+++ b/scripts/sync-manifests.cjs
@@ -2,7 +2,9 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const {
+	ROOT_DIR,
 	PACKAGE_JSON_PATH,
 	SERVER_JSON_PATH,
 	MANIFEST_JSON_PATH,
@@ -103,6 +105,33 @@ function setPath(target, dottedPath, value) {
 function getPath(target, dottedPath) {
 	return dottedPath.split('.').reduce((node, key) => node[key], target);
 }
+
+// The `version` script in package.json stages these same files by name, and
+// nothing but this check ties the two lists together. A target absent from the
+// `git add` list fails quietly: the manifest is synced on disk but never
+// committed, so the tag ships the previous version and the release leaves the
+// working tree dirty. Fail before anything is written instead.
+function assertTargetsAreStaged() {
+	const versionScript = packageJson.scripts?.version ?? '';
+	const gitAddCommands = [...versionScript.matchAll(/(?:^|&&|;)[^\S\n]*git\s+add\s+([^&|;\n]+)/g)];
+	if (gitAddCommands.length === 0) {
+		throw new Error(
+			'package.json: the version script no longer runs `git add`, so a release would commit no synced manifest',
+		);
+	}
+
+	const staged = new Set(gitAddCommands.flatMap((match) => match[1].trim().split(/\s+/)));
+	for (const { file, label } of targets) {
+		const relativePath = path.relative(ROOT_DIR, file).split(path.sep).join('/');
+		if (!staged.has(relativePath)) {
+			throw new Error(
+				`${label}: '${relativePath}' is missing from the \`git add\` list in the version script in package.json`,
+			);
+		}
+	}
+}
+
+assertTargetsAreStaged();
 
 console.log(`Syncing distribution manifests to version ${metadata.version}...`);
 


### PR DESCRIPTION
Closes #488.

`scripts/sync-manifests.cjs` and the `git add` list in the `version` script name the same files, with nothing tying the two together. Adding a target without extending the list is silent: the manifest is synced on disk, never staged, and the tag ships the previous version while the release leaves the working tree dirty.

`assertTargetsAreStaged()` now runs before anything is written. It extracts the `git add` argument list from the `version` script and throws naming any target absent from it, so a mismatch aborts the release instead of shipping a stale manifest.

## Whole paths rather than a substring test

The issue suggested `versionScript.includes( rel )`. That waves through a target nested under a staged path, and the repository already has a shape where this bites: a future target at `.claude-plugin/plugin.json` passes the substring test, because `plugins/mediawiki-mcp-server/.claude-plugin/plugin.json` is staged. The guard therefore splits the `git add` arguments into whole paths and tests set membership.

## Verification

Both acceptance criteria were exercised against a real `npm version patch` in a scratch clone, with only the `preversion` gate stubbed out.

| Scenario | Result |
| --- | --- |
| Lists in agreement | Release completes, `v0.14.1` tagged, working tree clean, all six manifests at the new version |
| New target absent from the `git add` list | Exit 1, `extra/manifest.json: 'extra/manifest.json' is missing from the git add list in the version script in package.json`. No tag, no release commit, no manifest written |
| Target nested under a staged path | Exit 1 with the same message shape. The substring test passes this one |
| `git add` removed from the `version` script | Exit 1, `the version script no longer runs git add, so a release would commit no synced manifest` |
| Standalone `npm run sync-manifests` | Unaffected, exit 0 |

`npm run lint`, `npm run fmt:check`, `npm run validate:server-json`, `tsc --noEmit` and the 1590-test suite all pass.

The guard reaches the release only through the `version` hook and `npm run sync-manifests`. `.github/workflows/release.yml` does not call the sync script, so CI is untouched.

## Worth knowing

npm bumps `package.json` and `package-lock.json` before running the `version` hook and does not revert them when the hook fails, so a caught mismatch leaves those two files modified. Nothing else changes: no commit, no tag, no manifest written. The fix-up is `git checkout package.json package-lock.json`, then add the missing path and re-run.

## Follow-ups, deliberately not in scope

- The check is one-directional. Removing a `targets` entry while its path stays in the `git add` list leaves that manifest silently unsynced. Closing that needs an allowlist for the staged paths that are not sync targets, `CHANGELOG.md` among them.
- `CHANGELOG.md` is written by `scripts/promote-changelog.cjs` and staged by the same list, so it carries the same exposure through a different script.
- A mismatch surfaces at release time rather than in CI on the pull request that introduces it.

No CHANGELOG entry: this is release tooling with no effect on the server that a user can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
