### PR TITLE
Stop wiki requests when the caller cancels a tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki, instead of letting it run to completion. Cancelling a write is not an undo: an edit already committed by the wiki stays committed.
+- Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki, instead of letting it run to completion. Cancelling a write is not an undo: an edit already committed by the wiki stays committed. Cancelled calls are logged as `cancelled` rather than counted as wiki failures.
 - Reading an `mcp://wikis/{wikiKey}` resource for a wiki that is not configured now fails with a JSON-RPC `-32602` error naming the URI, as the protocol requires. It previously returned an empty document, which a client could not tell from a wiki with nothing to report.
 - Wiki keys are now percent-encoded in the `mcp://wikis/` URIs the server publishes, and decoded when one is read or passed as a `wiki` argument, so a key containing a character that needs escaping, such as `%`, a comma or a non-ASCII letter, is now reachable. A key that is already a plain hostname, with or without a port, keeps the URI it had.
 - A wiki key beginning with `mcp://wikis/` is refused at startup instead of being accepted and then resolving to the wrong wiki.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki. It previously ran to completion, so an abandoned call kept working the wiki's API after nobody was waiting for the answer.
 - Reading an `mcp://wikis/{wikiKey}` resource for a wiki that is not configured now fails with a JSON-RPC `-32602` error naming the URI, as the protocol requires. It previously returned an empty document, which a client could not tell from a wiki with nothing to report.
 - Wiki keys are now percent-encoded in the `mcp://wikis/` URIs the server publishes, and decoded when one is read or passed as a `wiki` argument, so a key containing a character that needs escaping, such as `%`, a comma or a non-ASCII letter, is now reachable. A key that is already a plain hostname, with or without a port, keeps the URI it had.
 - A wiki key beginning with `mcp://wikis/` is refused at startup instead of being accepted and then resolving to the wrong wiki.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki. It previously ran to completion, so an abandoned call kept working the wiki's API after nobody was waiting for the answer.
+- Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki, instead of letting it run to completion. Cancelling a write is not an undo: an edit already committed by the wiki stays committed.
 - Reading an `mcp://wikis/{wikiKey}` resource for a wiki that is not configured now fails with a JSON-RPC `-32602` error naming the URI, as the protocol requires. It previously returned an empty document, which a client could not tell from a wiki with nothing to report.
 - Wiki keys are now percent-encoded in the `mcp://wikis/` URIs the server publishes, and decoded when one is read or passed as a `wiki` argument, so a key containing a character that needs escaping, such as `%`, a comma or a non-ASCII letter, is now reachable. A key that is already a plain hostname, with or without a port, keeps the URI it had.
 - A wiki key beginning with `mcp://wikis/` is refused at startup instead of being accepted and then resolving to the wrong wiki.

--- a/src/runtime/createContext.ts
+++ b/src/runtime/createContext.ts
@@ -8,6 +8,8 @@ import { EditServiceImpl } from '../services/editService.js';
 import { RevisionNormalizerImpl } from '../services/revisionNormalize.js';
 import { ResponseFormatterImpl } from '../results/response.js';
 import { ErrorClassifierImpl } from '../errors/classifyError.js';
