### PR TITLE
Bind refresh tokens to their client, and name the redirect host at consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 
+- The hosted OAuth sign-in's approval page is shorter and now names the address you will be returned to, including for a local application, where it previously said only "an application on this device". It no longer promises a permissions step the wiki does not always show.
 - The HTTP transport's own `401`, `503` and `413` replies carry new JSON-RPC error codes. Clients read the HTTP status for these conditions, so no change is expected; anything matching on the old codes `-32001` and `-32000` needs updating.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Security
 
+- A refresh token issued by the hosted OAuth sign-in can no longer be redeemed by a different client. A request presenting a `client_id` other than the one the token was issued to is refused with `invalid_grant` and has to sign in again. Requests that send no `client_id`, and tokens issued before this release, keep working.
 - The HTTP transport did not validate the `Origin` header on any bind other than loopback, leaving it open to DNS rebinding: an attacker who re-points a domain at a server the victim's browser can reach could call tools and read the results, without having to reach that server themselves. The Docker image binds to `0.0.0.0` by default, so this affected container deployments unless `MCP_ALLOWED_ORIGINS` was set.
 
 ### Breaking changes

--- a/src/auth/authorizationServer/callback.ts
+++ b/src/auth/authorizationServer/callback.ts
@@ -103,6 +103,10 @@ export async function handleCallback(
 		accessToken: tokens.access_token,
 		refreshToken: tokens.refresh_token,
 		expiresAt: Date.now() + tokens.expires_in * 1000,
+		// Recorded here, where the issuing client is already in hand, rather than
+		// at redemption: putUpstreamToken is the record's only write on this path,
+		// so binding it costs no extra store flush.
+		clientId: txn.clientId,
 	});
 	const clientCode = randomUUID();
 	store.putCode(clientCode, {

--- a/src/auth/authorizationServer/consent.ts
+++ b/src/auth/authorizationServer/consent.ts
@@ -15,33 +15,39 @@ export function renderConsentPage(a: {
 	authorizeQuery: string;
 	csrfToken: string;
 	redirectHost: string;
-	clientIdHost?: string;
 }): string {
-	// No per-permission line: the proxy always requests the consumer's full grants
-	// (see authorize.ts). The user sees the exact grants on MediaWiki's own
-	// authorization screen during the upstream leg.
-	const destination =
-		a.redirectHost && !isLoopbackHost(a.redirectHost)
-			? a.redirectHost
-			: 'an application on this device';
-	// CIMD clients carry a verified client_id host (the client_id URL's host was
-	// checked against the trusted allowlist and confirmed by the document's own
-	// self-reference); the client_name below is self-asserted and unverified, so
-	// the verified host leads. DCR clients pass no host and this line is omitted.
-	const verifiedHost = a.clientIdHost
-		? `<p class="pg-verified">Verified application: <strong>${esc(a.clientIdHost)}</strong></p>`
-		: '';
+	// The proxy always requests the consumer's full grants (see authorize.ts), and
+	// MediaWiki itemises them on the first authorization only — it remembers the
+	// grant afterwards, which is why per-client consent lives here.
+	const onThisDevice = a.redirectHost === '' || isLoopbackHost(a.redirectHost);
+	// An unregistered redirect_uri is refused before consent renders, so an absent
+	// host is unreachable; it degrades rather than printing "to  on this device".
+	const host = a.redirectHost === '' ? '' : `<strong>${esc(a.redirectHost)}</strong>`;
+	const returnTo = onThisDevice
+		? host === ''
+			? `You'll be returned to an address on this device.`
+			: `You'll be returned to ${host} on this device.`
+		: `You'll be returned to ${host}.`;
+	// Any local process can bind a loopback address, so the host cannot say which
+	// program will receive the grant; whether the reader started this sign-in is the
+	// only check available to them.
+	const timing = onThisDevice ? `Allow only if you started this sign-in a moment ago. ` : '';
+	const ask = `<p class="pg-note-strong">${timing}${returnTo}</p>`;
 	const body =
-		verifiedHost +
-		`<p class="pg-lead"><strong>${esc(a.clientName)}</strong> wants to act as you on <strong>${esc(a.wiki)}</strong>.</p>` +
-		`<p class="pg-note">After you approve, you will be sent back to <strong>${esc(destination)}</strong>.</p>` +
+		ask +
 		`<form method="POST" action="/mcp/consent?${esc(a.authorizeQuery)}" class="pg-actions">` +
 		`<input type="hidden" name="csrf" value="${esc(a.csrfToken)}">` +
-		`<button class="pg-btn pg-primary" name="decision" value="approve" type="submit">Approve</button>` +
+		// Deny first in source order so the progressive action lands on the right per
+		// Codex, and so a flex row mirrors it with the writing direction under RTL.
 		`<button class="pg-btn pg-neutral" name="decision" value="deny" type="submit">Deny</button>` +
-		`</form>` +
-		`<p class="pg-note">You'll confirm the exact permissions on ${esc(a.wiki)} in the next step.</p>`;
-	return renderPage({ title: 'Authorize application', icon: { name: 'lock' }, body });
+		`<button class="pg-btn pg-primary" name="decision" value="approve" type="submit">Allow</button>` +
+		`</form>`;
+	return renderPage({
+		title: 'Authorize application',
+		heading: `Allow ${a.clientName} to use your ${a.wiki} account?`,
+		icon: { name: 'lock' },
+		body,
+	});
 }
 
 // Shown when the user denies and there is no trusted client redirect to bounce to.

--- a/src/auth/authorizationServer/proxyStore.ts
+++ b/src/auth/authorizationServer/proxyStore.ts
@@ -34,6 +34,12 @@ export interface UpstreamToken {
 	// this upstream token. A presented refresh token whose rid differs is a
 	// superseded/replayed token (OAuth 2.1 §4.3.1 reuse detection).
 	refreshId?: string;
+	// The downstream client this grant was issued to, so the refresh grant can
+	// refuse a token presented by a different one (OAuth 2.1 §4.3). Optional
+	// because records written before this field existed are replayed verbatim
+	// from disk: requiring it would make the type a lie at runtime and sign
+	// those users out on the deploy that added it.
+	clientId?: string;
 }
 
 export interface DurableSnapshot {

--- a/src/auth/authorizationServer/router.ts
+++ b/src/auth/authorizationServer/router.ts
@@ -158,11 +158,10 @@ export function mountAuthorizationServer(
 	});
 
 	// Resolve a client_id to a ClientRecord: CIMD (fetch its metadata document) for a
-	// URL id, else the DCR store. For CIMD, `clientIdHost` is the verified host to show
-	// at consent; `error` is set (with a reason) only when a CIMD resolve fails.
+	// URL id, else the DCR store. `error` is set (with a reason) only when a CIMD
+	// resolve fails.
 	async function resolveClient(clientId: string | undefined): Promise<{
 		client: ClientRecord | undefined;
-		clientIdHost?: string;
 		error?: string;
 	}> {
 		if (clientId && cimdResolver && isCimdClientId(clientId)) {
@@ -170,7 +169,7 @@ export function mountAuthorizationServer(
 			if (!r.ok) {
 				return { client: undefined, error: r.reason };
 			}
-			return { client: r.client, clientIdHost: new URL(clientId).host };
+			return { client: r.client };
 		}
 		return { client: clientId ? store.getClient(clientId) : undefined };
 	}
@@ -221,7 +220,6 @@ export function mountAuthorizationServer(
 					authorizeQuery: serializeAuthorizeQuery(q),
 					csrfToken,
 					redirectHost: redirectHost ?? '',
-					clientIdHost: resolved.clientIdHost,
 				}),
 			);
 			return;

--- a/src/auth/authorizationServer/token.ts
+++ b/src/auth/authorizationServer/token.ts
@@ -75,6 +75,21 @@ export async function handleToken(
 		if (!upstream?.refreshToken) {
 			return bad('invalid_grant', 'no upstream refresh token');
 		}
+		// Bind the refresh token to the client it was issued to (OAuth 2.1 §4.3).
+		// Both halves are conditional by necessity: `client_id` is OPTIONAL at the
+		// token endpoint (§3.2.2) and omitting it is a live case, while records
+		// persisted before `clientId` existed carry none. Placed BEFORE the
+		// rotation claim below — returning after it would strand the claim in the
+		// `refreshing` set, and the next legitimate refresh would then read as a
+		// replay and revoke the whole family, turning a wrong `client_id` from an
+		// unauthenticated caller into a remote sign-out of the real user.
+		if (
+			upstream.clientId !== undefined &&
+			body.client_id !== undefined &&
+			body.client_id !== upstream.clientId
+		) {
+			return bad('invalid_grant', 'refresh token was not issued to this client');
+		}
 		// Refresh-token rotation + reuse detection (OAuth 2.1 §4.3.1). Claim the
 		// rotation atomically (synchronously, before the upstream await): the presented
 		// token must be the CURRENT one and no rotation may already be in flight. A

--- a/src/auth/pageShell.ts
+++ b/src/auth/pageShell.ts
@@ -65,7 +65,6 @@ background:var(--page-bg);padding:24px;color:var(--c-base)}
 .pg-icon--error{color:var(--c-error)}
 .pg-icon--success{color:var(--c-success)}
 .pg-title{font-size:1.25rem;font-weight:700;line-height:1.875rem;margin:0 0 8px}
-.pg-verified{font-size:.8125rem;line-height:1.25rem;color:var(--c-success);margin:0 0 8px}
 .pg-lead{font-size:.875rem;line-height:1.375rem;margin:0}
 .pg-actions{display:flex;flex-wrap:wrap;gap:12px;margin:16px 0 0}
 .pg-btn{flex:1;display:inline-flex;align-items:center;justify-content:center;min-height:32px;padding:0 11px;border:1px solid;border-radius:2px;font-size:.875rem;font-weight:700;font-family:inherit;cursor:pointer;transition:background-color .1s,color .1s,border-color .1s,box-shadow .1s}
@@ -76,13 +75,19 @@ background:var(--page-bg);padding:24px;color:var(--c-base)}
 .pg-neutral{background:var(--btn-normal-bg);border-color:var(--bd-base);color:var(--c-base)}
 .pg-neutral:hover{background:var(--btn-normal-bg-hover)}
 .pg-note{font-size:.8125rem;line-height:1.25rem;color:var(--c-subtle);margin:16px 0 0}
