### PR TITLE
Provision a confidential OAuth2 consumer for the dev wiki

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,7 @@ One-time, wiki-side setup, with [Extension:OAuth](https://www.mediawiki.org/wiki
 - **OAuth 2.0**, requesting **specific permissions** (a *full* consumer, not the owner-only "for use only by me" option), including the edit grants your users need.
 - **Grant types:** Authorization code and Refresh token.
 - **Callback URL:** exactly `<MCP_PUBLIC_URL>/oauth/callback`; Extension:OAuth exact-matches the redirect URI. With `MCP_PUBLIC_URL=https://wiki.example.org/mcp`, that is `https://wiki.example.org/mcp/oauth/callback`.
-- **Confidential client:** check "This consumer is confidential" and keep the **client secret** it shows. The proxy authenticates with that secret to refresh tokens and keep users signed in past the wiki's ~1-hour access-token lifetime; it refuses to start without one, so a public/PKCE consumer is not supported.
+- **Confidential client:** check "Client is confidential" and keep the **client secret** it shows. The proxy authenticates with that secret to refresh tokens and keep users signed in past the wiki's ~1-hour access-token lifetime; it refuses to start without one, so a public/PKCE consumer is not supported.
 
 Copy the resulting consumer **key** into the wiki's `oauth2ClientId` and its **secret** into `oauth2ClientSecret` (next step).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -174,6 +174,7 @@ satisfies the contract below works.
 | Variable | Meaning | Source |
 |---|---|---|
 | `OAUTH2_CLIENT_ID` | Consumer key → `config.json` `oauth2ClientId` | provisioning script |
+| `MCP_OAUTH2_CLIENT_SECRET` | Consumer secret. The proxy refuses to start without it | provisioning script |
 | `MW_DEV_BOT_USER` / `MW_DEV_BOT_PASSWORD` | Static credentials for non-proxy auth tests | provisioning script |
 | `MCP_TRUSTED_HOSTS` | Outbound SSRF-guard exemption for a loopback/private wiki | provisioning script |
 | `MCP_PUBLIC_URL`, `MCP_OAUTH_JWT_SIGNING_KEY`, `PORT`, `MCP_TRANSPORT` | Proxy configuration | you |
@@ -186,18 +187,25 @@ set -a; eval "$( scripts/provision-dev-wiki.sh <container> )"; set +a
 ```
 
 On a wiki whose Extension:OAuth is recent enough to register OAuth2 consumers
-from the command line, this registers an approved OAuth 2.0 public (PKCE)
+from the command line, this registers an approved **confidential** OAuth 2.0
 consumer whose callback matches `${MCP_PUBLIC_URL}/oauth/callback`, creates a bot
-password, and exports `OAUTH2_CLIENT_ID`, `MW_DEV_BOT_USER`, `MW_DEV_BOT_PASSWORD`,
-and (for a loopback wiki) `MCP_TRUSTED_HOSTS`. Override the proxy base with
-`--public-url` if you run the server on a non-default port.
+password, and exports `OAUTH2_CLIENT_ID`, `MCP_OAUTH2_CLIENT_SECRET`,
+`MW_DEV_BOT_USER`, `MW_DEV_BOT_PASSWORD`, and (for a loopback wiki)
+`MCP_TRUSTED_HOSTS`. Override the proxy base with `--public-url` if you run the
+server on a non-default port, and the install path with `--mw-path` if MediaWiki
+does not live at `/var/www/html` — MediaWiki core's own docker environment puts
+it at `/var/www/html/w`.
+
+The consumer must be confidential: the proxy authenticates with the secret to
+refresh upstream tokens, and refuses to start without one.
 
 On an older Extension:OAuth — for example the copy bundled with the MediaWiki
 1.43 LTS, whose `createOAuthConsumer.php` is OAuth1-only — the script cannot
 register the consumer from the command line. It prints step-by-step instructions
 to register it once in the browser at
 `Special:OAuthConsumerRegistration/propose/oauth2`, after which you set
-`OAUTH2_CLIENT_ID` yourself before starting the proxy.
+`OAUTH2_CLIENT_ID` and `MCP_OAUTH2_CLIENT_SECRET` yourself before starting the
+proxy. Tick "Client is confidential" there; the secret is shown once.
 
 ### 3. Configure the wiki entry
 
@@ -213,7 +221,8 @@ In `config.json`, point the wiki at the provisioned consumer (adjust
       "server": "http://localhost:8080",
       "articlepath": "/wiki",
       "scriptpath": "/w",
-      "oauth2ClientId": "${OAUTH2_CLIENT_ID}"
+      "oauth2ClientId": "${OAUTH2_CLIENT_ID}",
+      "oauth2ClientSecret": "${MCP_OAUTH2_CLIENT_SECRET}"
     }
   }
 }
@@ -227,8 +236,8 @@ export MCP_OAUTH_JWT_SIGNING_KEY="$(openssl rand -hex 32)"   # keep this FIXED a
 node dist/index.js
 ```
 
-`MCP_TRUSTED_HOSTS` (from step 2) is already exported for a loopback wiki. A
-changed signing key invalidates every issued token.
+`MCP_TRUSTED_HOSTS` and `MCP_OAUTH2_CLIENT_SECRET` (from step 2) are already
+exported. A changed signing key invalidates every issued token.
 
 ### 5. Walk the sign-in flow
 

--- a/scripts/provision-dev-wiki.sh
+++ b/scripts/provision-dev-wiki.sh
@@ -49,8 +49,8 @@ Options:
   --dry-run            Print the docker commands that would run, then exit.
   -h, --help           Show this help.
 
-Output (stdout, env-file format): OAUTH2_CLIENT_ID, MW_DEV_BOT_USER,
-MW_DEV_BOT_PASSWORD, and (for loopback wikis) MCP_TRUSTED_HOSTS.
+Output (stdout, env-file format): OAUTH2_CLIENT_ID, MCP_OAUTH2_CLIENT_SECRET,
+MW_DEV_BOT_USER, MW_DEV_BOT_PASSWORD, and (for loopback wikis) MCP_TRUSTED_HOSTS.
 EOF
 }
 