+import { withAbortSignal } from '../wikis/abortableMwn.js';
+import { getRequestSignal } from './requestContext.js';
 
 export function createToolContext(deps: {
 	logger: Logger;
@@ -17,7 +19,14 @@ export function createToolContext(deps: {
 }): ToolContext {
 	const { logger, state, transport, getProxyConfig } = deps;
 	return {
-		mwn: (wikiKey?: string) => state.mwnProvider.get(wikiKey),
+		// The cached instance is shared across requests, so the caller's
+		// cancellation signal is applied as a per-request view over it rather
+		// than being set on the instance itself.
+		mwn: async (wikiKey?: string) => {
+			const bot = await state.mwnProvider.get(wikiKey);
+			const signal = getRequestSignal();
+			return signal === undefined ? bot : withAbortSignal(bot, signal);
+		},
 		wikis: state.wikiRegistry,
 		activeWiki: state.activeWiki,
 		uploadDirs: state.uploadDirs,

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -4,7 +4,7 @@ import type { Tool } from './tool.js';
 import type { ToolContext } from './context.js';
 import { applySpecialCase } from '../errors/specialCases.js';
 import { errorMessage } from '../errors/isErrnoException.js';
-import { getRuntimeToken, withRequestFields } from './requestContext.js';
+import { getRequestSignal, getRuntimeToken, withRequestFields } from './requestContext.js';
 import { isWikiScoped, normalizeWikiArg } from './wikiArg.js';
 import {
 	emitToolCall,
@@ -140,12 +140,27 @@ async function runDispatchInner<TSchema extends ZodRawShape, TCtx extends ToolCo
 		const finalMessage = tailored ? overridden.message : `Failed to ${verb}: ${overridden.message}`;
 		errorText = finalMessage;
 
-		ctx.logger.error('Tool failed', {
-			tool: tool.name,
-			category: overridden.category,
-			code: overridden.code,
-		});
+		// A cancelled call fails on the way down — mwn surfaces the torn-down
+		// request as a malformed response rather than as an abort — so the
+		// classification describes the teardown, not the wiki. Reporting it as an
+		// upstream failure would make every cancellation look like an outage.
+		// The result is still built, and still discarded: the caller has gone.
+		if (getRequestSignal()?.aborted === true) {
+			ctx.logger.info('Tool call cancelled', { tool: tool.name });
+		} else {
+			ctx.logger.error('Tool failed', {
+				tool: tool.name,
+				category: overridden.category,
+				code: overridden.code,
+			});
+		}
 		result = ctx.format.error(overridden.category, finalMessage, overridden.code);
+	}
+
+	// Covers both failure routes above: a throw, and a tool that catches the
+	// abort itself and returns an error result.
+	if (outcome !== 'success' && getRequestSignal()?.aborted === true) {
+		outcome = 'cancelled';
 	}
 
 	// Echo the resolved wiki back to the caller. Re-wrap via structuredResult

--- a/src/runtime/instrument.ts
+++ b/src/runtime/instrument.ts
@@ -4,7 +4,10 @@ import { emitTelemetryEvent } from './logger.js';
 import { recordToolCall } from './metrics.js';
 import type { ErrorCategory } from '../errors/classifyError.js';
 
-export type ToolOutcome = 'success' | ErrorCategory;
+// `cancelled` sits alongside ErrorCategory rather than inside it: the caller
+// walked away, which is not a fault to classify or to shape into a response.
+// It only needs to be distinguishable in the logs and the metric.
+export type ToolOutcome = 'success' | 'cancelled' | ErrorCategory;
 
 const WARNING_OUTCOMES: ReadonlySet<ToolOutcome> = new Set([
 	'not_found',
@@ -16,7 +19,8 @@ const WARNING_OUTCOMES: ReadonlySet<ToolOutcome> = new Set([
 ]);
 
 export function levelFor(outcome: ToolOutcome): 'info' | 'warning' | 'error' {
-	if (outcome === 'success') {
+	// A cancellation is ordinary client behaviour, not a degradation.
+	if (outcome === 'success' || outcome === 'cancelled') {
 		return 'info';
 	}
 	if (outcome === 'upstream_failure') {

--- a/src/runtime/register.ts
+++ b/src/runtime/register.ts
@@ -1,6 +1,7 @@
 import type {
 	McpServer,
 	RegisteredTool,
+	ServerContext,
 	ToolCallback,
 	CallToolResult,
 } from '@modelcontextprotocol/server';
@@ -9,6 +10,18 @@ import type { Tool } from './tool.js';
 import type { ToolContext } from './context.js';
 import { buildToolInputSchema } from './wikiArg.js';
 import { withRequestFields } from './requestContext.js';
+
+/**
+ * Runs `fn` with the SDK request's cancellation signal in the request scope, so
+ * `ctx.mwn()` can apply it to that request's MediaWiki calls. The signal lives
+ * at `ctx.mcpReq.signal`, not on the context root. The key is written only when
+ * a signal is actually present, so a scope set further out is never clobbered
+ * with `undefined`.
+ */
+function withRequestScope<T>(ctx: ServerContext | undefined, fn: () => Promise<T>): Promise<T> {
+	const signal = ctx?.mcpReq?.signal;
+	return signal === undefined ? fn() : withRequestFields({ signal }, fn);
+}
 
 export function register<TSchema extends ZodRawShape, TCtx extends ToolContext>(
 	server: McpServer,
@@ -30,13 +43,12 @@ export function register<TSchema extends ZodRawShape, TCtx extends ToolContext>(
 		// The SDK callback signature is `(args, ctx) => ...`. Descriptor handlers
 		// take only `args`, so the `ctx` the SDK supplies is consumed here: its
 		// cancellation signal goes into the request scope, where `ctx.mwn()`
-		// picks it up and applies it to that request's MediaWiki calls. We widen
-		// the type because TypeScript can't unify our concrete handler with the
-		// SDK's generic `ToolCallback` through the generic boundary.
+		// picks it up and applies it to that request's MediaWiki calls. The
+		// parameter is typed as the SDK's own `ServerContext` rather than a
+		// hand-written shape so the compiler checks the property path — the cast
+		// below erases it, and an invented shape silently reads `undefined`.
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generic boundary; MCP SDK's ToolCallback can't be unified with our typed handler
-		((args: z.infer<z.ZodObject<TSchema>>, extra: { signal?: AbortSignal }) =>
-			withRequestFields({ signal: extra?.signal }, () => handler(args))) as unknown as ToolCallback<
-			z.ZodObject<TSchema>
-		>,
+		((args: z.infer<z.ZodObject<TSchema>>, ctx: ServerContext) =>
+			withRequestScope(ctx, () => handler(args))) as unknown as ToolCallback<z.ZodObject<TSchema>>,
 	);
 }

--- a/src/runtime/register.ts
+++ b/src/runtime/register.ts
@@ -8,6 +8,7 @@ import type { ZodRawShape, z } from 'zod';
 import type { Tool } from './tool.js';
 import type { ToolContext } from './context.js';
 import { buildToolInputSchema } from './wikiArg.js';
+import { withRequestFields } from './requestContext.js';
 
 export function register<TSchema extends ZodRawShape, TCtx extends ToolContext>(
 	server: McpServer,
@@ -26,11 +27,16 @@ export function register<TSchema extends ZodRawShape, TCtx extends ToolContext>(
 			inputSchema: buildToolInputSchema(tool) as z.ZodObject<TSchema>,
 			annotations: tool.annotations,
 		},
-		// The SDK callback signature is `(args, ctx) => ...`. Our descriptor
-		// handlers ignore the `ctx` parameter, so we widen the type here:
-		// TypeScript can't unify our concrete handler with the SDK's generic
-		// `ToolCallback` through the generic boundary.
+		// The SDK callback signature is `(args, ctx) => ...`. Descriptor handlers
+		// take only `args`, so the `ctx` the SDK supplies is consumed here: its
+		// cancellation signal goes into the request scope, where `ctx.mwn()`
+		// picks it up and applies it to that request's MediaWiki calls. We widen
+		// the type because TypeScript can't unify our concrete handler with the
+		// SDK's generic `ToolCallback` through the generic boundary.
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- generic boundary; MCP SDK's ToolCallback can't be unified with our typed handler
-		handler as unknown as ToolCallback<z.ZodObject<TSchema>>,
+		((args: z.infer<z.ZodObject<TSchema>>, extra: { signal?: AbortSignal }) =>
+			withRequestFields({ signal: extra?.signal }, () => handler(args))) as unknown as ToolCallback<
+			z.ZodObject<TSchema>
+		>,
 	);
 }

--- a/src/runtime/requestContext.ts
+++ b/src/runtime/requestContext.ts
@@ -3,12 +3,19 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 interface RequestContext {
 	runtimeToken?: string;
 	wikiKey?: string;
+	signal?: AbortSignal;
 }
 
 export const runtimeTokenStore = new AsyncLocalStorage<RequestContext>();
 
 export function getRuntimeToken(): string | undefined {
 	return runtimeTokenStore.getStore()?.runtimeToken;
+}
+
+// The MCP request's cancellation signal, aborted when the client cancels the
+// request or the connection drops. Undefined outside a request scope.
+export function getRequestSignal(): AbortSignal | undefined {
+	return runtimeTokenStore.getStore()?.signal;
 }
 
 export function getRequestWiki(): string | undefined {

--- a/src/runtime/requestContext.ts
+++ b/src/runtime/requestContext.ts
@@ -38,3 +38,16 @@ export function withRequestFields<T>(
 	const current = runtimeTokenStore.getStore() ?? {};
 	return runtimeTokenStore.run({ ...current, ...fields }, fn);
 }
+
+/**
+ * Runs `fn` with the cancellation signal detached, keeping the rest of the
+ * scope (notably the runtime token, which the call still needs to authenticate).
+ *
+ * For work that outlives the request that happened to trigger it: a result
+ * shared between concurrent callers must not be torn down because the first
+ * caller to arrive walked away, which would hand every other waiter the
+ * failure path.
+ */
+export function withoutRequestSignal<T>(fn: () => Promise<T>): Promise<T> {
+	return withRequestFields({ signal: undefined }, fn);
+}

--- a/src/wikis/abortableMwn.ts
+++ b/src/wikis/abortableMwn.ts
@@ -1,0 +1,49 @@
+import type { Mwn, RawRequestParams } from 'mwn';
+
+/**
+ * Marks an error so mwn's retry ladder leaves it alone. `handleRequestFailure`
+ * in mwn's core checks this flag before deciding a failure is transient.
+ */
+interface RetryableError {
+	disableRetry?: boolean;
+}
+
+/**
+ * Returns a view of `bot` whose MediaWiki API calls carry `signal`, so an
+ * abandoned request stops hitting the wiki instead of running to completion.
+ *
+ * Every API call mwn makes funnels through `rawRequest` — `request()` calls it
+ * directly and `query()` goes through `request()` — so intercepting that one
+ * method covers every tool without touching any of them. The interception is a
+ * Proxy rather than a subclass or a clone because mwn caches CSRF tokens and
+ * login state as plain instance fields: a Proxy forwards those reads and writes
+ * to the shared cached instance, where `Object.create` would shadow every write
+ * onto a throwaway object and silently re-fetch a token per request. Methods are
+ * returned unbound on purpose, so `this` inside them is the Proxy and mwn's own
+ * internal `this.rawRequest(...)` calls are intercepted too.
+ *
+ * The abort also has to be marked `disableRetry`. mwn treats a rejection that
+ * carries no HTTP response as transient and retries it, and an aborted request
+ * has no response — so an untreated abort sleeps through the whole retry ladder
+ * (3 retries, 5s apart by default) before giving up, making cancellation slower
+ * than letting the request finish.
+ */
+export function withAbortSignal(bot: Mwn, signal: AbortSignal): Mwn {
+	return new Proxy(bot, {
+		get(target, prop, receiver): unknown {
+			if (prop !== 'rawRequest') {
+				return Reflect.get(target, prop, receiver);
+			}
+			return async (requestOptions: RawRequestParams): Promise<unknown> => {
+				try {
+					return await target.rawRequest({ ...requestOptions, signal });
+				} catch (err: unknown) {
+					if (signal.aborted && typeof err === 'object' && err !== null) {
+						(err as RetryableError).disableRetry = true;
+					}
+					throw err;
+				}
+			};
+		},
+	});
+}

--- a/src/wikis/abortableMwn.ts
+++ b/src/wikis/abortableMwn.ts
@@ -14,13 +14,24 @@ interface RetryableError {
  *
  * Every API call mwn makes funnels through `rawRequest` — `request()` calls it
  * directly and `query()` goes through `request()` — so intercepting that one
- * method covers every tool without touching any of them. The interception is a
- * Proxy rather than a subclass or a clone because mwn caches CSRF tokens and
- * login state as plain instance fields: a Proxy forwards those reads and writes
- * to the shared cached instance, where `Object.create` would shadow every write
- * onto a throwaway object and silently re-fetch a token per request. Methods are
- * returned unbound on purpose, so `this` inside them is the Proxy and mwn's own
- * internal `this.rawRequest(...)` calls are intercepted too.
+ * method covers every call that enters through this view, without touching any
+ * tool. The interception is a Proxy rather than a subclass or a clone because
+ * mwn caches CSRF tokens and login state as plain instance fields: a Proxy
+ * forwards those reads and writes to the shared cached instance, where
+ * `Object.create` would shadow every write onto a throwaway object and silently
+ * re-fetch a token per request. Methods are returned unbound on purpose, so
+ * `this` inside them is the Proxy and mwn's own internal `this.rawRequest(...)`
+ * calls are intercepted too.
+ *
+ * That last property is why anything wrapped *inside* this view must preserve
+ * the receiver: a layer that rebinds `this` to the bare instance cuts this
+ * Proxy out of every internal hop and the signal silently stops applying. See
+ * the note in `mwnErrorSanitizer.ts`, which sits inside this one.
+ *
+ * Not covered: the `Page`/`File`/`Category`/`User`/`Wikitext` helper classes mwn
+ * builds in its constructor close over the bare instance, so calls made through
+ * them never re-enter this Proxy. Nothing in `src/` uses them; a tool that
+ * reached for `bot.page(...)` would quietly lose cancellation.
  *
  * The abort also has to be marked `disableRetry`. mwn treats a rejection that
  * carries no HTTP response as transient and retries it, and an aborted request
@@ -39,7 +50,11 @@ export function withAbortSignal(bot: Mwn, signal: AbortSignal): Mwn {
 					return await target.rawRequest({ ...requestOptions, signal });
 				} catch (err: unknown) {
 					if (signal.aborted && typeof err === 'object' && err !== null) {
-						(err as RetryableError).disableRetry = true;
+						// Best-effort: a frozen error would throw on assignment in strict
+						// mode and replace the real failure with a TypeError.
+						if (Object.isExtensible(err)) {
+							(err as RetryableError).disableRetry = true;
+						}
 					}
 					throw err;
 				}

--- a/src/wikis/mwnErrorSanitizer.ts
+++ b/src/wikis/mwnErrorSanitizer.ts
@@ -92,9 +92,14 @@ export function wrapMwnErrors<T extends object>(target: T, token?: string): T {
 			}
 			return function (this: unknown, ...args: unknown[]): unknown {
 				try {
+					// Called with the receiver, not rebound to the raw target. Rebinding
+					// would make this wrapper non-composable: mwn reaches its own methods
+					// through `this`, so sending `this` back to the bare object cuts out
+					// any proxy layered outside this one — which is how a per-request
+					// concern such as the cancellation signal silently stops applying.
 					const result =
 						// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Reflect.get returns unknown; the trapped property is the original function
-						(value as (...a: unknown[]) => unknown).apply(this === receiver ? obj : this, args);
+						(value as (...a: unknown[]) => unknown).apply(this ?? obj, args);
 					if (isThenable(result)) {
 						return result.catch((err: unknown) => {
 							redactAuthorizationHeader(err, token);

--- a/src/wikis/siteInfo.ts
+++ b/src/wikis/siteInfo.ts
@@ -1,6 +1,7 @@
 import type { ToolContext } from '../runtime/context.js';
 import type { SiteInfo, LicenseInfo, SiteInfoCache } from './siteInfoCache.js';
 import { normalizeServer } from './normalizeServer.js';
+import { withoutRequestSignal } from '../runtime/requestContext.js';
 
 interface SiteInfoApiResponse {
 	query?: {
@@ -84,7 +85,12 @@ export async function resolveSiteInfo(ctx: ToolContext, wikiKey: string): Promis
 		return existing;
 	}
 
-	const promise = fetchSiteInfo(ctx, wikiKey).finally(() => {
+	// Detached from the calling request's cancellation: this promise is handed
+	// to every concurrent caller, so honouring the first caller's cancellation
+	// would drop all the others onto the fallback and silently degrade their
+	// page URLs. The extra siteinfo request an abandoned caller leaves behind is
+	// one cheap call, and it populates the cache for everyone.
+	const promise = withoutRequestSignal(() => fetchSiteInfo(ctx, wikiKey)).finally(() => {
 		inflight.delete(wikiKey);
 	});
 	inflight.set(wikiKey, promise);

--- a/tests/runtime/cancellation.test.ts
+++ b/tests/runtime/cancellation.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport } from '@modelcontextprotocol/server';
+import { createServer } from '../../src/server.js';
+import { clearRegisteredServers } from '../../src/runtime/logger.js';
+import { getRequestSignal } from '../../src/runtime/requestContext.js';
+import { fakeContext } from '../helpers/fakeContext.js';
+
+afterEach(() => {
+	clearRegisteredServers();
+});
+
+/**
+ * These drive a real McpServer over a real transport rather than fabricating the
+ * SDK's handler context. The signal lives at `ctx.mcpReq.signal`, and a stand-in
+ * shaped the way the implementation happens to read it would pass whether or not
+ * that path is right — which is exactly how an inert version of this feature can
+ * ship with a green suite.
+ */
+describe('request cancellation reaches tool handlers', () => {
+	it('exposes the SDK-supplied signal to the handler through the request scope', async () => {
+		let seen: AbortSignal | undefined;
+		const ctx = fakeContext({
+			mwn: (async () => {
+				seen = getRequestSignal();
+				throw new Error('stop here — the signal is what this asserts');
+			}) as never,
+		});
+		const server = await createServer(ctx);
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: 'cancellation-test', version: '0.0.0' });
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+		try {
+			await client.callTool({ name: 'get-page', arguments: { title: 'Anything' } });
+		} finally {
+			await client.close();
+		}
+
+		expect(seen).toBeInstanceOf(AbortSignal);
+		expect(seen?.aborted).toBe(false);
+	});
+
+	it('aborts that signal when the caller cancels the request', async () => {
+		let seen: AbortSignal | undefined;
+		let released: (() => void) | undefined;
+		const reachedHandler = new Promise<void>((resolve) => {
+			released = resolve;
+		});
+		const ctx = fakeContext({
+			mwn: (async () => {
+				seen = getRequestSignal();
+				released?.();
+				// Hold the handler open so the cancellation lands mid-flight,
+				// which is the case the wiki request needs to be torn down in.
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+				throw new Error('never reached');
+			}) as never,
+		});
+		const server = await createServer(ctx);
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: 'cancellation-test', version: '0.0.0' });
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+		// The cancellation has to name the id of the in-flight call, so record it
+		// off the wire rather than assuming the client's numbering.
+		let callId: string | number = 0;
+		const send = clientTransport.send.bind(clientTransport);
+		clientTransport.send = (async (message: { method?: string; id?: string | number }, opts) => {
+			if (message.method === 'tools/call' && message.id !== undefined) {
+				callId = message.id;
+			}
+			return send(message as never, opts as never);
+		}) as typeof clientTransport.send;
+
+		try {
+			void client
+				.callTool({ name: 'get-page', arguments: { title: 'Anything' } })
+				.catch(() => undefined);
+			await reachedHandler;
+
+			// Sent on the wire rather than by aborting the client's own promise:
+			// the SDK's client resolves a caller-side abort locally and emits no
+			// notification, so aborting it would prove nothing about the server.
+			await clientTransport.send({
+				jsonrpc: '2.0',
+				method: 'notifications/cancelled',
+				params: { requestId: callId, reason: 'test' },
+			});
+
+			await vi.waitFor(() => {
+				expect(seen?.aborted).toBe(true);
+			});
+		} finally {
+			await client.close();
+		}
+	});
+});

--- a/tests/runtime/createContext.test.ts
+++ b/tests/runtime/createContext.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { createToolContext } from '../../src/runtime/createContext.js';
-import { createAppState } from '../../src/wikis/state.js';
+import { createAppState, type AppState } from '../../src/wikis/state.js';
 import { logger } from '../../src/runtime/logger.js';
+import { withRequestFields } from '../../src/runtime/requestContext.js';
 import type { Config } from '../../src/config/loadConfig.js';
 
 const testConfig: Config = {
@@ -39,5 +40,45 @@ describe('createToolContext', () => {
 		expect(ctx.errors).toBeDefined();
 		expect(ctx.logger).toBe(logger);
 		expect(ctx.transport).toBe('stdio');
+	});
+
+	it('applies the request cancellation signal to the mwn instance it hands out', async () => {
+		const calls: { signal?: AbortSignal }[] = [];
+		const bot = {
+			async rawRequest(options: { signal?: AbortSignal }): Promise<unknown> {
+				calls.push(options);
+				return {};
+			},
+		};
+		const state = {
+			...createAppState(testConfig),
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering only the surface under test
+			mwnProvider: { get: async (): Promise<unknown> => bot } as unknown as AppState['mwnProvider'],
+		};
+		const ctx = createToolContext({ logger, state, transport: 'stdio' });
+		const controller = new AbortController();
+
+		await withRequestFields({ signal: controller.signal }, async () => {
+			const scoped = await ctx.mwn();
+			await scoped.rawRequest({ url: 'https://test.wiki/w/api.php' });
+		});
+
+		expect(calls[0]?.signal).toBe(controller.signal);
+	});
+
+	it('hands out the bare instance when no request scope is active', async () => {
+		const bot = {
+			async rawRequest(): Promise<unknown> {
+				return {};
+			},
+		};
+		const state = {
+			...createAppState(testConfig),
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering only the surface under test
+			mwnProvider: { get: async (): Promise<unknown> => bot } as unknown as AppState['mwnProvider'],
+		};
+		const ctx = createToolContext({ logger, state, transport: 'stdio' });
+
+		expect(await ctx.mwn()).toBe(bot);
 	});
 });

--- a/tests/runtime/dispatcher.test.ts
+++ b/tests/runtime/dispatcher.test.ts
@@ -6,6 +6,7 @@ import { fakeContext } from '../helpers/fakeContext.js';
 import { createMockMwnError } from '../helpers/mock-mwn-error.js';
 import { clearRegisteredServers } from '../../src/runtime/logger.js';
 import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.js';
+import { withRequestFields } from '../../src/runtime/requestContext.js';
 import { getPage } from '../../src/tools/get-page.js';
 import { ContentFormat } from '../../src/results/contentFormat.js';
 
@@ -167,5 +168,38 @@ describe('dispatcher emits tool_call telemetry', () => {
 		expect(line!.outcome).toBe('permission_denied');
 		expect(line!.level).toBe('warning');
 		expect(typeof line!.error_message).toBe('string');
+	});
+
+	it('reports an aborted call as cancelled rather than an upstream failure', async () => {
+		const ctx = fakeContext();
+		// What a torn-down request actually looks like from the tool's side: mwn
+		// surfaces the abort as a malformed response, not as an abort, so the
+		// classifier would otherwise call this a wiki outage.
+		const tool = noopTool(async () => {
+			throw new TypeError("Cannot read properties of undefined (reading 'pages')");
+		});
+		const controller = new AbortController();
+		controller.abort();
+
+		await withRequestFields({ signal: controller.signal }, () => dispatch(tool, ctx)({ x: 'y' }));
+
+		const line = captureToolCallLine(stderrSpy);
+		expect(line).toBeDefined();
+		expect(line!.outcome).toBe('cancelled');
+		expect(line!.level).toBe('info');
+	});
+
+	it('still reports a genuine failure as an upstream failure when nothing was cancelled', async () => {
+		const ctx = fakeContext();
+		const tool = noopTool(async () => {
+			throw new TypeError("Cannot read properties of undefined (reading 'pages')");
+		});
+		const controller = new AbortController();
+
+		await withRequestFields({ signal: controller.signal }, () => dispatch(tool, ctx)({ x: 'y' }));
+
+		const line = captureToolCallLine(stderrSpy);
+		expect(line!.outcome).toBe('upstream_failure');
+		expect(line!.level).toBe('error');
 	});
 });

--- a/tests/runtime/register.test.ts
+++ b/tests/runtime/register.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import type { ZodRawShape } from 'zod';
 import { register } from '../../src/runtime/register.js';
 import type { Tool } from '../../src/runtime/tool.js';
-import { getRequestSignal } from '../../src/runtime/requestContext.js';
 
 // `register` wraps the descriptor's raw shape in a z.object() before handing it
 // to the SDK, so the registered field names are read back off `.shape`.
@@ -94,39 +93,10 @@ describe('register', () => {
 		expect(result).toBe(registered);
 	});
 
-	it("puts the SDK's cancellation signal into the request scope for the handler", async () => {
-		const registerTool = vi.fn().mockReturnValue({});
-		const server = { registerTool } as never;
-		const tool: Tool<{ a: z.ZodString }> = {
-			name: 'baz',
-			description: 'd',
-			inputSchema: { a: z.string() },
-			annotations: {
-				title: 'B',
-				readOnlyHint: true,
-				destructiveHint: false,
-				idempotentHint: true,
-				openWorldHint: true,
-			},
-			handle: async () => ({ content: [] }),
-		};
-		let seen: AbortSignal | undefined;
-		register(server, tool, async () => {
-			seen = getRequestSignal();
-			return { content: [] };
-		});
-
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- invoking the callback this call registered
-		const registered = registerTool.mock.calls[0][2] as (
-			args: unknown,
-			extra: { signal?: AbortSignal },
-		) => Promise<unknown>;
-		const controller = new AbortController();
-		await registered({ a: 'x' }, { signal: controller.signal });
-
-		expect(seen).toBe(controller.signal);
-	});
-
+	// The signal reaching the handler is covered in tests/runtime/cancellation.test.ts,
+	// against a real McpServer. Asserting it here would mean fabricating the SDK's
+	// context object, which proves only that the implementation reads the shape the
+	// test invented for it.
 	it('still runs the handler when the SDK supplies no signal', async () => {
 		const registerTool = vi.fn().mockReturnValue({});
 		const server = { registerTool } as never;

--- a/tests/runtime/register.test.ts
+++ b/tests/runtime/register.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { ZodRawShape } from 'zod';
 import { register } from '../../src/runtime/register.js';
 import type { Tool } from '../../src/runtime/tool.js';
+import { getRequestSignal } from '../../src/runtime/requestContext.js';
 
 // `register` wraps the descriptor's raw shape in a z.object() before handing it
 // to the SDK, so the registered field names are read back off `.shape`.
@@ -37,7 +38,9 @@ describe('register', () => {
 				description: 'd',
 				annotations: tool.annotations,
 			}),
-			handler,
+			// Not `handler` itself: register wraps it so the SDK's per-request
+			// context can be consumed before the descriptor handler runs.
+			expect.any(Function),
 		);
 		// objectContaining above ignores extra keys, so pin the exact set too.
 		expect(Object.keys(registerTool.mock.calls[0][1]).sort()).toEqual([
@@ -89,5 +92,70 @@ describe('register', () => {
 		};
 		const result = register(server, tool, vi.fn());
 		expect(result).toBe(registered);
+	});
+
+	it("puts the SDK's cancellation signal into the request scope for the handler", async () => {
+		const registerTool = vi.fn().mockReturnValue({});
+		const server = { registerTool } as never;
+		const tool: Tool<{ a: z.ZodString }> = {
+			name: 'baz',
+			description: 'd',
+			inputSchema: { a: z.string() },
+			annotations: {
+				title: 'B',
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+			handle: async () => ({ content: [] }),
+		};
+		let seen: AbortSignal | undefined;
+		register(server, tool, async () => {
+			seen = getRequestSignal();
+			return { content: [] };
+		});
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- invoking the callback this call registered
+		const registered = registerTool.mock.calls[0][2] as (
+			args: unknown,
+			extra: { signal?: AbortSignal },
+		) => Promise<unknown>;
+		const controller = new AbortController();
+		await registered({ a: 'x' }, { signal: controller.signal });
+
+		expect(seen).toBe(controller.signal);
+	});
+
+	it('still runs the handler when the SDK supplies no signal', async () => {
+		const registerTool = vi.fn().mockReturnValue({});
+		const server = { registerTool } as never;
+		const tool: Tool<{ a: z.ZodString }> = {
+			name: 'qux',
+			description: 'd',
+			inputSchema: { a: z.string() },
+			annotations: {
+				title: 'Q',
+				readOnlyHint: true,
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+			},
+			handle: async () => ({ content: [] }),
+		};
+		let ran = false;
+		register(server, tool, async () => {
+			ran = true;
+			return { content: [] };
+		});
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- invoking the callback this call registered
+		const registered = registerTool.mock.calls[0][2] as (
+			args: unknown,
+			extra?: { signal?: AbortSignal },
+		) => Promise<unknown>;
+		await registered({ a: 'x' });
+
+		expect(ran).toBe(true);
 	});
 });

--- a/tests/wikis/abortableMwn.test.ts
+++ b/tests/wikis/abortableMwn.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Mwn, RawRequestParams } from 'mwn';
 import { withAbortSignal } from '../../src/wikis/abortableMwn.js';
+import { wrapMwnErrors } from '../../src/wikis/mwnErrorSanitizer.js';
 
 /**
  * A stand-in shaped like the parts of mwn this wrapper leans on: `rawRequest`
@@ -99,6 +100,19 @@ describe('withAbortSignal', () => {
 			);
 
 		expect((err as { disableRetry?: boolean }).disableRetry).toBeUndefined();
+	});
+
+	it('still reaches rawRequest when composed with the error sanitiser', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		// The composition production actually builds: the provider hands out an
+		// error-sanitised instance, and the abort view goes on the outside. A
+		// wrapper that rebinds `this` to the raw object breaks the outer proxy's
+		// interception of mwn's internal hops, so the signal silently vanishes.
+		await withAbortSignal(wrapMwnErrors(bot), controller.signal).request({ action: 'query' });
+
+		expect(bot.calls[0]?.signal).toBe(controller.signal);
 	});
 
 	it('writes through to the shared instance so cached state is not shadowed', () => {

--- a/tests/wikis/abortableMwn.test.ts
+++ b/tests/wikis/abortableMwn.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { Mwn, RawRequestParams } from 'mwn';
+import { withAbortSignal } from '../../src/wikis/abortableMwn.js';
+
+/**
+ * A stand-in shaped like the parts of mwn this wrapper leans on: `rawRequest`
+ * as the single network choke point, a `request` that reaches it through
+ * `this`, and a mutable token field standing in for mwn's cached CSRF token.
+ */
+function createFakeBot(
+	rawRequest: (options: RawRequestParams) => Promise<unknown>,
+): Mwn & { csrfToken: string; calls: RawRequestParams[] } {
+	const bot = {
+		csrfToken: '%notoken%',
+		calls: [] as RawRequestParams[],
+		async rawRequest(options: RawRequestParams): Promise<unknown> {
+			this.calls.push(options);
+			return rawRequest(options);
+		},
+		async request(params: Record<string, unknown>): Promise<unknown> {
+			// mwn reaches its own network method through `this`, which is what
+			// makes intercepting `rawRequest` cover `request` and `query` too.
+			return this.rawRequest({ url: 'https://wiki.example/api.php', data: params });
+		},
+	};
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double covering only the surface under test
+	return bot as unknown as Mwn & { csrfToken: string; calls: RawRequestParams[] };
+}
+
+describe('withAbortSignal', () => {
+	it('attaches the signal to the request options', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		await withAbortSignal(bot, controller.signal).rawRequest({
+			url: 'https://wiki.example/api.php',
+		});
+
+		expect(bot.calls[0]?.signal).toBe(controller.signal);
+	});
+
+	it('keeps the caller-supplied request options', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		await withAbortSignal(bot, controller.signal).rawRequest({
+			url: 'https://wiki.example/api.php',
+			method: 'post',
+		});
+
+		expect(bot.calls[0]?.url).toBe('https://wiki.example/api.php');
+		expect(bot.calls[0]?.method).toBe('post');
+	});
+
+	it('reaches calls that mwn routes through its own `this.rawRequest`', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		await withAbortSignal(bot, controller.signal).request({ action: 'query' });
+
+		// The Proxy returns methods unbound, so `this` inside `request` is the
+		// Proxy and its internal hop is intercepted. Binding to the target here
+		// would silently drop the signal from every internally-issued call.
+		expect(bot.calls).toHaveLength(1);
+		expect(bot.calls[0]?.signal).toBe(controller.signal);
+	});
+
+	it('marks an aborted failure so mwn does not retry it', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => {
+			controller.abort();
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		const err = await withAbortSignal(bot, controller.signal)
+			.rawRequest({ url: 'https://wiki.example/api.php' })
+			.then(
+				() => undefined,
+				(e: unknown) => e,
+			);
+
+		// mwn's handleRequestFailure retries any rejection carrying no HTTP
+		// response, and an aborted request has none — without this flag a
+		// cancelled call sleeps through the full retry ladder before giving up.
+		expect((err as { disableRetry?: boolean }).disableRetry).toBe(true);
+	});
+
+	it('leaves a genuine transient failure retriable', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => {
+			throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+		});
+
+		const err = await withAbortSignal(bot, controller.signal)
+			.rawRequest({ url: 'https://wiki.example/api.php' })
+			.then(
+				() => undefined,
+				(e: unknown) => e,
+			);
+
+		expect((err as { disableRetry?: boolean }).disableRetry).toBeUndefined();
+	});
+
+	it('writes through to the shared instance so cached state is not shadowed', () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		const scoped = withAbortSignal(bot, controller.signal) as unknown as { csrfToken: string };
+		scoped.csrfToken = 'fresh-token';
+
+		// A per-request clone would strand this write on a throwaway object and
+		// make every request re-fetch the token from the wiki.
+		expect(bot.csrfToken).toBe('fresh-token');
+	});
+});


### PR DESCRIPTION
Tool handlers ignored the cancellation signal the SDK gives them, so a call the caller had abandoned kept querying the wiki until it finished on its own. Cancelling now aborts the request that is in flight.

## How

Every mwn API call funnels through `rawRequest` — `request()` calls it directly and `query()` goes through `request()` — so the signal is applied at that one point and reaches every tool without any tool changing. It travels in the existing request-scoped `AsyncLocalStorage`, entering at `register()` from `ctx.mcpReq.signal` and being picked up by `ctx.mwn()`.

The interception is a Proxy over the shared cached instance rather than a clone: mwn caches CSRF tokens and login state as plain instance fields, and a per-request clone would strand those writes and re-fetch a token every request. Methods are returned unbound so `this` inside them is the Proxy, which is what makes mwn's own internal `this.rawRequest(...)` hops get intercepted.

## Two things a reviewer should look at

**The error sanitiser now preserves the receiver.** `wrapMwnErrors` rebound `this` to the bare instance, which cut any outer proxy out of every internal hop — the abort view included. That made it non-composable, and it is why the signal reached `ctx.mwn()` but never reached a socket. Internal calls now pass through the redaction wrapper as well; its own tests are unchanged and green.

**Shared siteinfo is detached from the caller's signal.** `resolveSiteInfo` hands one in-flight promise to every concurrent waiter, so honouring the first caller's cancellation would drop all the others onto the degraded fallback. `withoutRequestSignal` keeps the runtime token and drops only the signal.

## The abort has to be marked `disableRetry`

mwn treats a rejection carrying no HTTP response as transient, and an aborted request has none — so passing the signal through alone makes cancellation **slower than letting the request finish**, sleeping the full ladder (3 retries, 5s apart). A genuine transient failure is left retriable.

## Verification

End to end against a wiki that accepts the connection and never responds, driving the built server over stdio:

| | result |
|---|---|
| upstream socket after cancel | closed within milliseconds |
| tool settles | 3.0 s |
| same, `disableRetry` removed | 18 s, three retry lines |

Suite 1,668 green; `tsc --noEmit`, lint and format clean. The two new tests in `tests/runtime/cancellation.test.ts` drive a real `McpServer` and both fail if the signal is read off the context root again.

## Cancelled calls no longer read as wiki failures

A torn-down request does not surface as an abort — mwn swallows it and a downstream dereference fails — so the classifier called every cancellation an `upstream_failure` at error level. With cancellation now a routine path that would turn each one into a false outage signal in the logs and the `mcp_tool_calls_total` metric.

`cancelled` is added to `ToolOutcome` alongside `ErrorCategory` rather than inside it, so error classification and response shaping are untouched; the caller still gets the same error result and still discards it. The new label is additive, so existing dashboards keep working.
