### PR TITLE
Refuse to provision against a wiki that cannot issue OAuth2 tokens

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,9 +167,15 @@ Extension:OAuth works.
 ### 1. Prerequisites and the environment contract
 
 You need a reachable MediaWiki container with **Extension:OAuth installed and
-OAuth2 enabled** (OAuth2 signing keys configured on the wiki), a known admin
-account, and a local build of this repo (`npm run build`). Any environment that
-satisfies the contract below works.
+OAuth2 enabled**, a known admin account, and a local build of this repo
+(`npm run build`). Any environment that satisfies the contract below works.
+
+Installing Extension:OAuth is not enough to issue OAuth2 tokens. The wiki also
+needs `$wgOAuth2PrivateKey` and `$wgOAuth2PublicKey` set, the admin account needs
+an email address, and that account needs `mwoauthproposeconsumer` and
+`mwoauthmanageconsumer` — rights Extension:OAuth grants to no group by default.
+The provisioning script checks all three and prints the fix for whatever is
+missing, so run it first and let it tell you.
 
 | Variable | Meaning | Source |
 |---|---|---|

--- a/scripts/provision-dev-wiki.sh
+++ b/scripts/provision-dev-wiki.sh
@@ -107,6 +107,61 @@ docker exec "$CONTAINER" test -f "$RUN_PHP" \
 docker exec "$CONTAINER" test -f "$OAUTH_SCRIPT" \
 	|| die "Extension:OAuth not found at $MW_PATH/extensions/OAuth (install it and enable OAuth2)"
 
+# Extension:OAuth being installed does not make the wiki able to issue OAuth2
+# tokens. Registration needs rights that Extension:OAuth grants to nobody by
+# default, and the token endpoint needs a signing keypair. Missing either, a
+# consumer registered here — or in the browser — is useless, so check before
+# provisioning rather than handing back credentials that cannot work.
+readiness_php='$u=User::newFromName("'"$ADMIN_USER"'");'
+readiness_php+='$p=MediaWiki\MediaWikiServices::getInstance()->getPermissionManager();'
+readiness_php+='echo "KEYS=".(((string)($GLOBALS["wgOAuth2PrivateKey"]??"")!==""'
+readiness_php+='&&(string)($GLOBALS["wgOAuth2PublicKey"]??"")!=="")?"yes":"no")'
+readiness_php+='." EMAIL=".($u->getEmail()!==""?"yes":"no")'
+readiness_php+='." PROPOSE=".($p->userHasRight($u,"mwoauthproposeconsumer")?"yes":"no")'
+readiness_php+='." APPROVE=".($p->userHasRight($u,"mwoauthmanageconsumer")?"yes":"no")."\n";'
+readiness="$(printf '%s' "$readiness_php" \
+	| docker exec -i "$CONTAINER" php "$RUN_PHP" eval 2>/dev/null | tr -d '\r')"
+
+case "$readiness" in
+	*KEYS=*)
+		missing=''
+		case "$readiness" in *KEYS=no*) missing="${missing}keys " ;; esac
+		case "$readiness" in *EMAIL=no*) missing="${missing}email " ;; esac
+		case "$readiness" in *PROPOSE=no*) missing="${missing}propose " ;; esac
+		case "$readiness" in *APPROVE=no*) missing="${missing}approve " ;; esac
+		if [ -n "$missing" ]; then
+			log "This wiki cannot issue OAuth2 tokens yet. Fix the items below, then re-run."
+			log ""
+			case "$missing" in *keys*)
+				log "  OAuth2 signing keys are not configured. Generate a keypair:"
+				log "    openssl genrsa -out oauth2.key 2048"
+				log "    openssl rsa -in oauth2.key -pubout -out oauth2.pub"
+				log "  and set \$wgOAuth2PrivateKey / \$wgOAuth2PublicKey in LocalSettings.php"
+				log "  to the key text (or to paths the web server user can read)."
+				log "" ;;
+			esac
+			case "$missing" in *propose*|*approve*)
+				log "  ${ADMIN_USER} may not register consumers. Extension:OAuth grants these"
+				log "  to no group by default, so add to LocalSettings.php:"
+				log "    \$wgGroupPermissions['sysop']['mwoauthproposeconsumer'] = true;"
+				log "    \$wgGroupPermissions['sysop']['mwoauthmanageconsumer'] = true;"
+				log "" ;;
+			esac
+			case "$missing" in *email*)
+				log "  ${ADMIN_USER} has no email address, which consumer registration requires."
+				log "  Set one at Special:Preferences (or Special:ChangeEmail) on the wiki."
+				log "" ;;
+			esac
+			die "wiki not ready for OAuth2 (missing: ${missing% })"
+		fi
+		;;
+	*)
+		log "warning: could not determine whether this wiki can issue OAuth2 tokens."
+		log "Continuing; if sign-in later fails, check the OAuth2 signing keys and the"
+		log "mwoauthproposeconsumer right for ${ADMIN_USER}."
+		;;
+esac
+
 # --- register consumer (only if the stock CLI supports OAuth2) ---------------
 # The OAuth2 flags exist only in newer Extension:OAuth. The copy bundled with the
 # MediaWiki 1.43 LTS ships an OAuth1-only createOAuthConsumer.php, so the consumer


### PR DESCRIPTION
Installing Extension:OAuth does not make a wiki able to issue OAuth2 tokens. Three further things are needed, and the script checked none of them:

- `$wgOAuth2PrivateKey` / `$wgOAuth2PublicKey`, or the token endpoint cannot sign anything.
- An email address on the owning account, which consumer registration requires.
- `mwoauthproposeconsumer` and `mwoauthmanageconsumer` — **rights Extension:OAuth grants to no group by default**, so a stock wiki cannot register a consumer at all.

Missing any of them, the consumer the script registers is useless, and the browser fallback fails in the same way — the instructions it prints end at "You are not allowed to execute the action you have requested."

## What changes

The script probes the wiki for all three before provisioning. If something is missing it names it, prints the fix, and exits non-zero without emitting credentials. If the probe itself cannot run it warns and continues, so an unknown never blocks a working setup.

`docs/testing.md` gains the same prerequisites in its contract section, which previously mentioned only the signing keys.

## Why detect rather than configure

Setting these would mean editing `LocalSettings.php` inside the container, which is often a bind-mounted file in the user's own checkout. That is a much larger blast radius than the additive database rows this script writes today, it has to stay idempotent across re-runs, and writing RSA key material into a git checkout invites committing it. The script's stated contract is that the environment belongs to the caller, so it verifies the environment instead of mutating it.

## Verification

Exercised against a real MediaWiki 1.43.6 wiki running Extension:OAuth 1.1.0, in both directions:

| Case | Result |
|---|---|
| Wiki fully configured | preflight passes, provisioning proceeds |
| Signing keys absent | exit 1, `missing: keys`, no credentials on stdout |
| Account without email or consumer rights | exit 1, `missing: email propose approve`, no credentials on stdout |
| Container not running | unchanged error |
| `--dry-run` | unchanged, still makes no Docker contact |

The keys case was produced by overriding the configured keypair on the live wiki and restoring it afterwards, so the failure path is observed rather than argued.

The full hosted sign-in flow was then run end to end against that wiki once it satisfied the checks — discovery, dynamic registration, consent, MediaWiki grant approval, token exchange against a confidential consumer, and a tool call. A page created through the proxy is attributed on-wiki to the signed-in user, and the wiki receives the upstream MediaWiki token and never the proxy JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
