### PR TITLE
Drop type assertions the compiler does not need

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
-	"plugins": ["typescript", "node", "import"],
+	"plugins": [
+		"typescript",
+		"node",
+		"import"
+	],
 	"categories": {
 		"correctness": "error",
 		"suspicious": "warn"
@@ -17,16 +21,26 @@
 		"typescript/no-misused-promises": "error",
 		"typescript/await-thenable": "error",
 		"typescript/no-explicit-any": "warn",
-		"import/extensions": ["error", "ignorePackages", { "js": "never" }]
+		"import/extensions": [
+			"error",
+			"ignorePackages",
+			{
+				"js": "never"
+			}
+		],
+		"typescript/no-unnecessary-type-assertion": "error"
 	},
 	"overrides": [
 		{
-			"files": ["scripts/**"],
-			"rules": {
-			}
+			"files": [
+				"scripts/**"
+			],
+			"rules": {}
 		},
 		{
-			"files": ["tests/**"],
+			"files": [
+				"tests/**"
+			],
 			"rules": {
 				"typescript/no-unsafe-type-assertion": "off",
 				"typescript/no-unnecessary-type-assertion": "off"

--- a/src/results/response.ts
+++ b/src/results/response.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, TextContent } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ErrorEnvelope } from '../results/schemas.ts';
 import type { ErrorCategory } from '../errors/classifyError.ts';
 import { formatPayload } from './format.ts';
@@ -16,7 +16,7 @@ export interface ResponseFormatter {
 
 export function structuredResult(data: unknown): CallToolResult {
 	return {
-		content: [{ type: 'text', text: formatPayload(data) } as TextContent],
+		content: [{ type: 'text', text: formatPayload(data) }],
 		// structuredContent mirrors the typed payload so the dispatcher can detect
 		// truncation via the `truncation` field without reparsing the rendered text.
 		structuredContent: data,
@@ -35,7 +35,7 @@ export function errorResult(
 	const envelope: ErrorEnvelope =
 		code !== undefined ? { category, message, code } : { category, message };
 	return {
-		content: [{ type: 'text', text: JSON.stringify(envelope) } as TextContent],
+		content: [{ type: 'text', text: JSON.stringify(envelope) }],
 		isError: true,
 	};
 }

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ManagementContext } from '../runtime/context.ts';
 import { discoverWiki } from '../wikis/wikiDiscovery.ts';
@@ -25,7 +25,7 @@ export const addWiki: Tool<typeof inputSchema, ManagementContext> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'add wiki',
 	target: (a) => a.wikiUrl,
 

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { inlineDiffToText } from '../results/diffFormat.ts';
@@ -165,7 +165,7 @@ export const comparePages: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'compare pages',
 
 	async handle(args, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiEditPageParams } from 'types-mediawiki-api';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -34,7 +34,7 @@ export const createPage: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'create page',
 	target: (a) => a.title,
 
@@ -45,8 +45,7 @@ export const createPage: Tool<typeof inputSchema> = {
 		const mwn = await ctx.mwn();
 		const baseOptions: ApiEditPageParams = {};
 		if (contentModel !== undefined) {
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- input is validated against ApiEditPageParams.contentmodel via the inputSchema enum
-			baseOptions.contentmodel = contentModel as ApiEditPageParams['contentmodel'];
+			baseOptions.contentmodel = contentModel;
 		}
 		if (bot === true) {
 			baseOptions.bot = true;

--- a/src/tools/delete-page.ts
+++ b/src/tools/delete-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiDeleteResponse } from 'mwn';
 import type { ApiDeleteParams } from 'types-mediawiki-api';
 import type { Tool } from '../runtime/tool.ts';
@@ -22,7 +22,7 @@ export const deletePage: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'delete page',
 	target: (a) => a.title,
 

--- a/src/tools/extensions/bucket/bucket-query.ts
+++ b/src/tools/extensions/bucket/bucket-query.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -42,7 +42,7 @@ export const bucketQuery: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'run Bucket query',
 	target: (a) => a.query,
 

--- a/src/tools/extensions/cargo/cargo-describe-table.ts
+++ b/src/tools/extensions/cargo/cargo-describe-table.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 
@@ -35,7 +35,7 @@ export const cargoDescribeTable: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'describe Cargo table',
 	target: (a) => a.table,
 

--- a/src/tools/extensions/cargo/cargo-list-tables.ts
+++ b/src/tools/extensions/cargo/cargo-list-tables.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 
@@ -19,7 +19,7 @@ export const cargoListTables: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'list Cargo tables',
 
 	async handle(_args, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/extensions/cargo/cargo-query.ts
+++ b/src/tools/extensions/cargo/cargo-query.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -64,7 +64,7 @@ export const cargoQuery: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'run Cargo query',
 	target: (a) => a.tables,
 

--- a/src/tools/extensions/neowiki/neowiki-create-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-create-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -70,7 +70,7 @@ export const neowikiCreateSubject: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: false,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'create NeoWiki subject',
 	target: (a) => a.label,
 

--- a/src/tools/extensions/neowiki/neowiki-cypher-query.ts
+++ b/src/tools/extensions/neowiki/neowiki-cypher-query.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -39,7 +39,7 @@ export const neowikiCypherQuery: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'run NeoWiki Cypher query',
 	target: (a) => a.cypher,
 

--- a/src/tools/extensions/neowiki/neowiki-delete-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-delete-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -23,7 +23,7 @@ export const neowikiDeleteSubject: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'delete NeoWiki subject',
 	target: (a) => a.id,
 

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -44,7 +44,7 @@ export const neowikiGetPageSubjects: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'get NeoWiki page subjects',
 	target: (a) => a.title ?? (a.pageId !== undefined ? String(a.pageId) : ''),
 

--- a/src/tools/extensions/neowiki/neowiki-get-schema.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -26,7 +26,7 @@ export const neowikiGetSchema: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'get NeoWiki schema',
 	target: (a) => a.name,
 

--- a/src/tools/extensions/neowiki/neowiki-get-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -41,7 +41,7 @@ export const neowikiGetSubject: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'get NeoWiki subject',
 	target: (a) => a.id,
 

--- a/src/tools/extensions/neowiki/neowiki-list-schemas.ts
+++ b/src/tools/extensions/neowiki/neowiki-list-schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -38,7 +38,7 @@ export const neowikiListSchemas: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'list NeoWiki schemas',
 
 	async handle({ continueFrom }, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/extensions/neowiki/neowiki-search-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-search-subjects.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -28,7 +28,7 @@ export const neowikiSearchSubjects: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'search NeoWiki subjects',
 	target: (a) => a.search,
 

--- a/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -38,7 +38,7 @@ export const neowikiSetMainSubject: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'set NeoWiki main subject',
 	target: (a) => a.subjectId ?? '',
 

--- a/src/tools/extensions/neowiki/neowiki-update-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-update-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -46,7 +46,7 @@ export const neowikiUpdateSubject: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'update NeoWiki subject',
 	target: (a) => a.id,
 

--- a/src/tools/extensions/neowiki/neowiki-validate-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-validate-subject.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
@@ -56,7 +56,7 @@ export const neowikiValidateSubject: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'validate NeoWiki subject',
 	target: (a) => a.id ?? a.schema ?? '',
 

--- a/src/tools/extensions/smw/smw-list-properties.ts
+++ b/src/tools/extensions/smw/smw-list-properties.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -60,7 +60,7 @@ export const smwListProperties: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'list SMW properties',
 
 	async handle({ search, limit, continueFrom }, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/extensions/smw/smw-query.ts
+++ b/src/tools/extensions/smw/smw-query.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
@@ -60,7 +60,7 @@ export const smwQuery: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'run SMW query',
 	target: (a) => a.query,
 

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
@@ -49,7 +49,7 @@ export const getCategoryMembers: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve category members',
 	target: (a) => a.category,
 

--- a/src/tools/get-file-data.ts
+++ b/src/tools/get-file-data.ts
@@ -1,10 +1,5 @@
 import { z } from 'zod';
-import type {
-	CallToolResult,
-	ToolAnnotations,
-	ImageContent,
-	TextContent,
-} from '@modelcontextprotocol/server';
+import type { CallToolResult, ImageContent, TextContent } from '@modelcontextprotocol/server';
 import type { ApiPage, ImageInfo } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -59,7 +54,7 @@ export const getFileData: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'fetch the file image',
 	target: (a) => a.title,
 

--- a/src/tools/get-file.ts
+++ b/src/tools/get-file.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiPage, ImageInfo } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -19,7 +19,7 @@ export const getFile: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve file data',
 	target: (a) => a.title,
 

--- a/src/tools/get-links-here.ts
+++ b/src/tools/get-links-here.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
@@ -86,7 +86,7 @@ export const getLinksHere: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve links',
 	target: (a) => a.title,
 

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiPage, ApiRevision } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -38,7 +38,7 @@ export const getPageHistory: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve page history',
 	target: (a) => a.title,
 

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
@@ -41,7 +41,7 @@ export const getPage: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve page data',
 	target: (a) => a.title,
 

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Mwn } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -279,7 +279,7 @@ export const getPages: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve pages',
 
 	async handle(args, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
@@ -112,7 +112,7 @@ export const getRecentChanges: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve recent changes',
 
 	async handle(args, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiPage, ApiRevision } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -33,7 +33,7 @@ export const getRevision: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve revision data',
 	target: (a) => String(a.revisionId),
 

--- a/src/tools/get-site-info.ts
+++ b/src/tools/get-site-info.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { resolveSiteInfo } from '../wikis/siteInfo.ts';
@@ -147,7 +147,7 @@ export const getSiteInfo: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'fetch site info',
 
 	async handle(args: GetSiteInfoArgs, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/list-wikis.ts
+++ b/src/tools/list-wikis.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { extensionPacks } from './extensions/index.ts';
@@ -28,7 +28,7 @@ export const listWikis: Tool<Record<string, never>> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	wikiScoped: false,
 	failureVerb: 'list wikis',
 

--- a/src/tools/move-page.ts
+++ b/src/tools/move-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiMoveResponse } from 'mwn';
 import type { ApiMoveParams } from 'types-mediawiki-api';
 import type { Tool } from '../runtime/tool.ts';
@@ -40,7 +40,7 @@ export const movePage: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'move page',
 	target: (a) => a.fromTitle,
 

--- a/src/tools/oauth-logout.ts
+++ b/src/tools/oauth-logout.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { createTokenStore } from '../auth/tokenStore.ts';
@@ -20,7 +20,7 @@ export const oauthLogout: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: false,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'log out',
 
 	async handle({ wiki }, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/oauth-status.ts
+++ b/src/tools/oauth-status.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { createTokenStore } from '../auth/tokenStore.ts';
@@ -15,7 +15,7 @@ export const oauthStatus: Tool<Record<string, never>> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: false,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'read OAuth status',
 
 	async handle(_args, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { truncateByBytes } from '../results/truncation.ts';
@@ -37,7 +37,7 @@ export const parseWikitext: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'preview wikitext',
 
 	async handle(

--- a/src/tools/remove-wiki.ts
+++ b/src/tools/remove-wiki.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ManagementContext } from '../runtime/context.ts';
 import { parseWikiResourceUri, InvalidWikiResourceUriError } from '../wikis/wikiResource.ts';
@@ -22,7 +22,7 @@ export const removeWiki: Tool<typeof inputSchema, ManagementContext> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: false,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'remove wiki',
 	target: (a) => a.uri,
 

--- a/src/tools/search-page-by-prefix.ts
+++ b/src/tools/search-page-by-prefix.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
@@ -38,7 +38,7 @@ export const searchPageByPrefix: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve search data',
 	target: (a) => a.prefix,
 

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiSearchResult } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
@@ -28,7 +28,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'retrieve search data',
 	target: (a) => a.query,
 

--- a/src/tools/undelete-page.ts
+++ b/src/tools/undelete-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiUndeleteResponse } from 'mwn';
 import type { ApiUndeleteParams } from 'types-mediawiki-api';
 import type { Tool } from '../runtime/tool.ts';
@@ -22,7 +22,7 @@ export const undeletePage: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'undelete page',
 	target: (a) => a.title,
 

--- a/src/tools/update-file-from-url.ts
+++ b/src/tools/update-file-from-url.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
@@ -26,7 +26,7 @@ export const updateFileFromUrl: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: false,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'update file',
 	target: (a) => a.title,
 

--- a/src/tools/update-file.ts
+++ b/src/tools/update-file.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
@@ -25,7 +25,7 @@ export const updateFile: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: false,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'update file',
 	target: (a) => a.title,
 

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
@@ -98,7 +98,7 @@ export const updatePage: Tool<typeof inputSchema> = {
 		destructiveHint: true,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'update page',
 	target: (a) => a.title,
 

--- a/src/tools/upload-file-from-url.ts
+++ b/src/tools/upload-file-from-url.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
@@ -26,7 +26,7 @@ export const uploadFileFromUrl: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'upload file',
 	target: (a) => a.title,
 

--- a/src/tools/upload-file.ts
+++ b/src/tools/upload-file.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiUploadParams } from 'types-mediawiki-api';
 import type { ApiUploadResponse } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
@@ -25,7 +25,7 @@ export const uploadFile: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'upload file',
 	target: (a) => a.title,
 

--- a/src/tools/whoami.ts
+++ b/src/tools/whoami.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CallToolResult, ToolAnnotations } from '@modelcontextprotocol/server';
+import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 
@@ -45,7 +45,7 @@ export const whoami: Tool<typeof inputSchema> = {
 		destructiveHint: false,
 		idempotentHint: true,
 		openWorldHint: true,
-	} as ToolAnnotations,
+	},
 	failureVerb: 'read user identity',
 
 	async handle(args: WhoamiArgs, ctx: ToolContext): Promise<CallToolResult> {

--- a/src/transport/ssrfGuard.ts
+++ b/src/transport/ssrfGuard.ts
@@ -143,8 +143,7 @@ function assertAddressIsUnicast(address: string, urlString: string): void {
 	}
 
 	if (parsed.kind() === 'ipv6') {
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by parsed.kind() === 'ipv6'; ipaddr.js doesn't expose a type predicate
-		const extraMatch = ipaddr.subnetMatch(parsed as ipaddr.IPv6, EXTRA_BLOCKED_V6, 'unicast');
+		const extraMatch = ipaddr.subnetMatch(parsed, EXTRA_BLOCKED_V6, 'unicast');
 		if (extraMatch !== 'unicast') {
 			throw new SsrfValidationError(
 				`Refusing to fetch URL resolving to non-public address ${address} (${extraMatch}): ${urlString}`,

--- a/tests/auth/authorizationServer/consent.test.ts
+++ b/tests/auth/authorizationServer/consent.test.ts
@@ -11,12 +11,13 @@ import {
 	readTxnCookie,
 } from '../../../src/auth/authorizationServer/consent.ts';
 import { signConsent } from '../../../src/auth/authorizationServer/jwt.ts';
+import { fakeProxyConfig } from '../../helpers/fakeProxyConfig.ts';
 
-const pc = {
+const pc = fakeProxyConfig({
 	issuer: 'https://wiki.example/mcp',
 	consentTtlMs: 60_000,
 	signingKey: 'k'.repeat(32),
-} as any;
+});
 
 describe('consent', () => {
 	it('renders the consent page with client, wiki, the form and CSRF field', () => {


### PR DESCRIPTION
CI was printing 50 `no-unnecessary-type-assertion` warnings on every run. This removes the assertions rather than the warnings.

## What they were

| Pattern | Count |
|---|---|
| `annotations: { … } as ToolAnnotations` on every tool descriptor | 46 |
| `{ type: 'text', text: … } as TextContent` in the response helpers | 2 |
| `parsed as ipaddr.IPv6` in the SSRF guard | 1 |
| `contentModel as ApiEditPageParams['contentmodel']` in create-page | 1 |

All 46 annotations objects sat in a position already contextually typed as `ToolAnnotations` by `Tool<TSchema>`, so the assertion said nothing the compiler did not already know. The two `TextContent` ones are the same shape.

## Why this is not purely cosmetic

An assertion also suppresses excess-property checking. Every one of these was quietly forfeiting a check on the object it wrapped — a typo'd annotation key would have been accepted. Removing them turns that checking back on, and everything still compiles.

Two of the four carried `oxlint-disable` comments for `no-unsafe-type-assertion`, and both suppressions turn out to have been unnecessary too. The ipv6 branch of the SSRF guard already holds a type `subnetMatch` accepts, and create-page's `contentmodel` is already narrowed by its own schema enum. Assertion and suppression both go, so `src` suppressions drop 84 → 82 and assertions 122 → 73.

The consent suite built a `ProxyConfig` with `as any`, which predates the shared fixture added in #509. It now uses `fakeProxyConfig`, which is what that fixture exists for.

## Emit is unchanged

Built `master` and this branch side by side. The only difference across all 145 output files is the two deleted comment lines, which the compiler had been copying into `dist`. Stripping comments and blank lines, the code in both differing files hashes identically.

## The second commit is separately droppable

`typescript/no-unnecessary-type-assertion` is promoted from the `suspicious` category's `warn` to `error`. The count reached 50 precisely because a warning costs nothing to ignore — CI prints it and exits 0, so nothing forces anyone to act. Verified it now blocks a regression: reintroducing a redundant assertion fails `npm run lint` with exit 1.

Scoped to `src` — the `tests/**` override already disables this rule, since a test double is often asserted deliberately.

Drop that commit if you would rather keep it advisory.

## Verified

`npm run typecheck`, `npm test` (134 files, 1684 tests), `npm run lint`, `npm run fmt:check` and `npm run build` all exit 0. Lint warnings **51 → 0**.

No CHANGELOG entry — no tool surface, behaviour or env var changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)