### PR TITLE
Close a rendered value before the next field, and record the custom-scheme callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- A tool result that renders a long or multi-line value, such as a page's wikitext, now closes it with a blank line before the next field. Previously the next field's label was the only cue the value had ended, so content containing a line like `Summary: …` read as a field of the result.
 - An error during hosted OAuth sign-in is now reported back to the application that started it, instead of only shown on a page the application never sees, so a client no longer waits indefinitely for a callback that never arrives. This covers a missing or non-S256 PKCE challenge and a `resource` naming another server.
 - A sign-in request asking for a response type this server does not support is now refused, instead of being answered with an authorization code it did not ask for.
 - Cancelling a tool call, or disconnecting while one is still running, now stops the request the server had in flight to the wiki, instead of letting it run to completion. Cancelling a write is not an undo: an edit already committed by the wiki stays committed. Cancelled calls are logged as `cancelled` rather than counted as wiki failures.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -142,6 +142,8 @@ Only add callbacks you recognise as the client's official ones — a redirect yo
 
 Some clients identify themselves by a vendor-hosted URL instead of a callback; verified first-party ones are trusted out of the box. To admit another client that works this way, add its host to `MCP_OAUTH_CIMD_ALLOWED_HOSTS` (comma-separated bare hosts or `host:port`) rather than `MCP_OAUTH_ALLOWED_REDIRECTS`.
 
+The defaults include one callback that is not a web address, `cursor://anysphere.cursor-mcp/oauth/callback`, which any program on the user's own machine could claim.
+
 ## Running it with Docker
 
 The image is published at `ghcr.io/professionalwiki/mediawiki-mcp-server`. Pull and run it:

--- a/src/results/format.ts
+++ b/src/results/format.ts
@@ -98,7 +98,10 @@ function renderField(label: string, value: unknown, indent: string): string {
 		if (value.length <= INLINE_STRING_LIMIT && !value.includes('\n')) {
 			return `${prefix} ${value}`;
 		}
-		return `${prefix}\n\n${value}`;
+		// Closed with a blank line. Without one the next field's label is the only
+		// signal the value ended, and a value whose own text contains a line like
+		// "Summary: …" is then indistinguishable from a field of this payload.
+		return `${prefix}\n\n${value}\n`;
 	}
 	if (typeof value === 'number' || typeof value === 'boolean') {
 		return `${prefix} ${value}`;

--- a/tests/results/format.test.ts
+++ b/tests/results/format.test.ts
@@ -10,3 +10,24 @@ describe('formatPayload unknown values', () => {
 		expect(result).not.toContain('[object Object]');
 	});
 });
+
+describe('formatPayload multi-line values', () => {
+	it('separates a multi-line value from the field that follows it', () => {
+		const result = formatPayload({ content: 'first\nsecond', revision: 42 });
+
+		// Without the blank line the next label is the only cue the value ended.
+		expect(result).toContain('second\n\nRevision: 42');
+	});
+
+	it('keeps a line inside a value from reading as a field of the payload', () => {
+		// A page whose own wikitext contains "Summary: …" must not appear to carry a
+		// Summary field. The blank line is what makes the boundary readable.
+		const result = formatPayload({ content: 'intro\nSummary: not a field', revision: 7 });
+
+		// Assert the boundary exists before slicing on it: indexOf returning -1 would
+		// make slice(-1) yield one character, and the check below would pass vacuously.
+		const boundary = result.indexOf('\n\nRevision:');
+		expect(boundary).toBeGreaterThan(0);
+		expect(result.slice(boundary)).not.toContain('Summary:');
+	});
+});

--- a/tests/tools/get-pages.test.ts
+++ b/tests/tools/get-pages.test.ts
@@ -563,7 +563,10 @@ describe('get-pages', () => {
 
 			const text = assertStructuredSuccess(result);
 			// No requestedTitle when title equals the requested title; first field is pageId.
-			expect(text).toMatch(/Page ID: 1[\s\S]*?Source:\n\nx{50000}\n {2}Truncation:/);
+			// The blank line after the source is what separates it from the next field:
+			// without it the wikitext runs straight into `Truncation:`, and a page whose
+			// own text contains such a line would read as a field of this payload.
+			expect(text).toMatch(/Page ID: 1[\s\S]*?Source:\n\nx{50000}\n\n {2}Truncation:/);
 			expect(text).toContain('    Reason: content-truncated');
 			expect(text).toContain('    Returned bytes: 50000');
 			expect(text).toContain('    Total bytes: 50001');


### PR DESCRIPTION
The last two items from the 2026-07-28 spec-compliance audit that needed any change.

## A rendered value now closes before the next field

`formatPayload` emitted a long or multi-line value with no terminator, so the next field's label was the only signal the value had ended:

```
Content:

intro
Summary: not a field
Revision: 42
```

A page whose own wikitext contains a line like `Summary: …` therefore reads as carrying a `Summary` field of the result. Values are now closed with a blank line.

Clients reading `structuredContent` were never affected — this is the text channel only.

Exactly one existing assertion pinned the old adjacency, and it happens to be the clearest illustration of the problem: the truncation case, where 50 000 bytes of wikitext ran straight into `Truncation:`.

## The non-web callback is now named

The proxy trusts one default callback that is not a web address: `cursor://anysphere.cursor-mcp/oauth/callback`. `docs/deployment.md` now names it, because an operator reading that section would not otherwise expect a default that is not an HTTPS or loopback URL.

One sentence, deliberately. The risk is not actionable — there is no way to remove a shipped default — and why we keep it is a decision record rather than operator guidance, so that stays in the source comment beside the entry.

## No change for the `structuredContent` SHOULD

The audit also flagged that we mirror `structuredContent` as prose rather than as serialized JSON, against a SHOULD in `server/tools`. Deliberately unchanged: that section's own example for an array-returning tool pairs `structuredContent` with a prose text block, which is the shape already emitted; it is the only unbolded normative keyword on the page; and no tool declares an `outputSchema`, so `structuredContent` carries no validation contract either way. A second serialized copy would roughly double every payload against the caps in `src/results/truncation.ts`.

## Verification

Full suite 1,686 green; `typecheck`, lint and format clean. Both new format guards fail when the terminator is removed — including the boundary check, which I first wrote so that a missing boundary made it pass vacuously via `slice(-1)`.
