### PR TITLE
Warn when CONFIG points at a missing configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 
 - Plugin installs can now be pointed at your own wiki. Claude Code prompts for a configuration file when the plugin is enabled, and the Codex plugin forwards the `CONFIG` environment variable from the shell Codex is launched from. Previously neither plugin offered a way to set `CONFIG`, leaving the server on English Wikipedia.
+- The server now warns at startup when `CONFIG` points at a file that does not exist. It previously fell back to the default English Wikipedia configuration with no indication of the misconfiguration, so a typo in the path meant silently talking to the wrong wiki.
 
 ## [0.14.0] - 2026-07-23
 

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -384,6 +384,11 @@ function applyOAuth2ClientSecretOverride(
 
 export function loadConfigFromFile(): Config {
 	if (!fs.existsSync(configPath)) {
+		if (process.env.CONFIG) {
+			logger.warning(
+				`CONFIG points at "${configPath}", which does not exist. Falling back to the built-in default configuration (English Wikipedia). A relative path resolves against the server's working directory.`,
+			);
+		}
 		return { ...defaultConfig, uploadDirs: resolveUploadDirs(undefined) };
 	}
 	const rawData = fs.readFileSync(configPath, 'utf-8');

--- a/tests/config/loadConfig.test.ts
+++ b/tests/config/loadConfig.test.ts
@@ -38,6 +38,27 @@ describe('loadConfigFromFile', () => {
 			const { loadConfigFromFile, defaultConfig } = await import('../../src/config/loadConfig.js');
 			expect(loadConfigFromFile()).toEqual(defaultConfig);
 		});
+
+		it('warns when CONFIG points at a missing file', async () => {
+			vi.stubEnv('CONFIG', '/etc/mediawiki-mcp/absent.json');
+			vi.mocked(fs.existsSync).mockReturnValue(false);
+			const { loadConfigFromFile, defaultConfig } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile()).toEqual(defaultConfig);
+
+			const output = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+			expect(output).toContain('/etc/mediawiki-mcp/absent.json');
+			expect(output).toContain('does not exist');
+		});
+
+		it('does not warn when CONFIG is empty and config.json does not exist', async () => {
+			vi.stubEnv('CONFIG', '');
+			vi.mocked(fs.existsSync).mockReturnValue(false);
+			const { loadConfigFromFile, defaultConfig } = await import('../../src/config/loadConfig.js');
+			expect(loadConfigFromFile()).toEqual(defaultConfig);
+
+			const output = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+			expect(output).not.toContain('does not exist');
+		});
 	});
 
 	describe('${VAR} substitution in secret fields', () => {


### PR DESCRIPTION
Follow-up to #489/#494. The loader falls back to the built-in default configuration when the `CONFIG` path does not exist — silently. A typo'd path, a relative path resolved against an unexpected working directory, or an unmounted volume in Docker all meant serving English Wikipedia with no signal, which is the same stranding #489 described. Every configuration route (plugin prompt, env var, mcpb prompt) bottoms out in this failure mode.

## What changed

An explicitly set `CONFIG` that does not resolve to a file now logs a startup warning naming the path:

```
{"level":"warning","message":"CONFIG points at \"/nope/absent.json\", which does not exist. Falling back to the built-in default configuration (English Wikipedia). A relative path resolves against the server's working directory."}
```

An unset or empty `CONFIG` stays silent, since falling back is the documented default there — this includes the empty string a skipped Claude Code plugin prompt substitutes. Fallback behavior itself is unchanged; only the silence is gone.

## Verification

- New tests (written first, red then green): warning emitted with the offending path when `CONFIG` is set and missing; no warning when `CONFIG` is empty and `./config.json` is absent.
- Live boot of the built stdio server: `CONFIG=/nope/absent.json` emits the warning line on stderr before the startup event; `CONFIG=` boots silently to the default configuration.
- `tsc --noEmit`, lint, format, and the full suite (1592 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)