### PR TITLE
Inherit the read-only posture when adding a wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 - The HTTP server no longer exits when a `GET /ready` probe finds the default wiki slow or unreachable; it answers the documented `503 not_ready` instead.
 - Readiness probes arriving while an earlier one is still running now share its result, so a slow wiki is asked once rather than once per waiting probe.
+- A wiki added with `add-wiki` to a deployment where every wiki is read-only is now read-only itself. It was previously writable, which revealed all the write tools.
 
 ## [0.14.0] - 2026-07-23
 

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -47,6 +47,16 @@ export const addWiki: Tool<typeof inputSchema, ManagementContext> = {
 			);
 		}
 
+		// A wiki added at runtime must not be more privileged than the deployment
+		// it joins. `add-wiki` takes only a URL, so the caller cannot express a
+		// read-only intent; inheriting the restrictive posture is the safe
+		// reading of an ambiguous request. Without this, one call on an
+		// all-read-only deployment revealed every write tool, because the
+		// tools/list gate offers writes as soon as ANY configured wiki is
+		// writable and an added wiki carried no `readOnly` field at all.
+		const configured = Object.values(ctx.wikis.getAll());
+		const readOnly = configured.length > 0 && configured.every((w) => w.readOnly === true);
+
 		try {
 			ctx.wikis.add(wikiInfo.servername, {
 				sitename: wikiInfo.sitename,
@@ -55,6 +65,7 @@ export const addWiki: Tool<typeof inputSchema, ManagementContext> = {
 				scriptpath: wikiInfo.scriptpath,
 				token: null,
 				private: false,
+				readOnly,
 			});
 		} catch (error) {
 			if (error instanceof DuplicateWikiKeyError) {

--- a/tests/tools/add-wiki.test.ts
+++ b/tests/tools/add-wiki.test.ts
@@ -4,9 +4,13 @@ vi.mock('../../src/wikis/wikiDiscovery.js', () => ({
 	discoverWiki: vi.fn(),
 }));
 
+import type { RegisteredTool } from '@modelcontextprotocol/server';
 import { discoverWiki } from '../../src/wikis/wikiDiscovery.js';
 import { SsrfValidationError } from '../../src/transport/ssrfGuard.js';
-import { DuplicateWikiKeyError } from '../../src/wikis/wikiRegistry.js';
+import { DuplicateWikiKeyError, WikiRegistryImpl } from '../../src/wikis/wikiRegistry.js';
+import type { WikiConfig } from '../../src/config/loadConfig.js';
+import { reconcileTools } from '../../src/runtime/reconcile.js';
+import { WRITE_TOOL_NAMES } from '../../src/runtime/wikiCapability.js';
 import { formatPayload } from '../../src/results/format.js';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.js';
 import { fakeManagementContext } from '../helpers/fakeContext.js';
@@ -61,6 +65,92 @@ describe('add-wiki', () => {
 			}),
 		);
 		expect(reconcile).toHaveBeenCalledTimes(1);
+	});
+
+	function discoversExampleOrg(): void {
+		vi.mocked(discoverWiki).mockResolvedValue({
+			servername: 'example.org',
+			sitename: 'Example Wiki',
+			server: 'https://example.org',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+		});
+	}
+
+	function wikiConfig(overrides: Partial<WikiConfig> = {}): WikiConfig {
+		return {
+			sitename: 'Existing',
+			server: 'https://existing.example',
+			articlepath: '/wiki',
+			scriptpath: '/w',
+			...overrides,
+		};
+	}
+
+	it('makes the added wiki read-only when every configured wiki is read-only', async () => {
+		discoversExampleOrg();
+		const registry = new WikiRegistryImpl(
+			{ 'existing.example': wikiConfig({ readOnly: true }) },
+			true,
+		);
+		const ctx = fakeManagementContext({ reconcile: vi.fn(), wikis: registry });
+
+		await dispatch(addWiki, ctx)({ wikiUrl: 'https://example.org/' });
+
+		expect(registry.get('example.org')?.readOnly).toBe(true);
+	});
+
+	it('leaves the added wiki writable when any configured wiki is writable', async () => {
+		discoversExampleOrg();
+		const registry = new WikiRegistryImpl(
+			{
+				'ro.example': wikiConfig({ readOnly: true }),
+				'rw.example': wikiConfig({ readOnly: false }),
+			},
+			true,
+		);
+		const ctx = fakeManagementContext({ reconcile: vi.fn(), wikis: registry });
+
+		await dispatch(addWiki, ctx)({ wikiUrl: 'https://example.org/' });
+
+		expect(registry.get('example.org')?.readOnly).toBe(false);
+	});
+
+	// The behaviour the inheritance exists for, proven through the real registry
+	// and the real gating rules rather than by composing two unit assertions.
+	it('keeps the write tools hidden after adding a wiki to a read-only deployment', async () => {
+		discoversExampleOrg();
+		const registry = new WikiRegistryImpl({ 'ro.example': wikiConfig({ readOnly: true }) }, true);
+		const ctx = fakeManagementContext({ reconcile: vi.fn(), wikis: registry });
+
+		const tools = new Map<string, RegisteredTool>();
+		const states = new Map<string, boolean>();
+		for (const name of [...WRITE_TOOL_NAMES, 'get-page']) {
+			states.set(name, true);
+			tools.set(name, {
+				get enabled() {
+					return states.get(name) === true;
+				},
+				enable: () => states.set(name, true),
+				disable: () => states.set(name, false),
+			} as unknown as RegisteredTool);
+		}
+		const deps = {
+			wikiRegistry: registry,
+			transport: 'http' as const,
+			wikiProbe: { hasAnyExtension: async () => false } as never,
+			extensionPacks: [],
+		};
+
+		await reconcileTools(tools, deps);
+		expect(WRITE_TOOL_NAMES.every((n) => states.get(n) === false)).toBe(true);
+
+		await dispatch(addWiki, ctx)({ wikiUrl: 'https://example.org/' });
+		await reconcileTools(tools, deps);
+
+		// Still hidden: the added wiki inherited the deployment's read-only posture.
+		expect(WRITE_TOOL_NAMES.every((n) => states.get(n) === false)).toBe(true);
+		expect(states.get('get-page')).toBe(true);
 	});
 
 	it('categorises SSRF rejections as invalid_input', async () => {


### PR DESCRIPTION
Found by the same compliance audit as #499, as an incidental discovery rather than a spec finding.

## The bug

`add-wiki` stored no `readOnly` field on the wiki it created, so an added wiki was writable. The `tools/list` gate offers the write tools as soon as *any* configured wiki is writable:

```ts
isAllowed: (c) => Object.values(c.allWikis).some((w) => w.readOnly !== true),
```

So on a deployment where every configured wiki was `readOnly: true`, one `add-wiki` call revealed all nine write tools. Measured during the audit: 16 tools before, 27 after.

The per-call capability guard still refused the actual writes, so this was a wrong advertised tool set rather than an authorization hole — but the tool set is what a model plans against, so it would offer the user edits that can only fail.

## The fix

An added wiki inherits the deployment's posture: read-only when every configured wiki is read-only, writable otherwise. `add-wiki` takes only a URL, so the caller cannot express a read-only intent either way; inheriting the restrictive posture is the safe reading of an ambiguous request.

An operator who wants a writable wiki on an otherwise read-only deployment still declares it in `config.json`, as they must today to set any per-wiki field.

## Testing

Three new tests, all confirmed to fail against the unfixed code before passing:

- an added wiki is read-only when every configured wiki is read-only;
- an added wiki stays writable when any configured wiki is writable;
- end-to-end through the real registry and the real gating rules: the write tools are hidden before `add-wiki`, and still hidden after, while a read tool stays enabled.

Full suite green (1,599), lint, format, `tsc`, and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)