@@ -82,7 +82,7 @@ OAUTH_SCRIPT="${MW_PATH%/}/extensions/OAuth/maintenance/createOAuthConsumer.php"
 consumer_argv=(docker exec "$CONTAINER" php "$RUN_PHP" "$OAUTH_SCRIPT"
 	--user "$ADMIN_USER" --name "$CONSUMER_NAME"
 	--description 'MediaWiki MCP Server dev proxy' --version '1.0'
-	--oauthVersion 2 --oauth2IsNotConfidential
+	--oauthVersion 2
 	--oauth2GrantTypes authorization_code --oauth2GrantTypes refresh_token
 	--callbackUrl "$CALLBACK_URL" --approve --jsonOnSuccess)
 IFS=',' read -ra grant_arr <<< "$GRANTS"
@@ -108,28 +108,40 @@ docker exec "$CONTAINER" test -f "$OAUTH_SCRIPT" \
 	|| die "Extension:OAuth not found at $MW_PATH/extensions/OAuth (install it and enable OAuth2)"
 
 # --- register consumer (only if the stock CLI supports OAuth2) ---------------
-# The --oauthVersion / --oauth2IsNotConfidential flags exist only in newer
-# Extension:OAuth. The copy bundled with some releases (e.g. the MediaWiki 1.43
-# LTS) ships an OAuth1-only createOAuthConsumer.php, so CLI registration of an
-# OAuth2 public client is impossible there and must be done in the browser.
-# Detect by looking for the public-client flag in the script itself.
+# The OAuth2 flags exist only in newer Extension:OAuth. The copy bundled with the
+# MediaWiki 1.43 LTS ships an OAuth1-only createOAuthConsumer.php, so the consumer
+# has to be registered in the browser there.
+#
+# Probe on oauth2IsNotConfidential: it appears only in the newer script. Do not
+# probe 'oauthVersion' or 'oauth2GrantTypes' — the OAuth1-only file contains both
+# as hardcoded array values, so matching those sends a 1.43 wiki down the CLI
+# path, where registration then fails on the unrecognised flags.
 client_id=''
+client_secret=''
 if docker exec "$CONTAINER" grep -q 'oauth2IsNotConfidential' "$OAUTH_SCRIPT" 2>/dev/null; then
 	log "Registering OAuth 2.0 consumer '${CONSUMER_NAME}'"
 	log "  callback: ${CALLBACK_URL}"
 	consumer_json="$("${consumer_argv[@]}")" || die "consumer registration failed (see above)"
 	client_id="$(printf '%s' "$consumer_json" | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')"
 	[ -n "$client_id" ] || die "could not parse consumer key from output: $consumer_json"
