### PR TITLE
Return authorization errors to the client, not to a dead page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- An error during hosted OAuth sign-in is now reported back to the application that started it, instead of only shown on a page the application never sees, so a client no longer waits indefinitely for a callback that never arrives. This covers a missing or non-S256 PKCE challenge and a `resource` naming another server.
+- A sign-in request asking for a response type this server does not support is now refused, instead of being answered with an authorization code it did not ask for.
 - Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki, instead of letting it run to completion. Cancelling a write is not an undo: an edit already committed by the wiki stays committed. Cancelled calls are logged as `cancelled` rather than counted as wiki failures.
 - Reading an `mcp://wikis/{wikiKey}` resource for a wiki that is not configured now fails with a JSON-RPC `-32602` error naming the URI, as the protocol requires. It previously returned an empty document, which a client could not tell from a wiki with nothing to report.
 - Wiki keys are now percent-encoded in the `mcp://wikis/` URIs the server publishes, and decoded when one is read or passed as a `wiki` argument, so a key containing a character that needs escaping, such as `%`, a comma or a non-ASCII letter, is now reachable. A key that is already a plain hostname, with or without a port, keeps the URI it had.

--- a/src/auth/authorizationServer/authorize.ts
+++ b/src/auth/authorizationServer/authorize.ts
@@ -8,6 +8,7 @@ import { redirectUriMatches } from './redirectPolicy.js';
 export interface AuthorizeQuery {
 	client_id?: string;
 	redirect_uri?: string;
+	response_type?: string;
 	state?: string;
 	code_challenge?: string;
 	code_challenge_method?: string;
@@ -22,9 +23,39 @@ export interface ConsentClaims {
 }
 
 export type AuthorizePlan =
+	// Rendered as a page. Only for a request whose client or redirect_uri we could
+	// not establish: bouncing an error to an unverified redirect_uri would make the
+	// endpoint an open redirector.
 	| { kind: 'error'; status: number; body: Record<string, unknown> }
+	// Returned to the client as OAuth error parameters, once its redirect_uri is
+	// known-registered (RFC 6749 §4.1.2.1). A page here instead leaves the client
+	// waiting on a callback that never arrives.
+	| { kind: 'error-redirect'; location: string }
 	| { kind: 'consent'; clientName: string }
 	| { kind: 'redirect'; location: string };
+
+/**
+ * Builds an OAuth error response on a redirect_uri already established as
+ * registered for this client. `iss` is always included: asMetadata advertises
+ * `authorization_response_iss_parameter_supported`, which obliges a client to
+ * reject an authorization response that omits it.
+ */
+function errorRedirectTo(
+	redirectUri: string,
+	pc: ProxyConfig,
+	error: string,
+	description: string,
+	state: string | undefined,
+): string {
+	const u = new URL(redirectUri);
+	u.searchParams.set('error', error);
+	u.searchParams.set('error_description', description);
+	if (state) {
+		u.searchParams.set('state', state);
+	}
+	u.searchParams.set('iss', pc.issuer);
+	return u.toString();
+}
 
 /**
  * Pure planner for the proxy's /authorize endpoint. Validates the downstream
@@ -67,6 +98,25 @@ export function planAuthorize(
 	if (!q.redirect_uri || !client.redirectUris.some((u) => redirectUriMatches(q.redirect_uri!, u))) {
 		return err('redirect_uri not registered');
 	}
+	// Captured in straight-line code: the narrowing above is lost inside a closure,
+	// since `q.redirect_uri` is a mutable property.
+	const redirectUri = q.redirect_uri;
+	// Everything below runs on a redirect_uri we have established as registered, so
+	// the client learns about the failure through its own callback.
+	const errRedirect = (error: string, d: string): AuthorizePlan => ({
+		kind: 'error-redirect',
+		location: errorRedirectTo(redirectUri, pc, error, d, q.state),
+	});
+
+	// `response_type` is REQUIRED by OAuth 2.1 and `code` is the only value this
+	// server supports (asMetadata publishes `response_types_supported: ['code']`).
+	// A present-but-unsupported value is refused rather than silently answered with
+	// a code the client did not ask for. An absent one is still treated as a code
+	// request: clients that omit it work today, and rejecting them would newly break
+	// a working setup for no security gain.
+	if (q.response_type !== undefined && q.response_type !== 'code') {
+		return errRedirect('unsupported_response_type', 'only response_type=code is supported');
+	}
 	// RFC 8707 resource indicator. A spec-compliant client reads `resource` from
 	// the protected-resource document (resolvePublicBase, WITH a trailing slash)
 	// and echoes it here, while pc.issuer is the RFC 8414 issuer (slash-free).
@@ -74,13 +124,15 @@ export function planAuthorize(
 	// normalized off rather than rejecting the slash-bearing variant.
 	const stripSlash = (s: string): string => s.replace(/\/+$/, '');
 	if (q.resource && stripSlash(q.resource) !== stripSlash(pc.issuer)) {
-		return err('resource does not match this server');
+		// RFC 8707 §2 defines invalid_target for a resource the server does not
+		// serve, which a client can act on by retrying with a corrected value.
+		return errRedirect('invalid_target', 'resource does not match this server');
 	}
 	if (q.code_challenge_method !== 'S256' || !q.code_challenge) {
-		return err('S256 code_challenge required');
+		return errRedirect('invalid_request', 'S256 code_challenge required');
 	}
 
-	const redirectHost = new URL(q.redirect_uri).hostname;
+	const redirectHost = new URL(redirectUri).hostname;
 	const consentOk =
 		consent && consent.clientId === client.clientId && consent.redirectHost === redirectHost;
 	if (!consentOk) {
@@ -139,12 +191,14 @@ export function planDeny(
 	) {
 		return { kind: 'page' };
 	}
-	const u = new URL(q.redirect_uri);
-	u.searchParams.set('error', 'access_denied');
-	u.searchParams.set('error_description', 'The user denied the authorization request.');
-	if (q.state) {
-		u.searchParams.set('state', q.state);
-	}
-	u.searchParams.set('iss', pc.issuer);
-	return { kind: 'redirect', location: u.toString() };
+	return {
+		kind: 'redirect',
+		location: errorRedirectTo(
+			q.redirect_uri,
+			pc,
+			'access_denied',
+			'The user denied the authorization request.',
+			q.state,
+		),
+	};
 }

--- a/src/auth/authorizationServer/router.ts
+++ b/src/auth/authorizationServer/router.ts
@@ -59,6 +59,7 @@ function readAuthorizeQuery(query: Request['query']): AuthorizeQuery {
 	return {
 		client_id: firstScalar(query.client_id),
 		redirect_uri: firstScalar(query.redirect_uri),
+		response_type: firstScalar(query.response_type),
 		state: firstScalar(query.state),
 		code_challenge: firstScalar(query.code_challenge),
 		code_challenge_method: firstScalar(query.code_challenge_method),
@@ -208,6 +209,12 @@ export function mountAuthorizationServer(
 			sendAuthError(res, plan.status, errorReason(plan.body, 'invalid request'));
 			return;
 		}
+		if (plan.kind === 'error-redirect') {
+			// No transaction was minted, so no txn cookie: the `state` on this URL is
+			// the CLIENT's, and planting it would have the callback read it as ours.
+			res.redirect(302, plan.location);
+			return;
+		}
 		if (plan.kind === 'consent') {
 			// Anti-CSRF nonce: set as a SameSite=Strict cookie and embedded in the form
 			// so the decision POST can prove it came from this page (double-submit).
@@ -292,6 +299,10 @@ export function mountAuthorizationServer(
 		const plan = planAuthorize(q, consent, pc, store, defaultWikiSitename, client);
 		if (plan.kind === 'error') {
 			sendAuthError(res, plan.status, errorReason(plan.body, 'invalid request'));
+			return;
+		}
+		if (plan.kind === 'error-redirect') {
+			res.redirect(302, plan.location);
 			return;
 		}
 		if (plan.kind === 'redirect') {

--- a/tests/auth/authorizationServer/authorize.test.ts
+++ b/tests/auth/authorizationServer/authorize.test.ts
@@ -83,9 +83,11 @@ describe('planAuthorize', () => {
 		};
 		expect(
 			planAuthorize(q, undefined, pc, store, 'Ex', store.getClient(client.clientId)).kind,
+			// A page, not a redirect: this redirect_uri is not registered, so bouncing
+			// an error to it would make the endpoint an open redirector.
 		).toBe('error');
 	});
-	it('errors on resource mismatch', () => {
+	it('redirects a resource mismatch back to the client as invalid_target', () => {
 		const { store, client } = setup();
 		expect(
 			planAuthorize(
@@ -96,7 +98,7 @@ describe('planAuthorize', () => {
 				'Ex',
 				store.getClient(client.clientId),
 			).kind,
-		).toBe('error');
+		).toBe('error-redirect');
 	});
 	it('accepts a resource equal to the issuer with a trailing slash (RFC 8707)', () => {
 		// A spec-compliant client echoes the protected-resource doc's `resource`
@@ -112,9 +114,9 @@ describe('planAuthorize', () => {
 				'Ex',
 				store.getClient(client.clientId),
 			).kind,
-		).not.toBe('error');
+		).toBe('consent');
 	});
-	it('still errors on a genuinely different resource (not just a trailing slash)', () => {
+	it('still refuses a genuinely different resource (not just a trailing slash)', () => {
 		const { store, client } = setup();
 		expect(
 			planAuthorize(
@@ -125,9 +127,9 @@ describe('planAuthorize', () => {
 				'Ex',
 				store.getClient(client.clientId),
 			).kind,
-		).toBe('error');
+		).toBe('error-redirect');
 	});
-	it('errors when code_challenge_method is not S256', () => {
+	it('redirects a non-S256 code_challenge_method back as invalid_request', () => {
 		const { store, client } = setup();
 		expect(
 			planAuthorize(
@@ -138,15 +140,15 @@ describe('planAuthorize', () => {
 				'Ex',
 				store.getClient(client.clientId),
 			).kind,
-		).toBe('error');
+		).toBe('error-redirect');
 	});
-	it('errors when code_challenge is missing', () => {
+	it('redirects a missing code_challenge back as invalid_request', () => {
 		const { store, client } = setup();
 		const q = baseQuery(client.clientId);
 		delete (q as Record<string, unknown>).code_challenge;
 		expect(
 			planAuthorize(q, undefined, pc, store, 'Ex', store.getClient(client.clientId)).kind,
-		).toBe('error');
+		).toBe('error-redirect');
 	});
 	it('renders consent when no cookie', () => {
 		const { store, client } = setup();

--- a/tests/transport/streamableHttp.proxy.test.ts
+++ b/tests/transport/streamableHttp.proxy.test.ts
@@ -465,6 +465,134 @@ describe('hosted OAuth proxy — end-to-end (real buildApp routes)', () => {
 			.send({ decision: 'approve', csrf });
 		expect(ok.status).toBe(302);
 	});
+	// OAuth 2.1 §4.1.2.1 splits authorization-endpoint failures: a page only when the
+	// client or redirect_uri could not be established, otherwise the error goes back
+	// to the client's own callback. Driven through the real app because the answer
+	// depends on the router branching on the plan, not just on the planner.
+	describe('authorization errors reach the client rather than a dead page', () => {
+		const REDIRECT = 'http://127.0.0.1:47311/cb';
+
+		async function registeredClient(app: ReturnType<typeof buildApp>['app']) {
+			const reg = await request(app)
+				.post('/mcp/register')
+				.set('Content-Type', 'application/json')
+				.send({ redirect_uris: [REDIRECT], client_name: 'E' });
+			const { randomVerifier, s256 } = await import('../../src/auth/pkce.js');
+			return {
+				client_id: String(reg.body.client_id),
+				redirect_uri: REDIRECT,
+				response_type: 'code',
+				state: 'client-state-e',
+				code_challenge: s256(randomVerifier()),
+				code_challenge_method: 'S256',
+				resource: ISSUER,
+			};
+		}
+
+		it.each([
+			[
+				'a resource this server does not serve',
+				{ resource: 'https://other.example' },
+				'invalid_target',
+			],
+			[
+				'an unsupported code_challenge_method',
+				{ code_challenge_method: 'plain' },
+				'invalid_request',
+			],
+			['a missing code_challenge', { code_challenge: undefined }, 'invalid_request'],
+			[
+				'a response_type this server does not support',
+				{ response_type: 'token' },
+				'unsupported_response_type',
+			],
+		] as const)('redirects %s back as %s', async (_label, override, expected) => {
+			const pc = proxyConfig('https://as.example');
+			const { app } = buildApp(makeDeps('https://as.example', new InMemoryProxyStore(), pc));
+			const params = { ...(await registeredClient(app)), ...override };
+
+			const res = await request(app).get('/mcp/authorize').query(params);
+
+			expect(res.status).toBe(302);
+			const loc = new URL(res.headers.location as string);
+			expect(loc.origin + loc.pathname).toBe(REDIRECT);
+			expect(loc.searchParams.get('error')).toBe(expected);
+			// state round-trips, so the client can match the failure to its request.
+			expect(loc.searchParams.get('state')).toBe('client-state-e');
+			// Mandatory here, not decorative: asMetadata advertises
+			// authorization_response_iss_parameter_supported, which obliges a client to
+			// REJECT a response without iss — swallowing the error exactly as the old
+			// HTML page did.
+			expect(loc.searchParams.get('iss')).toBe(ISSUER);
+			// The only observable difference between this branch and falling through to
+			// the success path is the absence of this cookie: setTxnCookie reads `state`
+			// off the URL it is given, so a fall-through would plant the CLIENT's own
+			// state as the proxy transaction id. Asserted with a predicate because a
+			// negated `toContain` against an asymmetric matcher can never fail.
+			const setCookies = (res.headers['set-cookie'] as string[] | undefined) ?? [];
+			expect(setCookies.some((c) => c.startsWith('mcp_txn='))).toBe(false);
+		});
+
+		it.each([
+			['an unknown client_id', { client_id: 'nope-not-registered' }],
+			['a redirect_uri that is not registered', { redirect_uri: 'https://attacker.example/cb' }],
+		] as const)('renders a page for %s instead of redirecting', async (_label, override) => {
+			const pc = proxyConfig('https://as.example');
+			const { app } = buildApp(makeDeps('https://as.example', new InMemoryProxyStore(), pc));
+			const params = { ...(await registeredClient(app)), ...override };
+
+			const res = await request(app).get('/mcp/authorize').query(params);
+
+			// Redirecting here would make the endpoint an open redirector: the target
+			// has not been established as belonging to this client.
+			expect(res.status).toBe(400);
+			expect(res.headers.location).toBeUndefined();
+			expect(res.headers['content-type']).toMatch(/text\/html/);
+		});
+
+		it('redirects rather than dead-ends when approval itself fails validation', async () => {
+			const pc = proxyConfig('https://as.example');
+			const { app } = buildApp(makeDeps('https://as.example', new InMemoryProxyStore(), pc));
+			const params = await registeredClient(app);
+
+			// Reach consent legitimately, then submit the decision with a request that
+			// fails a post-redirect_uri check. Without its own branch the POST handler
+			// falls through to the "consent could not be applied" page, which is the
+			// same dead end on the client's side.
+			const authz = await request(app).get('/mcp/authorize').query(params);
+			const cookies = (authz.headers['set-cookie'] as string[]) ?? [];
+			const csrf = cookies.find((c) => c.startsWith('mcp_consent_csrf='))!.split(';')[0];
+			const csrfToken = csrf.split('=').slice(1).join('=');
+
+			const res = await request(app)
+				.post('/mcp/consent')
+				.query({ ...params, resource: 'https://other.example' })
+				.set('Cookie', csrf)
+				.type('form')
+				.send({ csrf: csrfToken, decision: 'approve' });
+
+			expect(res.status).toBe(302);
+			const loc = new URL(res.headers.location as string);
+			expect(loc.searchParams.get('error')).toBe('invalid_target');
+			expect(loc.searchParams.get('iss')).toBe(ISSUER);
+			const setCookies = (res.headers['set-cookie'] as string[] | undefined) ?? [];
+			expect(setCookies.some((c) => c.startsWith('mcp_txn='))).toBe(false);
+		});
+
+		it('still accepts a request that omits response_type', async () => {
+			const pc = proxyConfig('https://as.example');
+			const { app } = buildApp(makeDeps('https://as.example', new InMemoryProxyStore(), pc));
+			const { response_type: _dropped, ...params } = await registeredClient(app);
+
+			const res = await request(app).get('/mcp/authorize').query(params);
+
+			// Clients that omit it work today, so refusing them would newly break a
+			// working setup for no security gain.
+			expect(res.status).toBe(200);
+			expect(res.text).toContain('to use your');
+		});
+	});
+
 	it('criterion 6: a grant-screen denial (no state, MediaWiki unauthorized_client) is bounced to the client as access_denied via the txn cookie', async () => {
 		fakeAs = await startFakeAs({ autoApproveAuthorize: true });
 		const store = new InMemoryProxyStore();


### PR DESCRIPTION
Every `/authorize` failure rendered an HTML page, so a client that had opened a browser for sign-in was left waiting on a callback that never arrived — no timeout, no retry, nothing to diagnose. The flow simply died.

OAuth 2.1 §4.1.2.1 divides these. A page is correct only when the `client_id` or `redirect_uri` could not be established, because bouncing an error to an unverified target would make the endpoint an open redirector. Every other failure belongs on the client's own callback as error parameters.

## What changed

`AuthorizePlan` now carries both shapes, and which one applies is decided by whether `redirect_uri` validation has already run.

A page still covers an unknown client, a missing or unregistered `redirect_uri`, and a CIMD document that would not resolve — an unresolvable client identity means its `redirect_uri` is not trusted either. The `resource` mismatch and the PKCE checks now redirect, as does an unsupported `response_type`.

## Three details that are load-bearing

**`iss` on every error redirect.** `asMetadata` advertises `authorization_response_iss_parameter_supported`, so a compliant client MUST reject a response without it. Omitting `iss` would swallow the error exactly as the page did, and the fix would defeat itself.

**`invalid_target` for the `resource` mismatch**, per RFC 8707 §2, rather than the more obvious `invalid_request`: a client that distinguishes them can retry with a corrected `resource`.

**`response_type` is validated only when present.** Absent still means a code request, so no client that works today is refused — including this repo's own `runHostedFlow`, which omits it. A client asking for a response type we do not support is refused instead of being handed a code it never asked for. That is also what keeps this a fix rather than a breaking change: a client sending `response_type=token` was already getting a code it did not ask for.

## What the new tests actually pin

The `error-redirect` branch's only observable difference from falling through to the success path is the **absence** of a txn cookie — `setTxnCookie` reads `state` off whatever URL it is given, so a fall-through would plant the client's own state as the proxy transaction id. Both branches assert that with a predicate rather than a negated `toContain` against an asymmetric matcher, which cannot fail.

Verified by mutation, not by a green suite: deleting the GET branch fails 4 tests, deleting the POST branch fails 1, deleting the `iss` line fails 4, and swapping `invalid_target` for `invalid_request` fails 1.

One existing assertion is tightened alongside: the RFC 8707 trailing-slash guard asserted `not.toBe('error')`, which goes vacuously true once a second error kind exists, so it now asserts `toBe('consent')`.

## Known limits, not addressed here

A duplicated `response_type` parameter (`?response_type=token&response_type=token`) reaches `firstScalar` as an array and reads as absent, so it is accepted as a code request rather than refused. Behaviour is unchanged from before this PR, which never read the parameter at all, so the new check narrows the accepted set without closing that variant.

`POST /mcp/consent` appends the signed consent cookie before validation runs, so a request that then fails leaves the browser holding a durable approval. Pre-existing and byte-identical at the base commit.
