### PR TITLE
Stop sending log messages to MCP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - The server no longer advertises the wikis' own authorization servers, so a client can no longer discover where to mint a token to send here. Without hosted OAuth sign-in enabled, `/.well-known/oauth-protected-resource` now answers `404`, and `list-wikis` stops reporting each wiki's `authorizationServer`. Deployments running the hosted sign-in are unaffected.
 - The `Origin` header is now validated on every bind, and a request carrying an unlisted origin is refused with `403`. If you serve a browser-based client from a public bind, set `MCP_ALLOWED_ORIGINS` before upgrading. Clients that send no `Origin` header, which is most of them, are unaffected.
 
+### Removed
+
+- The server no longer sends log messages to connected MCP clients and no longer advertises the `logging` capability, following the feature's deprecation in the 2026-07-28 MCP revision. All logging goes to stderr, unchanged; `MCP_LOG_LEVEL` still controls it.
+
 ### Changed
 
 - The hosted OAuth sign-in's approval page is shorter and now names the address you will be returned to, including for a local application, where it previously said only "an application on this device". It no longer promises a permissions step the wiki does not always show.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,7 +21,7 @@ Fields you'll filter on:
 - **`caller`** — `sha256:` plus the first 12 hex chars of SHA-256 of the bearer token, or the literal string `anonymous`. Stable per token within a process; never the raw token.
 - **`target`** — a single identifier extracted from the tool's input (typically a page title, search query, or URL). Omitted for tools without one: `get-pages`, `compare-pages`, `parse-wikitext`, `get-recent-changes`.
 
-`tool_call` lines go to stderr only; they are never forwarded to the connected MCP client.
+All log output goes to stderr only; nothing is forwarded to the connected MCP client.
 
 ### Startup banner
 

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -1,32 +1,16 @@
-import type { McpServer, LoggingLevel } from '@modelcontextprotocol/server';
-
-// Eight RFC 5424 severity levels, in the order LoggingLevelSchema declares them.
-// Used both for the level field in the JSON stderr line and the
-// LoggingMessageNotification the SDK forwards to clients.
-export type LogLevel = LoggingLevel;
+// Eight RFC 5424 severity levels, in ascending-severity order, matching the
+// level field in each JSON stderr line.
+export type LogLevel =
+	| 'debug'
+	| 'info'
+	| 'notice'
+	| 'warning'
+	| 'error'
+	| 'critical'
+	| 'alert'
+	| 'emergency';
 
 export type LogContext = Record<string, unknown>;
-
-const LOGGER_NAME = 'mediawiki-mcp-server';
-
-const servers: Set<McpServer> = new Set();
-
-export function registerServer(server: McpServer): void {
-	servers.add(server);
-}
-
-export function unregisterServer(server: McpServer): void {
-	servers.delete(server);
-}
-
-// Test-only: callers must not rely on these in production code.
-export function clearRegisteredServers(): void {
-	servers.clear();
-}
-
-export function getRegisteredServerCount(): number {
-	return servers.size;
-}
 
 const RESERVED_KEYS = new Set<string>(['ts', 'level', 'message']);
 
@@ -79,43 +63,18 @@ function buildLogObject(
 	return obj;
 }
 
-// Best-effort handler. The SDK already filters by per-session setLevel and skips
-// when capabilities.logging is unset, and we have already written stderr for the
-// operator. Failing here would be unhelpful noise.
-const swallowNotificationError = (): undefined => undefined;
-
-// Emits a structured event to stderr only, bypassing the MCP
-// sendLoggingMessage broadcast. Used for operator-facing telemetry
-// (e.g. tool_call events) that must not leak to connected clients.
-export function emitTelemetryEvent(level: LogLevel, data: LogContext): void {
-	if (LEVEL_RANK[level] < currentThreshold()) {
-		return;
-	}
-	const line = buildLogObject(level, '', data);
-	process.stderr.write(JSON.stringify(line) + '\n');
-}
-
 function emit(level: LogLevel, message: string, data?: LogContext): void {
 	if (LEVEL_RANK[level] < currentThreshold()) {
 		return;
 	}
 	const line = buildLogObject(level, message, data);
 	process.stderr.write(JSON.stringify(line) + '\n');
+}
 
