### PR TITLE
Ground the OAuth metadata doc types in the SDK's

### DIFF
--- a/src/auth/authorizationServer/asMetadata.ts
+++ b/src/auth/authorizationServer/asMetadata.ts
@@ -2,8 +2,9 @@ import type { OAuthMetadata } from '@modelcontextprotocol/server';
 import type { ProxyConfig } from './proxyConfig.ts';
 
 // The SDK's RFC 8414 document type, narrowed to the fields this proxy always
-// emits: RFC 8414 makes them optional, but clients rely on the PKCE, DCR, iss
-// and CIMD advertisements to pick a compatible flow.
+// emits: the spec and its registry extensions make them optional, but clients
+// pick a compatible flow from these advertisements (grant types, auth
+// methods, PKCE, DCR, iss, CIMD).
 export type AsMetadataDoc = OAuthMetadata &
 	Required<
 		Pick<

--- a/src/auth/authorizationServer/asMetadata.ts
+++ b/src/auth/authorizationServer/asMetadata.ts
@@ -1,18 +1,21 @@
+import type { OAuthMetadata } from '@modelcontextprotocol/server';
 import type { ProxyConfig } from './proxyConfig.ts';
 
-export interface AsMetadataDoc {
-	issuer: string;
-	authorization_endpoint: string;
-	token_endpoint: string;
-	registration_endpoint: string;
-	response_types_supported: string[];
-	grant_types_supported: string[];
-	code_challenge_methods_supported: string[];
-	token_endpoint_auth_methods_supported: string[];
-	authorization_response_iss_parameter_supported: boolean;
-	client_id_metadata_document_supported: boolean;
-	scopes_supported?: string[];
-}
+// The SDK's RFC 8414 document type, narrowed to the fields this proxy always
+// emits: RFC 8414 makes them optional, but clients rely on the PKCE, DCR, iss
+// and CIMD advertisements to pick a compatible flow.
+export type AsMetadataDoc = OAuthMetadata &
+	Required<
+		Pick<
+			OAuthMetadata,
+			| 'registration_endpoint'
+			| 'grant_types_supported'
+			| 'code_challenge_methods_supported'
+			| 'token_endpoint_auth_methods_supported'
+			| 'authorization_response_iss_parameter_supported'
+			| 'client_id_metadata_document_supported'
+		>
+	>;
 
 /**
  * Builds the RFC 8414 authorization-server metadata document advertising this

--- a/src/auth/oauthFlow.ts
+++ b/src/auth/oauthFlow.ts
@@ -2,6 +2,10 @@
 
 const TIMEOUT_MS = 5000;
 
+// Deliberately not the SDK's OAuthTokens, which requires token_type and makes
+// expires_in optional — the inverse of what post() enforces. expires_in must
+// be present because token stores schedule refresh from it; token_type may be
+// absent in MediaWiki responses.
 export interface TokenResponse {
 	access_token: string;
 	refresh_token?: string;

--- a/src/auth/protectedResource.ts
+++ b/src/auth/protectedResource.ts
@@ -1,4 +1,5 @@
 // src/auth/protectedResource.ts
+import type { OAuthProtectedResourceMetadata } from '@modelcontextprotocol/server';
 import type { UpstreamAsMetadata } from './metadata.ts';
 
 const RESOURCE_DOCUMENTATION =
@@ -21,13 +22,13 @@ export interface ProtectedResourceInput {
 	authorizationServers: readonly string[];
 }
 
-export interface ProtectedResourceDoc {
-	resource: string;
-	authorization_servers: string[];
-	bearer_methods_supported: string[];
-	scopes_supported?: string[];
-	resource_documentation?: string;
-}
+// The SDK's RFC 9728 document type, narrowed to the fields this server always
+// emits: RFC 9728 makes them optional, but a doc without an authorization
+// server would leave a client nowhere to sign in.
+export type ProtectedResourceDoc = OAuthProtectedResourceMetadata &
+	Required<
+		Pick<OAuthProtectedResourceMetadata, 'authorization_servers' | 'bearer_methods_supported'>
+	>;
 
 function anyWikiHasOAuth(wikis: Record<string, { oauth2ClientId?: string | null }>): boolean {
 	return Object.values(wikis).some(


### PR DESCRIPTION
Replaces the hand-declared `ProtectedResourceDoc` (RFC 9728) and `AsMetadataDoc` (RFC 8414) interfaces with aliases of the SDK's `OAuthProtectedResourceMetadata` and `OAuthMetadata` types, narrowed with `Required<Pick<…>>` to the fields this server always emits. Field names and shapes can no longer drift from the spec schemas, and a renamed SDK field becomes a compile error here. Types only — the emitted documents are unchanged, and no new dependency is added (both types are exported by `@modelcontextprotocol/server`).

One trade-off to weigh: the SDK schemas are loose objects, so the aliases carry a `[k: string]: unknown` index signature and a typo'd key in a builder literal is no longer an excess-property compile error. The per-field unit tests on both builders still catch a typo in any currently-emitted field at runtime.

`TokenResponse` deliberately stays local: our parser enforces `expires_in` and tolerates a missing `token_type`, which is the inverse of the SDK's `OAuthTokens` contract on both fields, so adopting it would misstate what the code validates.

Verified: full suite and typecheck green; a fixed-input smoke script confirmed the emitted documents are byte-identical between this branch's build and a master-equivalent build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)