### PR TITLE
Adopt MCP 2026-07-28 on stdio via serveStdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
+- The server now speaks MCP protocol revision 2026-07-28 on the stdio transport. A client that negotiates it gets the revision's per-connection serving and receives tool and resource list-change notifications over its subscription streams; clients on earlier revisions are served exactly as before.
 - Plugin installs can now be pointed at your own wiki. Claude Code prompts for a configuration file when the plugin is enabled, and the Codex plugin forwards the `CONFIG` environment variable from the shell Codex is launched from. Previously neither plugin offered a way to set `CONFIG`, leaving the server on English Wikipedia.
 - The server now warns at startup when `CONFIG` points at a file that does not exist. It previously fell back to the default English Wikipedia configuration with no indication of the misconfiguration, so a typo in the path meant silently talking to the wrong wiki.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,21 +65,6 @@ export const createServer = async (
 		},
 	);
 
-	// Only legacy-era instances join the sendLoggingMessage broadcast: the
-	// 2026-07-28 revision has no unsolicited notifications/message channel
-	// (SEP-2577 deprecates the API), and a modern instance would churn the
-	// registry without ever delivering anything. A per-request legacy instance
-	// registers for its request's lifetime, so mid-call log lines still reach
-	// the caller on the response stream.
-	if (reqCtx === undefined || reqCtx.era === 'legacy') {
-		registerServer(server);
-		const previousOnClose = server.server.onclose;
-		server.server.onclose = (): void => {
-			unregisterServer(server);
-			previousOnClose?.();
-		};
-	}
-
 	const publisher: ChangePublisher = options.publisher ?? {
 		// A live connection's RegisteredTool toggles already emit their own
 		// listChanged; only the resource list needs an explicit push.
@@ -117,6 +102,24 @@ export const createServer = async (
 	// publish would fan change events out to unrelated clients on every
 	// request.
 	await applyGates();
+
+	// Only legacy-era instances join the sendLoggingMessage broadcast: the
+	// 2026-07-28 revision has no unsolicited notifications/message channel
+	// (SEP-2577 deprecates the API), and a modern instance would churn the
+	// registry without ever delivering anything. A per-request legacy instance
+	// registers for its request's lifetime, so mid-call log lines still reach
+	// the caller on the response stream. Registration comes last on purpose:
+	// the only unregister path is onclose, which never fires for an instance
+	// that failed mid-construction and was never connected, so registering any
+	// earlier would leak a dead entry per construction throw.
+	if (reqCtx === undefined || reqCtx.era === 'legacy') {
+		registerServer(server);
+		const previousOnClose = server.server.onclose;
+		server.server.onclose = (): void => {
+			unregisterServer(server);
+			previousOnClose?.();
+		};
+	}
 
 	return server;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/server';
-import type { RegisteredTool } from '@modelcontextprotocol/server';
+import type { McpRequestContext, RegisteredTool } from '@modelcontextprotocol/server';
 import { createRequire } from 'node:module';
 import { registerServer, unregisterServer } from './runtime/logger.js';
 import { registerAllTools } from './tools/index.js';
@@ -24,7 +24,26 @@ Writes, deletes, and uploads use the caller's \`Authorization: Bearer\` token wh
 
 Tool errors fall into seven categories: \`not_found\`, \`permission_denied\`, \`invalid_input\`, \`conflict\`, \`authentication\`, \`rate_limited\`, and \`upstream_failure\`. Reads that exceed a per-call cap return a truncation marker describing what was returned and how to fetch the rest.`;
 
-export const createServer = async (ctx: ToolContext): Promise<McpServer> => {
+// How a transport hands change events to clients that cannot receive them as
+// unsolicited pushes. The stdio entry rewrites a live connection's outbound
+// change notifications onto its subscriptions/listen streams, so the default
+// publisher below covers both stdio eras; the HTTP transport supplies one
+// backed by its handler's notify facade instead, because a per-request
+// instance has no client left to push to by the time anything changes.
+export interface ChangePublisher {
+	toolsChanged(): void;
+	resourcesChanged(): void;
+}
+
+export interface CreateServerOptions {
+	publisher?: ChangePublisher;
+}
+
+export const createServer = async (
+	ctx: ToolContext,
+	reqCtx?: Pick<McpRequestContext, 'era'>,
+	options: CreateServerOptions = {},
+): Promise<McpServer> => {
 	const server = new McpServer(
 		{
 			name: SERVER_NAME,
@@ -46,31 +65,45 @@ export const createServer = async (ctx: ToolContext): Promise<McpServer> => {
 		},
 	);
 
-	registerServer(server);
-	// The SDK transport only fires onclose on DELETE / explicit transport.close()
-	// / process termination — not on a raw HTTP disconnect. So this registry
-	// drains on the same lifecycle as the existing sessions map in
-	// streamableHttp.ts; long-lived stale sessions persist until DELETE arrives
-	// or the process ends. Acceptable because sendLoggingMessage to a closed
-	// transport rejects, and swallowNotificationError absorbs that quietly.
-	const previousOnClose = server.server.onclose;
-	server.server.onclose = (): void => {
-		unregisterServer(server);
-		previousOnClose?.();
+	// Only legacy-era instances join the sendLoggingMessage broadcast: the
+	// 2026-07-28 revision has no unsolicited notifications/message channel
+	// (SEP-2577 deprecates the API), and a modern instance would churn the
+	// registry without ever delivering anything. A per-request legacy instance
+	// registers for its request's lifetime, so mid-call log lines still reach
+	// the caller on the response stream.
+	if (reqCtx === undefined || reqCtx.era === 'legacy') {
+		registerServer(server);
+		const previousOnClose = server.server.onclose;
+		server.server.onclose = (): void => {
+			unregisterServer(server);
+			previousOnClose?.();
+		};
+	}
+
+	const publisher: ChangePublisher = options.publisher ?? {
+		// A live connection's RegisteredTool toggles already emit their own
+		// listChanged; only the resource list needs an explicit push.
+		toolsChanged: (): void => {},
+		resourcesChanged: (): void => {
+			server.sendResourceListChanged();
+		},
 	};
 
 	const tools = new Map<string, RegisteredTool>();
-	const reconcile = async (): Promise<void> => {
-		await reconcileTools(tools, {
+	const applyGates = (): Promise<void> =>
+		reconcileTools(tools, {
 			wikiRegistry: ctx.wikis,
 			transport: ctx.transport,
 			wikiProbe: ctx.wikiProbe,
 			extensionPacks,
 		});
-		// Notify clients that the wiki resource list may have changed (e.g. after
-		// add-wiki / remove-wiki). Also covers tool-list changes since toggling a
-		// RegisteredTool's enabled state already emits its own listChanged event.
-		server.sendResourceListChanged();
+	// The reconcile callback add-wiki / remove-wiki invoke: re-gate, then tell
+	// clients the wiki resource list (and with it the tool list) may have
+	// changed.
+	const reconcile = async (): Promise<void> => {
+		await applyGates();
+		publisher.resourcesChanged();
+		publisher.toolsChanged();
 	};
 
 	const registered = registerAllTools(server, reconcile, ctx);
@@ -79,7 +112,11 @@ export const createServer = async (ctx: ToolContext): Promise<McpServer> => {
 	}
 	registerAllResources(server, ctx);
 
-	await reconcile();
+	// Construction gates without publishing: a fresh instance has no
+	// subscribers yet, and under a per-request factory a construction-time
+	// publish would fan change events out to unrelated clients on every
+	// request.
+	await applyGates();
 
 	return server;
 };

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { logger } from '../runtime/logger.js';
 import { createServer } from '../server.js';
 import { emitStartupBanner } from '../runtime/banner.js';
@@ -20,17 +20,23 @@ async function main(): Promise<void> {
 			uploadDirs: state.uploadDirs,
 		},
 	);
-	const transport = new StdioServerTransport();
 	const ctx = createToolContext({ logger, state, transport: 'stdio' });
-	const server = await createServer(ctx);
 
-	await server.connect(transport);
+	// serveStdio owns the connection: the opening exchange pins the era, one
+	// instance from the factory serves the connection's lifetime, and on a
+	// modern-pinned connection the entry rewrites outbound change
+	// notifications onto its subscriptions/listen streams — so the default
+	// change publisher in createServer covers both eras here.
+	const handle = serveStdio((reqCtx) => createServer(ctx, reqCtx), {
+		onerror: (error) => logger.error(`stdio serving error: ${error.message}`),
+	});
+
 	// Stdio has no in-flight queue, so grace doesn't apply — log graceMs: 0
 	// to make that explicit in the shutdown event.
 	registerShutdownHandlers({
 		transport: 'stdio',
 		graceMs: 0,
-		stdioTransport: transport,
+		stdioTransport: handle,
 	});
 }
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -74,8 +74,30 @@ describe('createServer change publishing', () => {
 			expect(result.isError ?? false).toBe(false);
 			expect(publisher.resourcesChanged).toHaveBeenCalledTimes(1);
 			expect(publisher.toolsChanged).toHaveBeenCalledTimes(1);
+			expect(publisher.resourcesChanged.mock.invocationCallOrder[0]).toBeLessThan(
+				publisher.toolsChanged.mock.invocationCallOrder[0],
+			);
 		} finally {
 			await client.close();
 		}
+	});
+
+	it('does not leave a failed construction registered with the logger broadcast', async () => {
+		const ctx = fakeContext({
+			wikiProbe: {
+				hasExtension: (async () => false) as never,
+				// Fails the construction-time gating pass, after tool registration.
+				hasAnyExtension: (async () => {
+					throw new Error('probe exploded');
+				}) as never,
+				inspect: (() => {}) as never,
+				invalidate: (() => {}) as never,
+			},
+		});
+		await expect(createServer(ctx, { era: 'legacy' })).rejects.toThrow('probe exploded');
+		// The throw happened before registration, so nothing leaked: the only
+		// unregister path is onclose, which never fires for an instance that was
+		// never connected.
+		expect(getRegisteredServerCount()).toBe(0);
 	});
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport } from '@modelcontextprotocol/server';
+import { createServer } from '../src/server.js';
+import { clearRegisteredServers, getRegisteredServerCount } from '../src/runtime/logger.js';
+import { fakeContext } from './helpers/fakeContext.js';
+
+afterEach(() => {
+	clearRegisteredServers();
+});
+
+describe('createServer era gating', () => {
+	it('registers with the logger broadcast when built without a request context', async () => {
+		await createServer(fakeContext());
+		expect(getRegisteredServerCount()).toBe(1);
+	});
+
+	it('registers a legacy-era instance with the logger broadcast', async () => {
+		await createServer(fakeContext(), { era: 'legacy' });
+		expect(getRegisteredServerCount()).toBe(1);
+	});
+
+	it('does not register a modern-era instance', async () => {
+		await createServer(fakeContext(), { era: 'modern' });
+		expect(getRegisteredServerCount()).toBe(0);
+	});
+});
+
+const wikiConfig = {
+	sitename: 'Test',
+	server: 'https://test.wiki',
+	articlepath: '/wiki',
+	scriptpath: '/w',
+	tags: null,
+};
+
+describe('createServer change publishing', () => {
+	it('does not publish during construction', async () => {
+		const publisher = { toolsChanged: vi.fn(), resourcesChanged: vi.fn() };
+		await createServer(fakeContext(), undefined, { publisher });
+		expect(publisher.toolsChanged).not.toHaveBeenCalled();
+		expect(publisher.resourcesChanged).not.toHaveBeenCalled();
+	});
+
+	it('publishes through the supplied publisher when a management tool reconciles', async () => {
+		const wikis: Record<string, typeof wikiConfig> = {
+			'test-wiki': wikiConfig,
+			'fr.wikipedia.org': wikiConfig,
+			'de.wikipedia.org': wikiConfig,
+		};
+		const ctx = fakeContext({
+			wikis: {
+				getAll: () => wikis as never,
+				get: ((key: string) => (Object.hasOwn(wikis, key) ? wikis[key] : undefined)) as never,
+				add: vi.fn() as never,
+				remove: ((key: string) => {
+					delete wikis[key];
+				}) as never,
+				isManagementAllowed: () => true,
+			},
+			wikiCache: { invalidate: vi.fn() as never },
+		});
+		const publisher = { toolsChanged: vi.fn(), resourcesChanged: vi.fn() };
+		const server = await createServer(ctx, { era: 'legacy' }, { publisher });
+
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: 'server-test', version: '0.0.0' });
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+		try {
+			const result = await client.callTool({
+				name: 'remove-wiki',
+				arguments: { uri: 'mcp://wikis/fr.wikipedia.org' },
+			});
+			expect(result.isError ?? false).toBe(false);
+			expect(publisher.resourcesChanged).toHaveBeenCalledTimes(1);
+			expect(publisher.toolsChanged).toHaveBeenCalledTimes(1);
+		} finally {
+			await client.close();
+		}
+	});
+});


### PR DESCRIPTION
First of two stacked PRs adopting the [MCP 2026-07-28 protocol revision](https://ts.sdk.modelcontextprotocol.io/v2/migration/support-2026-07-28.md). This one covers the stdio transport and the server-factory groundwork; the HTTP cutover follows in the second PR.

## What changes

- `createServer` becomes an era-aware factory: it accepts the SDK's per-instance construction context and an optional change publisher, gates tools at construction (reusing `reconcileTools` unchanged), and publishes change events only from the add-wiki / remove-wiki reconcile callback. The default publisher preserves today's behaviour exactly.
- Logger-broadcast registration is gated to legacy-era instances (the 2026-07-28 revision has no unsolicited `notifications/message` channel) and now happens only after construction succeeds — a construction throw previously would have leaked the half-built instance in the broadcast set, which matters once the HTTP PR builds instances per request.
- Stdio boots through `serveStdio(factory)`: the opening exchange pins the connection's era. 2025-era clients are served exactly as before; 2026-07-28 clients get modern serving from the same factory, with change notifications rewritten onto their `subscriptions/listen` streams by the SDK.

## Notes for review

- A subagent code review ran against this range ("ready to merge with fixes"; both fixes are included): it verified against the SDK sources that the discarded `server/discover` probe instance never registers with the logger broadcast, that onclose chaining survives `connect`, and that the default publisher surfaces exactly what the old inline call surfaced.
- One deliberate deviation from byte-equivalence for 2025 clients: `serveStdio`'s `onerror` now logs out-of-band transport errors (previously dropped silently). Error paths only.
- The CHANGELOG entry here is stdio-scoped; the HTTP PR replaces it with a both-transports entry, so the two PRs should land in the same release train.

## Testing

- 1,617 tests green at this tip; lint, format, and build clean.
- New suite `tests/server.test.ts`: era-gated registration, construction-does-not-publish, publisher ordering through a real client over `InMemoryTransport`, and a regression test for the failed-construction leak.
- Manual smoke: a legacy `initialize` over stdin round-trips against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)