+.pg-note-strong{font-size:.8125rem;line-height:1.25rem;color:var(--c-base);margin:16px 0 0}
 .pg-mono{font-family:ui-monospace,'SFMono-Regular',monospace;font-size:.8125rem;color:var(--c-subtle);background:var(--inset-bg);border:1px solid var(--bd-subtle);border-radius:2px;padding:8px;margin:16px 0 0;word-break:break-word}
 `;
 
 export function renderPage(o: {
 	title: string;
+	// Visible heading, when the page's own words belong there rather than a label.
+	// Kept separate from `title` so the document title stays fixed: it names the
+	// browser tab, and a page carrying a client-supplied string must not let that
+	// string choose what the tab says. Escaped like the title; pass plain text.
+	heading?: string;
 	icon: { name: IconName; accent?: IconAccent };
 	body: string;
 }): string {
-	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${esc(o.title)}</title><style>${STYLE}</style></head><body><main class="pg-wrap"><div class="pg-card">${renderIcon(o.icon.name, o.icon.accent)}<h1 class="pg-title">${esc(o.title)}</h1>${o.body}</div></main></body></html>`;
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${esc(o.title)}</title><style>${STYLE}</style></head><body><main class="pg-wrap"><div class="pg-card">${renderIcon(o.icon.name, o.icon.accent)}<h1 class="pg-title">${esc(o.heading ?? o.title)}</h1>${o.body}</div></main></body></html>`;
 }

--- a/tests/auth/authorizationServer/callback.test.ts
+++ b/tests/auth/authorizationServer/callback.test.ts
@@ -59,6 +59,11 @@ describe('handleCallback', () => {
 		expect(consumed.scopes).toEqual(['editpage']);
 		expect(store.getUpstreamToken(consumed.upstreamTokenId)?.accessToken).toBe('WA');
 		expect(store.getUpstreamToken(consumed.upstreamTokenId)?.refreshToken).toBe('WR');
+		// The only production write of the refresh grant's client binding. Losing
+		// it does not fail anything — the guard is conditional on the field being
+		// set, so an unbound record silently accepts any client. Assert it here,
+		// where the record is already in hand.
+		expect(store.getUpstreamToken(consumed.upstreamTokenId)?.clientId).toBe('cid');
 		expect(store.getTransaction('txn-1')).toBeUndefined();
 	});
 

--- a/tests/auth/authorizationServer/consent.test.ts
+++ b/tests/auth/authorizationServer/consent.test.ts
@@ -29,7 +29,7 @@ describe('consent', () => {
 		});
 		expect(html).toContain('Authorize application');
 		expect(html).toContain('Claude Code');
-		expect(html).toContain('act as you on');
+		expect(html).toContain('to use your');
 		expect(html).toContain('Example');
 		expect(html).toContain('action="/mcp/consent?txn=1"');
 		expect(html).toContain('name="csrf"');
@@ -51,6 +51,24 @@ describe('consent', () => {
 		expect(html).toContain('&lt;script&gt;');
 	});
 
+	it('asks in the heading and keeps the document title free of client-supplied text', () => {
+		const html = renderConsentPage({
+			clientName: 'Totally Legit Bank Login',
+			wiki: 'Example Wiki',
+			authorizeQuery: 'a=1',
+			csrfToken: 't',
+			redirectHost: '127.0.0.1',
+		});
+		// The ask is the heading, so the largest text on a decision page is the
+		// decision rather than a label.
+		expect(html).toContain(
+			'<h1 class="pg-title">Allow Totally Legit Bank Login to use your Example Wiki account?</h1>',
+		);
+		// The browser tab stays ours: a client that picked a misleading name must
+		// not get to choose what the window says.
+		expect(html).toContain('<title>Authorize application</title>');
+	});
+
 	it('shows the redirect destination host', () => {
 		const html = renderConsentPage({
 			clientName: 'ChatGPT',
@@ -62,7 +80,7 @@ describe('consent', () => {
 		expect(html).toContain('chatgpt.com');
 	});
 
-	it('renders loopback destinations as on-device', () => {
+	it('shows the loopback host and asks the one check a reader can run', () => {
 		const html = renderConsentPage({
 			clientName: 'Claude Code',
 			wiki: 'Example Wiki',
@@ -70,22 +88,71 @@ describe('consent', () => {
 			csrfToken: 't',
 			redirectHost: '127.0.0.1',
 		});
-		expect(html).toContain('an application on this device');
-		expect(html).not.toContain('127.0.0.1');
+		// The host has to be visible: this is the loopback case the display
+		// requirement exists for.
+		expect(html).toContain('127.0.0.1');
+		expect(html).toContain('on this device');
+		// The timing check is the discriminator for the confused-deputy case, where
+		// the user followed a link and started nothing.
+		expect(html).toContain('Allow only if you started this sign-in a moment ago');
 	});
 
-	it('shows the verified client_id host, leading the self-asserted name', () => {
+	it('drops the address rather than rendering a dangling clause when no host is known', () => {
 		const html = renderConsentPage({
-			clientName: 'VS Code',
-			wiki: 'My Wiki',
-			authorizeQuery: 'client_id=x',
+			clientName: 'Claude Code',
+			wiki: 'Example Wiki',
+			authorizeQuery: 'a=1',
 			csrfToken: 't',
-			redirectHost: 'vscode.dev',
-			clientIdHost: 'code.visualstudio.com',
+			redirectHost: '',
 		});
-		expect(html).toContain('code.visualstudio.com');
-		expect(html).toContain('Verified application');
-		expect(html.indexOf('pg-verified')).toBeLessThan(html.indexOf('pg-lead'));
+		// Unreachable through planAuthorize, which refuses an unregistered
+		// redirect_uri before consent renders; the renderer must still not emit a
+		// dangling comma.
+		expect(html).toContain('an address on this device');
+		expect(html).not.toContain('to  on this device');
+	});
+
+	it('does not caution for a remote destination', () => {
+		const html = renderConsentPage({
+			clientName: 'ChatGPT',
+			wiki: 'Example Wiki',
+			authorizeQuery: 'a=1',
+			csrfToken: 't',
+			redirectHost: 'chatgpt.com',
+		});
+		expect(html).not.toContain('Allow only if you started this sign-in');
+	});
+
+	it('promises no permissions step, which the wiki does not always show', () => {
+		const html = renderConsentPage({
+			clientName: 'Claude Code',
+			wiki: 'Example Wiki',
+			authorizeQuery: 'a=1',
+			csrfToken: 't',
+			redirectHost: '127.0.0.1',
+		});
+		// MediaWiki itemises grants the first time and remembers them after, which
+		// is the same skip the confused-deputy mitigation exists for. Telling the
+		// user a confirmation step follows would be false on every later sign-in.
+		expect(html).not.toContain('next step');
+	});
+
+	it('makes no publisher claim, for any client shape', () => {
+		for (const redirectHost of ['chatgpt.com', 'app.example.com', '127.0.0.1']) {
+			const html = renderConsentPage({
+				clientName: 'Some App',
+				wiki: 'My Wiki',
+				authorizeQuery: 'a=1',
+				csrfToken: 't',
+				redirectHost,
+			});
+			// What a metadata document proves is that a host on our allowlist served
+			// these details — a fact about the allowlist, not one the reader can act
+			// on. The return host is the fact that matters, and it is already shown.
+			expect(html).toContain(redirectHost);
+			expect(html).not.toContain('published');
+			expect(html).not.toContain('Verified');
+		}
 	});
 
 	it('renders cancelled and auth-error pages', () => {

--- a/tests/auth/authorizationServer/token.test.ts
+++ b/tests/auth/authorizationServer/token.test.ts
@@ -221,6 +221,131 @@ describe('handleToken refresh_token', () => {
 		expect(claims.upstreamTokenId).toBe(upstreamTokenId);
 	});
 
+	// The binding is checked before the rotation is claimed, and both halves of
+	// the guard are conditional. Nothing in the pre-existing suite exercises any
+	// of that, and tests are not typechecked (see #506), so a green suite is not
+	// evidence here — these four cases are.
+	it('refuses a refresh token presented by a different client', async () => {
+		const store = new InMemoryProxyStore();
+		const { rt } = await stage(store, {
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now(),
+			clientId: 'client-A',
+		});
+		const refresh = vi.fn();
+
+		const r = await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: rt, client_id: 'client-B-ATTACKER' },
+			pc,
+			store,
+			refresh,
+		);
+
+		expect(r.status).toBe(400);
+		expect(r.body.error).toBe('invalid_grant');
+		expect(refresh).not.toHaveBeenCalled();
+	});
+
+	it('leaves the family usable after refusing a mismatched client', async () => {
+		const store = new InMemoryProxyStore();
+		const { upstreamTokenId, rt } = await stage(store, {
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now(),
+			clientId: 'client-A',
+		});
+		const refresh = vi
+			.fn()
+			.mockResolvedValue({ access_token: 'NEW', refresh_token: 'WR2', expires_in: 3600 });
+
+		await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: rt, client_id: 'client-B-ATTACKER' },
+			pc,
+			store,
+			refresh,
+		);
+		// The legitimate client retries with the same, still-current token.
+		const r = await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: rt, client_id: 'client-A' },
+			pc,
+			store,
+			refresh,
+		);
+
+		// Refusing after claiming the rotation would strand the claim, so this
+		// retry would read as a replay and revoke the family — a stranger with a
+		// wrong client_id could sign the real user out.
+		expect(r.status).toBe(200);
+		expect(store.getUpstreamToken(upstreamTokenId)?.accessToken).toBe('NEW');
+	});
+
+	it('accepts a refresh token presented by the client it was issued to, and keeps the binding', async () => {
+		const store = new InMemoryProxyStore();
+		const { upstreamTokenId, rt } = await stage(store, {
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now(),
+			clientId: 'client-A',
+		});
+		const refresh = vi
+			.fn()
+			.mockResolvedValue({ access_token: 'NEW', refresh_token: 'WR2', expires_in: 3600 });
+
+		const r = await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: rt, client_id: 'client-A' },
+			pc,
+			store,
+			refresh,
+		);
+
+		expect(r.status).toBe(200);
+		// The rotation writes a partial record and relies on the store's merge to
+		// preserve this field. A rotation that dropped it would silently unbind the
+		// session on its first refresh.
+		expect(store.getUpstreamToken(upstreamTokenId)?.clientId).toBe('client-A');
+	});
+
+	it('tolerates an omitted client_id, and a record predating the binding', async () => {
+		const store = new InMemoryProxyStore();
+		const bound = await stage(store, {
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now(),
+			clientId: 'client-A',
+		});
+		// No clientId: what a record restored from a store written before this
+		// field existed looks like.
+		const legacy = await stage(store, {
+			accessToken: 'OLD',
+			refreshToken: 'WR',
+			expiresAt: Date.now(),
+		});
+		const refresh = vi
+			.fn()
+			.mockResolvedValue({ access_token: 'NEW', refresh_token: 'WR2', expires_in: 3600 });
+
+		// client_id is OPTIONAL at the token endpoint, so a bound record must still
+		// accept a request that omits it.
+		const omitted = await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: bound.rt },
+			pc,
+			store,
+			refresh,
+		);
+		// And an unbound record must accept any client_id, or the deploy that adds
+		// this field signs out everyone holding a live session.
+		const unbound = await handleToken(
+			{ grant_type: 'refresh_token', refresh_token: legacy.rt, client_id: 'anything' },
+			pc,
+			store,
+			refresh,
+		);
+
+		expect(omitted.status).toBe(200);
+		expect(unbound.status).toBe(200);
+	});
+
 	it('rotates the refresh token; replaying the old one is rejected and revokes the family', async () => {
 		const store = new InMemoryProxyStore();
 		const { upstreamTokenId, rt } = await stage(store, {

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -594,8 +594,8 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 
 		const { app } = buildApp({ ...makeDeps('https://test.example', store, pc), cimdResolver });
 
-		// Success: allowlisted host → document fetched, self-matches → consent page,
-		// which names the VERIFIED client_id host (vscode.dev), not just client_name.
+		// Success: allowlisted host → document fetched, self-matches → consent page
+		// built from that document's own client_name and redirect_uris.
 		const ok = await request(app).get('/mcp/authorize').query({
 			response_type: 'code',
 			client_id: clientId,
@@ -607,9 +607,9 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 		});
 		expect(ok.status).toBe(200);
 		expect(ok.text).toContain('vscode.dev');
-		// Uniquely proves the verified-host line rendered: 'vscode.dev' alone also
-		// appears on the redirectHost line, so assert the verified-line literal too.
-		expect(ok.text).toContain('Verified application');
+		// The name came from the fetched document, not from anything the request
+		// supplied — which is what proves the resolve actually happened.
+		expect(ok.text).toContain('Allow VS Code to use your');
 
 		// The allowed-host success above consulted the fetcher once; reset so the
 		// count below reflects ONLY the off-allowlist request.
@@ -952,7 +952,11 @@ describe('operator redirect allowlist — end-to-end (config → route → handl
 			resource: ISSUER,
 		});
 		expect(authz.status).toBe(200);
-		expect(authz.text).toContain('an application on this device');
+		expect(authz.text).toContain('on this device');
+		// Through the real route, not just the renderer: the host the grant will be
+		// sent to has to reach the page the user actually sees.
+		expect(authz.text).toContain(new URL(redirectUri).hostname);
+		expect(authz.text).toContain('Allow only if you started this sign-in a moment ago');
 	});
 });
 


### PR DESCRIPTION
Two fixes to the hosted OAuth authorization server, from the 2026-07-28 spec-compliance audit. Independent of each other; separate commits.

## Bind a refresh token to the client it was issued to

The refresh grant recorded nothing about which downstream client a refresh token belonged to, so it could not tell one client's token from another's. OAuth 2.1 §4.3 requires the authorization server to maintain that binding. The issuing client is now recorded on the upstream-token record where the callback creates it, and the refresh grant refuses a mismatch.

Worth being precise about what this is: spec-letter completeness and defence in depth, not a barrier against theft. Proxy clients are public and their ids are not secret, so anyone holding a stolen refresh token can present the matching `client_id`. Rotation with reuse detection remains the control that answers a leaked token.

**Two things to look at.**

*Placement is the fix.* The check sits before `beginRefreshRotation`. Returning after the claim would strand it in the `refreshing` set, so the next legitimate refresh would read as a replay and revoke the family — letting a stranger with a wrong `client_id` sign the real user out. A test fails if the guard moves past the claim.

*Both halves of the guard are conditional by necessity.* `client_id` is optional at the token endpoint and omitting it is a live case in this repo's own suite; the proxy store persists unconditionally, so records written before this field exists replay from disk without one. Requiring either would sign out every live session on deploy, for no security the paragraph above does not already concede. `clientId` is therefore optional on `UpstreamToken`.

## Show the redirect host on the approval page

The consent page replaced the redirect host with "an application on this device" for any loopback destination, hiding it in exactly the case the display requirement exists for. The page now names the host in every case, and is considerably shorter: the ask is the heading, one sentence carries the destination and the local-address check, and nothing sits below the buttons.

**Three deliberate choices.**

*`renderPage` gained a `heading` separate from `title`.* The document title stays fixed at "Authorize application" because it names the browser tab, and a page carrying a client-supplied name must not let that name choose what the tab says. A test uses a deliberately misleading client name to pin both halves.

*Buttons are Deny then Allow in source order,* so the progressive action lands on the right per Codex, and a flex row mirrors it with the writing direction under RTL as a CSS `order` override would not.

*No permissions-step promise, and no publisher line.* The old "you'll confirm the exact permissions in the next step" is false after the first sign-in, since MediaWiki remembers the grant — which is also why per-client consent exists here. And a CIMD metadata document only proves an allowlisted host served the details, which is a fact about our host allowlist rather than one a reader can act on; its redirect URIs need not be on its own host, so a divergence is ordinary rather than suspicious. `clientIdHost` is removed end to end along with its CSS.

## To confirm before merge

The removed permissions-step line rests on MediaWiki showing its authorization screen only on first grant. That follows the spec's confused-deputy model and our own 30-day `MCP_OAUTH_CONSENT_TTL`, but I have not observed it against a live wiki.

## Verification

Full suite 1,676 green; `tsc --noEmit`, lint and format clean. Both changes have tests that fail when the fix is reverted — verified by reintroducing the original refresh-grant behaviour and the loopback host substitution.