+	# A confidential consumer prints its secret once, here. Without it the proxy
+	# refuses to start, so an unparsed secret is a hard failure rather than a
+	# missing convenience.
+	client_secret="$(printf '%s' "$consumer_json" | sed -n 's/.*"secret":"\([^"]*\)".*/\1/p')"
+	[ -n "$client_secret" ] || die "could not parse consumer secret from output: $consumer_json"
 else
-	log "This wiki's Extension:OAuth createOAuthConsumer.php is OAuth1-only (no CLI"
-	log "flag for OAuth2 public clients), so the consumer can't be registered from"
-	log "the command line here. Register it once in the browser instead:"
+	log "This wiki's Extension:OAuth createOAuthConsumer.php is OAuth1-only, so the"
+	log "consumer can't be registered from the command line here. Register it once"
+	log "in the browser instead:"
 	log "  1. On the wiki, open Special:OAuthConsumerRegistration/propose/oauth2"
 	log "  2. Callback URL (exact): ${CALLBACK_URL}"
-	log "  3. Leave 'This consumer is confidential' UNCHECKED (public + PKCE)."
-	log "  4. Grant types: tick Authorization code and Refresh token."
+	log "  3. TICK 'Client is confidential' — the proxy authenticates with a client"
+	log "     secret to refresh tokens, and a public consumer has no secret."
+	log "  4. Under 'Allowed OAuth2 grant types', keep Authorization code and"
+	log "     Refresh token ticked."
 	log "  5. Request the grants your tools need (default set: ${GRANTS})."
-	log "  6. Copy the client application key into OAUTH2_CLIENT_ID."
+	log "  6. Copy the client application key into OAUTH2_CLIENT_ID and the client"
+	log "     secret into MCP_OAUTH2_CLIENT_SECRET; the secret is shown only once."
 	log "See docs/deployment.md for the field-by-field walkthrough."
 fi
 
@@ -150,6 +162,7 @@ fi
 # so `MW_DEV_BOT_USER=First Last@mcp-dev` must be quoted.
 if [ -n "$client_id" ]; then
 	printf 'OAUTH2_CLIENT_ID=%q\n' "$client_id"
+	printf 'MCP_OAUTH2_CLIENT_SECRET=%q\n' "$client_secret"
 fi
 if [ "$WITH_BOT" -eq 1 ]; then
 	printf 'MW_DEV_BOT_USER=%q\n' "$bot_user"


### PR DESCRIPTION
`scripts/provision-dev-wiki.sh` has not produced a working proxy setup since the change that made a confidential consumer mandatory. It registers a public (PKCE) consumer with `--oauth2IsNotConfidential` and emits no client secret, so `resolveProxyConfig` throws `ProxyConfigError` and the proxy the script exists to set up refuses to start. `docs/testing.md` did not mention the secret at all.

## What changes

The consumer is registered without `--oauth2IsNotConfidential`, and the secret the maintenance script prints is captured and exported as `MCP_OAUTH2_CLIENT_SECRET`. An unparsed secret fails hard, rather than writing an env file the proxy rejects a step later.

The browser fallback, which is the path MediaWiki 1.43 takes, told the reader to leave the consumer public. It now says to make it confidential and where to copy the secret.

Both that fallback and `docs/deployment.md` quoted a checkbox labelled "This consumer is confidential". No such label exists — Extension:OAuth renders `mwoauth-oauth2-is-confidential`, which is **"Client is confidential"**. Corrected in both places.

`docs/testing.md` also gains `--mw-path`, needed whenever MediaWiki is not at `/var/www/html`.

## MediaWiki 1.43 support

Unchanged, and now verified rather than assumed. 1.43's bundled `createOAuthConsumer.php` is OAuth1-only, so the script takes the browser fallback there, and 1.43's registration form does offer a confidential OAuth2 consumer with the authorization-code and refresh-token grants.

The version probe is worth a reviewer's attention because the obvious simplification is wrong. It greps for `oauth2IsNotConfidential`, a flag the script no longer passes, purely as a marker of a CLI that understands OAuth2. Probing the flags it does pass would break: the OAuth1-only file contains `'oauthVersion' => 1` and `'oauth2GrantTypes' => [...]` as hardcoded array values, so a 1.43 wiki would be sent down the CLI path and fail on the unrecognised flags. A comment records this.

## Verification

Against a live MediaWiki 1.43.6 wiki running Extension:OAuth 1.1.0:

| | result |
|---|---|
| Version probe on 1.43.6 (container) and upstream `REL1_43` | browser fallback |
| Version probe on upstream `master` | CLI registration |
| Real run against the 1.43 wiki | exit 0, correct instructions |
| `--dry-run` argv | zero occurrences of `--oauth2IsNotConfidential` |

The CLI branch cannot run against a 1.43 wiki, so it was checked against upstream `master` source instead: every flag the script passes is a declared option; `'oauth2IsConfidential' => !hasOption('oauth2IsNotConfidential')` confirms omitting the flag yields a confidential consumer; the `--oauth2GrantTypes` guard is on the version-1 branch, so our `--oauthVersion 2` call is accepted; and the success output carries `key` and `secret`.

That `secret` is the right value for `MCP_OAUTH2_CLIENT_SECRET`: the OAuth2 token endpoint validates with `hash_equals( $secret, Utils::hmacDBSecret( $this->secretKey ) )`, and the script prints exactly `Utils::hmacDBSecret( $cmr->getSecretKey() )`.

Suite 1,686 green; typecheck, lint and format clean.

## Note

No CHANGELOG entry: this is a contributor script and its runbook, with no change to shipped behaviour. Happy to add one for the `deployment.md` label correction if you would rather it were recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