-	if (servers.size === 0) {
-		return;
-	}
-
-	const payload: LogContext = data === undefined ? { message } : { message, ...data };
-	for (const server of servers) {
-		server
-			.sendLoggingMessage({
-				level,
-				logger: LOGGER_NAME,
-				data: payload,
-			})
-			.catch(swallowNotificationError);
-	}
+// Emits a structured event line carrying an `event` field instead of a
+// `message` (e.g. tool_call events for operator-facing telemetry).
+export function emitTelemetryEvent(level: LogLevel, data: LogContext): void {
+	emit(level, '', data);
 }
 
 export const logger = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/server';
-import type { McpRequestContext, RegisteredTool } from '@modelcontextprotocol/server';
+import type { RegisteredTool } from '@modelcontextprotocol/server';
 import { createRequire } from 'node:module';
-import { registerServer, unregisterServer } from './runtime/logger.ts';
 import { registerAllTools } from './tools/index.ts';
 import { registerAllResources } from './resources/index.ts';
 import { reconcileTools } from './runtime/reconcile.ts';
@@ -41,7 +40,6 @@ export interface CreateServerOptions {
 
 export const createServer = async (
 	ctx: ToolContext,
-	reqCtx?: Pick<McpRequestContext, 'era'>,
 	options: CreateServerOptions = {},
 ): Promise<McpServer> => {
 	const server = new McpServer(
@@ -59,7 +57,6 @@ export const createServer = async (
 				tools: {
 					listChanged: true,
 				},
-				logging: {},
 			},
 			instructions: SERVER_INSTRUCTIONS,
 		},
@@ -102,24 +99,6 @@ export const createServer = async (
 	// publish would fan change events out to unrelated clients on every
 	// request.
 	await applyGates();
-
-	// Only legacy-era instances join the sendLoggingMessage broadcast: the
-	// 2026-07-28 revision has no unsolicited notifications/message channel
-	// (SEP-2577 deprecates the API), and a modern instance would churn the
-	// registry without ever delivering anything. A per-request legacy instance
-	// registers for its request's lifetime, so mid-call log lines still reach
-	// the caller on the response stream. Registration comes last on purpose:
-	// the only unregister path is onclose, which never fires for an instance
-	// that failed mid-construction and was never connected, so registering any
-	// earlier would leak a dead entry per construction throw.
-	if (reqCtx === undefined || reqCtx.era === 'legacy') {
-		registerServer(server);
-		const previousOnClose = server.server.onclose;
-		server.server.onclose = (): void => {
-			unregisterServer(server);
-			previousOnClose?.();
-		};
-	}
 
 	return server;
 };

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 	// modern-pinned connection the entry rewrites outbound change
 	// notifications onto its subscriptions/listen streams — so the default
 	// change publisher in createServer covers both eras here.
-	const handle = serveStdio((reqCtx) => createServer(ctx, reqCtx), {
+	const handle = serveStdio(() => createServer(ctx), {
 		onerror: (error) => logger.error(`stdio serving error: ${error.message}`),
 	});
 

--- a/src/transport/streamableHttp.ts
+++ b/src/transport/streamableHttp.ts
@@ -12,7 +12,6 @@ import {
 	InMemoryServerEventBus,
 	isJsonContentType,
 	PARSE_ERROR,
-	type McpRequestContext,
 	type McpServer,
 } from '@modelcontextprotocol/server';
 import {
@@ -387,10 +386,7 @@ export interface BuildAppDeps {
 	// Called once per serving unit — every HTTP request under createMcpHandler
 	// (modern or stateless legacy alike) gets a fresh instance. The options
 	// carry the change publisher buildApp wires to the handler's notify facade.
-	createServerFn: (
-		reqCtx: McpRequestContext,
-		opts?: CreateServerOptions,
-	) => McpServer | Promise<McpServer>;
+	createServerFn: (opts?: CreateServerOptions) => McpServer | Promise<McpServer>;
 	host: string;
 	allowedHosts?: string[];
 	// Required, and empty means refuse every cross-origin request. See
@@ -506,7 +502,7 @@ export function buildApp(deps: BuildAppDeps): BuiltApp {
 		toolsChanged: (): void => handler.notify.toolsChanged(),
 		resourcesChanged: (): void => handler.notify.resourcesChanged(),
 	};
-	const handler = createMcpHandler((reqCtx) => createServerFn(reqCtx, { publisher }), {
+	const handler = createMcpHandler(() => createServerFn({ publisher }), {
 		legacy: 'stateless',
 		bus,
 		onerror: (error) => logger.error(`MCP handler error: ${error.message}`),
@@ -740,7 +736,7 @@ export function startHttpServer(): void {
 		cimdResolver,
 		defaultWikiKey,
 		defaultWikiSitename,
-		createServerFn: (reqCtx, opts) => createServer(ctx, reqCtx, opts),
+		createServerFn: (opts) => createServer(ctx, opts),
 		host,
 		allowedHosts,
 		allowedOrigins,

--- a/tests/runtime/cancellation.test.ts
+++ b/tests/runtime/cancellation.test.ts
@@ -1,14 +1,9 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/client';
 import { InMemoryTransport } from '@modelcontextprotocol/server';
 import { createServer } from '../../src/server.ts';
-import { clearRegisteredServers } from '../../src/runtime/logger.ts';
 import { getRequestSignal } from '../../src/runtime/requestContext.ts';
 import { fakeContext } from '../helpers/fakeContext.ts';
-
-afterEach(() => {
-	clearRegisteredServers();
-});
 
 /**
  * These drive a real McpServer over a real transport rather than fabricating the

--- a/tests/runtime/dispatcher.test.ts
+++ b/tests/runtime/dispatcher.test.ts
@@ -6,7 +6,6 @@ import type { Tool } from '../../src/runtime/tool.ts';
 import { fakeContext } from '../helpers/fakeContext.ts';
 import { fakeLogger } from '../helpers/fakeLogger.ts';
 import { createMockMwnError } from '../helpers/mock-mwn-error.ts';
-import { clearRegisteredServers } from '../../src/runtime/logger.ts';
 import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.ts';
 import { withRequestFields } from '../../src/runtime/requestContext.ts';
 import { getPage } from '../../src/tools/get-page.ts';
@@ -135,7 +134,6 @@ describe('dispatcher emits tool_call telemetry', () => {
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
-		clearRegisteredServers();
 		vi.unstubAllEnvs();
 	});
 

--- a/tests/runtime/instrument.test.ts
+++ b/tests/runtime/instrument.test.ts
@@ -14,7 +14,6 @@ import {
 	parseEnvelope,
 	safeTarget,
 } from '../../src/runtime/instrument.ts';
-import { registerServer, clearRegisteredServers } from '../../src/runtime/logger.ts';
 import { recordToolCall } from '../../src/runtime/metrics.ts';
 
 function captureToolCallLine(spy: StderrWriteSpy): Record<string, unknown> {
@@ -162,7 +161,6 @@ describe('emitToolCall', () => {
 
 	afterEach(() => {
 		stderrSpy.mockRestore();
-		clearRegisteredServers();
 		vi.unstubAllEnvs();
 	});
 
@@ -371,29 +369,6 @@ describe('emitToolCall', () => {
 		});
 
 		expect(captureToolCallLine(stderrSpy).caller).toMatch(/^sha256:[0-9a-f]{12}$/);
-	});
-
-	it('does not broadcast tool_call events to connected MCP clients', () => {
-		const fakeServer = {
-			sendLoggingMessage: vi.fn().mockResolvedValue(undefined),
-			server: { onclose: undefined },
-		};
-		registerServer(fakeServer as unknown as Parameters<typeof registerServer>[0]);
-
-		emitToolCall({
-			toolName: 'get-page',
-			target: undefined,
-			args: {},
-			started: performance.now(),
-			result: okResult(),
-			outcome: 'success',
-			upstreamStatus: undefined,
-			errorMessage: undefined,
-			runtimeToken: undefined,
-			wikiKey: 'a.example',
-		});
-
-		expect(fakeServer.sendLoggingMessage).not.toHaveBeenCalled();
 	});
 });
 

--- a/tests/runtime/logger.test.ts
+++ b/tests/runtime/logger.test.ts
@@ -1,30 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
-import {
-	clearRegisteredServers,
-	emitTelemetryEvent,
-	getRegisteredServerCount,
-	logger,
-	registerServer,
-	unregisterServer,
-	type LogContext,
-	type LogLevel,
-} from '../../src/runtime/logger.ts';
-
-interface FakeServer {
-	sendLoggingMessage: Mock;
-}
-
-function fakeServer(): FakeServer {
-	return {
-		sendLoggingMessage: vi.fn().mockResolvedValue(undefined),
-	};
-}
-
-function asMcpServer(fake: FakeServer): McpServer {
-	return fake as unknown as McpServer;
-}
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitTelemetryEvent, logger, type LogLevel } from '../../src/runtime/logger.ts';
 
 describe('logger', () => {
 	let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -35,7 +10,6 @@ describe('logger', () => {
 	});
 
 	afterEach(() => {
-		clearRegisteredServers();
 		stderrSpy.mockRestore();
 		vi.unstubAllEnvs();
 	});
@@ -102,74 +76,6 @@ describe('logger', () => {
 		});
 	});
 
-	describe('server registration', () => {
-		it('broadcasts to a registered server', () => {
-			const fake = fakeServer();
-			registerServer(asMcpServer(fake));
-
-			logger.warning('session bearer mismatch', { sessionId: 'abc' });
-
-			expect(fake.sendLoggingMessage).toHaveBeenCalledTimes(1);
-			expect(fake.sendLoggingMessage).toHaveBeenCalledWith({
-				level: 'warning',
-				logger: 'mediawiki-mcp-server',
-				data: { message: 'session bearer mismatch', sessionId: 'abc' },
-			});
-		});
-
-		it('broadcasts to every registered server', () => {
-			const fakeA = fakeServer();
-			const fakeB = fakeServer();
-			registerServer(asMcpServer(fakeA));
-			registerServer(asMcpServer(fakeB));
-
-			logger.info('hello');
-
-			expect(fakeA.sendLoggingMessage).toHaveBeenCalledTimes(1);
-			expect(fakeB.sendLoggingMessage).toHaveBeenCalledTimes(1);
-		});
-
-		it('stops sending to a server after it is unregistered', () => {
-			const fake = fakeServer();
-			registerServer(asMcpServer(fake));
-			unregisterServer(asMcpServer(fake));
-
-			logger.info('after unregister');
-
-			expect(fake.sendLoggingMessage).not.toHaveBeenCalled();
-		});
-
-		it('is a no-op when no servers are registered (stderr only)', () => {
-			logger.info('startup line');
-			// No throw, stderr still written
-			expect(stderrSpy).toHaveBeenCalled();
-		});
-
-		it('omits the data payload key when no context is supplied', () => {
-			const fake = fakeServer();
-			registerServer(asMcpServer(fake));
-
-			logger.info('plain');
-
-			const params = fake.sendLoggingMessage.mock.calls[0][0] as {
-				data: LogContext;
-			};
-			expect(params.data).toEqual({ message: 'plain' });
-		});
-	});
-
-	describe('fault tolerance', () => {
-		it('swallows rejections from sendLoggingMessage so logging never throws', async () => {
-			const fake = fakeServer();
-			fake.sendLoggingMessage.mockRejectedValueOnce(new Error('transport closed'));
-			registerServer(asMcpServer(fake));
-
-			expect(() => logger.error('boom')).not.toThrow();
-			// Allow microtask to flush so the .catch handler runs.
-			await new Promise((resolve) => setImmediate(resolve));
-		});
-	});
-
 	describe('MCP_LOG_LEVEL threshold', () => {
 		it('drops below-threshold stderr writes', () => {
 			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
@@ -213,15 +119,6 @@ describe('logger', () => {
 			expect(() => logger.info('x')).toThrow(/MCP_LOG_LEVEL.*toString/s);
 		});
 
-		it('does not broadcast to registered servers when below threshold', () => {
-			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
-			const fake = fakeServer();
-			registerServer(asMcpServer(fake));
-			logger.info('filtered');
-			expect(fake.sendLoggingMessage).not.toHaveBeenCalled();
-			unregisterServer(asMcpServer(fake));
-		});
-
 		it('gates emitTelemetryEvent with the same threshold', () => {
 			vi.stubEnv('MCP_LOG_LEVEL', 'warning');
 			emitTelemetryEvent('info', { event: 'tool_call', tool: 'x' });
@@ -229,55 +126,5 @@ describe('logger', () => {
 			emitTelemetryEvent('error', { event: 'tool_call', tool: 'x' });
 			expect(stderrSpy).toHaveBeenCalledTimes(1);
 		});
-	});
-});
-
-// Mirrors the registration pattern from createServer() in src/server.ts so the
-// test exercises the same onclose-wrapping path used in production.
-function buildRegisteredServer(): McpServer {
-	const server = new McpServer(
-		{ name: 'logger-integration-test', version: '0.0.0' },
-		{ capabilities: { logging: {} } },
-	);
-	registerServer(server);
-	const previousOnClose = server.server.onclose;
-	server.server.onclose = (): void => {
-		unregisterServer(server);
-		previousOnClose?.();
-	};
-	return server;
-}
-
-describe('logger registry lifecycle (integration)', () => {
-	afterEach(() => {
-		clearRegisteredServers();
-	});
-
-	it('unregisters the server when its transport closes via the client', async () => {
-		const server = buildRegisteredServer();
-		const client = new Client({ name: 'logger-test-client', version: '0.0.0' });
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-
-		expect(getRegisteredServerCount()).toBe(1);
-
-		await client.close();
-
-		expect(getRegisteredServerCount()).toBe(0);
-	});
-
-	it('unregisters the server when the server itself closes the transport', async () => {
-		const server = buildRegisteredServer();
-		const client = new Client({ name: 'logger-test-client', version: '0.0.0' });
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-
-		expect(getRegisteredServerCount()).toBe(1);
-
-		await server.close();
-
-		expect(getRegisteredServerCount()).toBe(0);
 	});
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -19,6 +19,9 @@ describe('createServer capabilities', () => {
 		const client = new Client({ name: 'server-test', version: '0.0.0' });
 		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
 		try {
+			// The positive assertion anchors the negative one: without it, a
+			// capabilities object that never arrived would also pass.
+			expect(client.getServerCapabilities()?.tools).toBeDefined();
 			expect(client.getServerCapabilities()?.logging).toBeUndefined();
 		} finally {
 			await client.close();

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,30 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/client';
 import { InMemoryTransport } from '@modelcontextprotocol/server';
 import { createServer } from '../src/server.ts';
-import { clearRegisteredServers, getRegisteredServerCount } from '../src/runtime/logger.ts';
 import { fakeContext } from './helpers/fakeContext.ts';
-
-afterEach(() => {
-	clearRegisteredServers();
-});
-
-describe('createServer era gating', () => {
-	it('registers with the logger broadcast when built without a request context', async () => {
-		await createServer(fakeContext());
-		expect(getRegisteredServerCount()).toBe(1);
-	});
-
-	it('registers a legacy-era instance with the logger broadcast', async () => {
-		await createServer(fakeContext(), { era: 'legacy' });
-		expect(getRegisteredServerCount()).toBe(1);
-	});
-
-	it('does not register a modern-era instance', async () => {
-		await createServer(fakeContext(), { era: 'modern' });
-		expect(getRegisteredServerCount()).toBe(0);
-	});
-});
 
 const wikiConfig = {
 	sitename: 'Test',
@@ -34,10 +12,39 @@ const wikiConfig = {
 	tags: null,
 };
 
+describe('createServer capabilities', () => {
+	it('does not advertise the logging capability', async () => {
+		const server = await createServer(fakeContext());
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		const client = new Client({ name: 'server-test', version: '0.0.0' });
+		await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+		try {
+			expect(client.getServerCapabilities()?.logging).toBeUndefined();
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('rejects construction when the initial gating pass fails', async () => {
+		const ctx = fakeContext({
+			wikiProbe: {
+				hasExtension: (async () => false) as never,
+				// Fails the construction-time gating pass, after tool registration.
+				hasAnyExtension: (async () => {
+					throw new Error('probe exploded');
+				}) as never,
+				inspect: (() => {}) as never,
+				invalidate: (() => {}) as never,
+			},
+		});
+		await expect(createServer(ctx)).rejects.toThrow('probe exploded');
+	});
+});
+
 describe('createServer change publishing', () => {
 	it('does not publish during construction', async () => {
 		const publisher = { toolsChanged: vi.fn(), resourcesChanged: vi.fn() };
-		await createServer(fakeContext(), undefined, { publisher });
+		await createServer(fakeContext(), { publisher });
 		expect(publisher.toolsChanged).not.toHaveBeenCalled();
 		expect(publisher.resourcesChanged).not.toHaveBeenCalled();
 	});
@@ -61,7 +68,7 @@ describe('createServer change publishing', () => {
 			wikiCache: { invalidate: vi.fn() as never },
 		});
 		const publisher = { toolsChanged: vi.fn(), resourcesChanged: vi.fn() };
-		const server = await createServer(ctx, { era: 'legacy' }, { publisher });
+		const server = await createServer(ctx, { publisher });
 
 		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 		const client = new Client({ name: 'server-test', version: '0.0.0' });
@@ -80,24 +87,5 @@ describe('createServer change publishing', () => {
 		} finally {
 			await client.close();
 		}
-	});
-
-	it('does not leave a failed construction registered with the logger broadcast', async () => {
-		const ctx = fakeContext({
-			wikiProbe: {
-				hasExtension: (async () => false) as never,
-				// Fails the construction-time gating pass, after tool registration.
-				hasAnyExtension: (async () => {
-					throw new Error('probe exploded');
-				}) as never,
-				inspect: (() => {}) as never,
-				invalidate: (() => {}) as never,
-			},
-		});
-		await expect(createServer(ctx, { era: 'legacy' })).rejects.toThrow('probe exploded');
-		// The throw happened before registration, so nothing leaked: the only
-		// unregister path is onclose, which never fires for an instance that was
-		// never connected.
-		expect(getRegisteredServerCount()).toBe(0);
 	});
 });

--- a/tests/transport/modernEra.test.ts
+++ b/tests/transport/modernEra.test.ts
@@ -3,7 +3,6 @@ import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/cli
 import { createMcpHandler, InMemoryServerEventBus } from '@modelcontextprotocol/server';
 import type { McpHttpHandler } from '@modelcontextprotocol/server';
 import { createServer, type ChangePublisher } from '../../src/server.ts';
-import { clearRegisteredServers } from '../../src/runtime/logger.ts';
 import { fakeContext } from '../helpers/fakeContext.ts';
 
 // Drives the era-routing handler in memory, exactly as buildApp wires it: the
@@ -18,7 +17,7 @@ function buildHandler(ctx = fakeContext()): {
 		toolsChanged: () => handler.notify.toolsChanged(),
 		resourcesChanged: () => handler.notify.resourcesChanged(),
 	};
-	const handler = createMcpHandler((reqCtx) => createServer(ctx, reqCtx, { publisher }), {
+	const handler = createMcpHandler(() => createServer(ctx, { publisher }), {
 		legacy: 'stateless',
 		bus,
 	});
@@ -46,7 +45,6 @@ describe('2026-07-28 era over Streamable HTTP (in-memory)', () => {
 		for (const cleanup of cleanups.splice(0)) {
 			await cleanup();
 		}
-		clearRegisteredServers();
 	});
 
 	it('negotiates the modern era when pinned to 2026-07-28 and round-trips a tool call', async () => {


### PR DESCRIPTION
Removes the MCP logging feature: the server no longer sends `notifications/message` to connected clients and no longer advertises the `logging` capability. The 2026-07-28 revision deprecates the feature (SEP-2577), naming stderr logging as the migration target — which this server already has. Stderr logging and `MCP_LOG_LEVEL` are unchanged.

This deletes the broadcast registry in `src/runtime/logger.ts`, the per-era registration with its `onclose` chaining in `src/server.ts`, and the now-unused `reqCtx` parameter of `createServer`.

**To decide:** clients on pre-2026 revisions stop receiving log notifications during the deprecation window rather than at its end. They keep working otherwise; with the capability no longer advertised, a legacy `logging/setLevel` now answers method-not-found, which is the spec-correct consequence.

Verified: full suite (1,720 tests), plus a test asserting the `logging` capability is no longer advertised, written first and confirmed failing against the previous code. Smoke-tested the built dist on both transports: a real stdio client sees no `logging` capability and stderr keeps its JSON lines, and a raw legacy `initialize` over HTTP answers capabilities without `logging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)