### PR TITLE
Add MCP protocol conformance and tool-surface checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
   mcp-checks:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,52 @@ jobs:
 
     - name: Ensure no changes
       run: git diff --exit-code
+
+  mcp-checks:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        cache: 'npm'
+
+    - run: npm ci
+
+    - run: npm run build
+
+    - name: Doctor and protocol conformance
+      run: npm run check:mcp
+
+    - name: Check out PR base
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+
+    - name: Build PR base
+      if: github.event_name == 'pull_request'
+      working-directory: base
+      run: npm ci && npm run build
+
+    - name: Export base tool surface
+      if: github.event_name == 'pull_request'
+      run: >
+        node_modules/.bin/mcpjam server export --stable
+        --transport stdio --command node
+        --args "$GITHUB_WORKSPACE/base/dist/index.js"
+        --cwd "$GITHUB_WORKSPACE/base"
+        --env "CONFIG=$GITHUB_WORKSPACE/scripts/mcp-checks.config.json"
+        --no-telemetry --quiet > base-surface.json
+
+    - name: Diff tool surface against base
+      if: github.event_name == 'pull_request'
+      run: >
+        node_modules/.bin/mcpjam server diff --baseline base-surface.json
+        --transport stdio --command node
+        --args "$GITHUB_WORKSPACE/dist/index.js"
+        --cwd "$GITHUB_WORKSPACE"
+        --env "CONFIG=$GITHUB_WORKSPACE/scripts/mcp-checks.config.json"
+        --fail-on breaking --no-telemetry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ A path handed to a runtime `createRequire( import.meta.url )` resolves against t
 - `npm test` — run the vitest suite once.
 - `npm run lint` — oxlint.
 - `npm run typecheck` — `tsc --noEmit` over `src` **and** `tests`, via `tsconfig.lint.json`. `npm run build` only typechecks `src`, so this is the check that covers test code.
+- `npm run check:mcp` — MCPJam doctor + MCP protocol conformance against the built server (build first). CI runs it on every PR and also diffs the tool surface against the PR base, failing on breaking changes.
 - `npm run fmt` / `npm run fmt:check` — oxfmt (write / dry-run).
 - `npm run preflight` — full gate (install, lint, typecheck, fmt check, validate `server.json`, test, build, bundle). Run before a release.
 - Git hooks: `lefthook` auto-installs on `npm install`. Pre-commit runs `oxfmt` (auto-fix on staged files) + `oxlint`. Pre-push runs `npm run typecheck` + the test suite. Bypass with `--no-verify`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,7 +78,7 @@ Token-free structural checks against the built server: a stdio doctor sweep plus
 npm run check:mcp
 ```
 
-Both use the minimal wiki configuration in `scripts/mcp-checks.config.json`, so results do not depend on your local `config.json`. CI runs the same script on every pull request, and additionally diffs the tool surface against the PR base — a removed or renamed tool fails the job, while description changes only show up in the report.
+Both use the minimal wiki configuration in `scripts/mcp-checks.config.json`, so results do not depend on your local `config.json`. The conformance run binds `127.0.0.1:3117`; set `PORT` to use a different port. CI runs the same script on every pull request, and additionally diffs the tool surface against the PR base — a removed or renamed tool fails the job, while description changes only show up in the report.
 
 ## MCP Inspector CLI (integration tests)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,6 +70,16 @@ Like the MCP Inspector, but with a built-in MCP client that can drive the server
 npm run mcpjam
 ```
 
+## MCPJam CLI checks
+
+Token-free structural checks against the built server: a stdio doctor sweep plus an MCP protocol conformance run against the HTTP transport. Build first with `npm run build`, then:
+
+```sh
+npm run check:mcp
+```
+
+Both use the minimal wiki configuration in `scripts/mcp-checks.config.json`, so results do not depend on your local `config.json`. CI runs the same script on every pull request, and additionally diffs the tool surface against the PR base — a removed or renamed tool fails the job, while description changes only show up in the report.
+
 ## MCP Inspector CLI (integration tests)
 
 The [MCP Inspector CLI](https://github.com/modelcontextprotocol/inspector) exercises tools against a real wiki. Build first with `npm run build`, then:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 			},
 			"devDependencies": {
 				"@anthropic-ai/mcpb": "^2.1.2",
+				"@mcpjam/cli": "^3.16.0",
 				"@modelcontextprotocol/client": "^2.0.0",
 				"@types/express": "^5.0.2",
 				"@types/node": "^26.0.1",
@@ -44,6 +45,248 @@
 			},
 			"engines": {
 				"node": ">=22.12.0"
+			}
+		},
+		"node_modules/@ai-sdk/amazon-bedrock": {
+			"version": "3.0.112",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-3.0.112.tgz",
+			"integrity": "sha512-nvBRPced+MMz4zMScNh/fDo6bPAMr0zJKJvxIdRST4E4ATc+cUPcmOW++IhgkkaW1WfCMNPqEX843BWQXWReXQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/anthropic": "2.0.92",
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31",
+				"@smithy/eventstream-codec": "^4.0.1",
+				"@smithy/util-utf8": "^4.0.0",
+				"aws4fetch": "^1.0.20"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/anthropic": {
+			"version": "2.0.92",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.92.tgz",
+			"integrity": "sha512-MlIQpuOnchlroR93Dq2GNw12jh/SAVjuFARXWRF/2SfowMv3J2fvPBUzA60waoQivZlf3XkzQ2nxSwer7dnh2g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/azure": {
+			"version": "2.0.122",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-2.0.122.tgz",
+			"integrity": "sha512-fLpsBWOAgl6nzJgty6mmkAZ43ROYxi1flwBRbHKb0snFx1Kk62jepEy5/R+F5w+XOFFg3gt3Cl1Zom2qLz/RoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/deepseek": "1.0.49",
+				"@ai-sdk/openai": "2.0.117",
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/deepseek": {
+			"version": "1.0.49",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-1.0.49.tgz",
+			"integrity": "sha512-Q+yHWvapEyiQlFRbopeyg4Eo0BQU8FAiWG0pXKOTTUI93zao2qiNpS6cJX87kUc9bUNaVqZqeSCGRGAWeuX0fw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "3.0.161",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.161.tgz",
+			"integrity": "sha512-aV5j1JFKzwfq4RCuWRDerzOsNkIZ7+Pbz4aaGESW7BLbuQMGlsOJTv24+Uyksi1cg5WTEKNik6ghLfFRsU7TKw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.14",
+				"@ai-sdk/provider-utils": "4.0.41",
+				"@vercel/oidc": "3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+			"integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.41",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+			"integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.14",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.8",
+				"undici": "^5.29.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/google": {
+			"version": "2.0.86",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.86.tgz",
+			"integrity": "sha512-MudH/IVlfPu6Z8KJBUEhGgfzRJ1WYfaFikshlYxbrwbKYQXXCnx17cts2rIO5RZwJ9Uq2trM8q9WYZyZCOZ6MA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/mistral": {
+			"version": "2.0.41",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/mistral/-/mistral-2.0.41.tgz",
+			"integrity": "sha512-BIOG4XDM9+BmHpDL6u2ZoryBorA8l+YSEHcSlemFSyIEDp8qefD6ElmeVkTrDoR3vP+j5VG6qVLQxDqzwshOmg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/openai": {
+			"version": "2.0.117",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.117.tgz",
+			"integrity": "sha512-fqr2OwpegPlS58NUAat4+6cAOR/x1askt5dXKY1rCjDyhHJYxm2OZM9fZnG9I717ny4uRSp2mhsMio2uthA0Pg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/openai-compatible": {
+			"version": "1.0.47",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.47.tgz",
+			"integrity": "sha512-6Esz5WZmm1YckHEHUtDurGEjoTbEI1CkcfUkL2Fu1rngWhrnW98hhaj3bnjuqwkG4U1SNwVEIfucMS3ZGADEiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+			"integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "3.0.31",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.31.tgz",
+			"integrity": "sha512-hlxLxqbdV+f7gBpL2SbLL+UhjV+DfUpJ28J4vSHekVV9fiTRrhqcd/ewJwaVbR/ahtLCGJPAVYzj+yJzaddc6g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.3",
+				"@standard-schema/spec": "^1.0.0",
+				"eventsource-parser": "^3.0.6",
+				"undici": "^5.29.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/xai": {
+			"version": "2.0.84",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-2.0.84.tgz",
+			"integrity": "sha512-lT/gAHQfgcSBQVZe4rr4jyL6jgnXY0GUR6kyIIkINuw3OjXRIyxV+dRC9cNFRSv98ljHp8yjOfeAj9slt//aTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/openai-compatible": "1.0.47",
+				"@ai-sdk/provider": "2.0.3",
+				"@ai-sdk/provider-utils": "3.0.31"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@anthropic-ai/mcpb": {
@@ -77,6 +320,13 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/@cfworker/json-schema": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@emnapi/core": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -109,6 +359,16 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@hono/node-server": {
@@ -368,6 +628,76 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@mcpjam/cli": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@mcpjam/cli/-/cli-3.16.0.tgz",
+			"integrity": "sha512-PSRVbIyE4mxk6ul6bwrxrNWmBOIptSvJrw+vUI92/yXCwZ0tGYXsjXsx5aonedhXvtYtgeyOiO71p1CNG3kFaA==",
+			"dev": true,
+			"dependencies": {
+				"@mcpjam/sdk": "^2.1.0",
+				"@modelcontextprotocol/server": "2.0.0",
+				"commander": "^12.1.0",
+				"posthog-node": "^5.24.10",
+				"ws": "^8.18.0",
+				"zod": "^4.2.0"
+			},
+			"bin": {
+				"mcpjam": "dist/index.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mcpjam/cli/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@mcpjam/sdk": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@mcpjam/sdk/-/sdk-2.1.0.tgz",
+			"integrity": "sha512-msNZ5grq1crhQzLfDtSWccWsbo3/1iHepjYH6d8Svc2yESuDOENLMycIJ0+W4fxAIvsARj3QDtfX75tO7xMlZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ai-sdk/amazon-bedrock": "^3.0.101",
+				"@ai-sdk/anthropic": "^2.0.17",
+				"@ai-sdk/azure": "^2.0.79",
+				"@ai-sdk/deepseek": "^1.0.5",
+				"@ai-sdk/google": "^2.0.11",
+				"@ai-sdk/mistral": "^2.0.19",
+				"@ai-sdk/openai": "^2.0.32",
+				"@ai-sdk/xai": "^2.0.29",
+				"@cfworker/json-schema": "^4.1.1",
+				"@modelcontextprotocol/client": "2.0.0",
+				"@modelcontextprotocol/ext-apps": "^1.7.4",
+				"@openrouter/ai-sdk-provider": "^2.2.0",
+				"@xmldom/xmldom": "^0.8.13",
+				"ai": "^6.0.141",
+				"ajv": "^8.17.1",
+				"ollama-ai-provider-v2": "^1.5.2",
+				"posthog-node": "^5.24.10",
+				"xml-crypto": "^6.1.2",
+				"xpath": "^0.0.34",
+				"zod": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@sentry/node": "^8.55.0"
+			},
+			"peerDependenciesMeta": {
+				"@sentry/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@modelcontextprotocol/client": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
@@ -415,6 +745,36 @@
 				"express": "^4.18.0 || ^5.0.0"
 			}
 		},
+		"node_modules/@modelcontextprotocol/ext-apps": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.5.tgz",
+			"integrity": "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"examples/*"
+			],
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@modelcontextprotocol/node": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
@@ -433,6 +793,48 @@
 			"peerDependenciesMeta": {
 				"hono": {
 					"optional": true
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
 				}
 			}
 		},
@@ -479,6 +881,20 @@
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@openrouter/ai-sdk-provider": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.10.0.tgz",
+			"integrity": "sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"ai": "^6.0.0",
+				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/api": {
@@ -1288,6 +1704,23 @@
 				"@noble/hashes": "^1.1.5"
 			}
 		},
+		"node_modules/@posthog/core": {
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.1.tgz",
+			"integrity": "sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/types": "^1.399.0"
+			}
+		},
+		"node_modules/@posthog/types": {
+			"version": "1.399.0",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.399.0.tgz",
+			"integrity": "sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -1569,6 +2002,61 @@
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.31.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.4.16.tgz",
+			"integrity": "sha512-u6l4XW99ESjEikMOGENsZxJblxWNvkTLRbCWcC1c2VwNdmd4QgviN2RRlZxliVWEzG3kyU/m0y3iuVFtLL/6jA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.16.tgz",
+			"integrity": "sha512-/gSbVMQlLRcneJ8D/JGbB1DNf0w4I7OpY2ldNUJ+myDmakPXEm9fy/X4swDlNYTOwBwsCKVJsogCfe7Txjnolg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -2112,6 +2600,16 @@
 				"node": ">=16.20.0"
 			}
 		},
+		"node_modules/@vercel/oidc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+			"integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.1.10",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -2225,6 +2723,26 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@xmldom/is-dom-node": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+			"integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.13",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/accepts": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2248,6 +2766,57 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/ai": {
+			"version": "6.0.239",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.239.tgz",
+			"integrity": "sha512-qTFRqxLxKVR0J8X1MAs0xR5nXNZbeQz5Nnhm6jeASQuADcYaZppcVE6/Fl0gKSARsT/6I5XOWWx+fhCdZl6BOw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "3.0.161",
+				"@ai-sdk/provider": "3.0.14",
+				"@ai-sdk/provider-utils": "4.0.41",
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/ai/node_modules/@ai-sdk/provider": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+			"integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.41",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+			"integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.14",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.8",
+				"undici": "^5.29.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/ajv": {
@@ -2347,6 +2916,13 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
+		},
+		"node_modules/aws4fetch": {
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+			"integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/axios": {
@@ -3077,6 +3653,27 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/express-rate-limit": {
+			"version": "8.6.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+			"integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
 		"node_modules/external-editor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -3580,6 +4177,17 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/ip-address": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/ipaddr.js": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -3681,12 +4289,27 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"dev": true,
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true
 		},
 		"node_modules/jsonfile": {
 			"version": "6.2.1",
@@ -4380,6 +5003,23 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/ollama-ai-provider-v2": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-1.5.5.tgz",
+			"integrity": "sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "^2.0.0",
+				"@ai-sdk/provider-utils": "^3.0.17"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.16"
+			}
+		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4643,6 +5283,27 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/posthog-node": {
+			"version": "5.47.3",
+			"resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.47.3.tgz",
+			"integrity": "sha512-mhKaZOGLgD5aKKTj6xNRE2K9vRJnRIj4FNZeguDNnCR0k8RKJh71KO78+UqVdOONBsMzoqb01AD/B+TtsK7YSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/core": "^1.46.1"
+			},
+			"engines": {
+				"node": "^20.20.0 || >=22.22.0"
+			},
+			"peerDependencies": {
+				"rxjs": "^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rxjs": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/powershell-utils": {
@@ -5357,6 +6018,19 @@
 				"@typescript/typescript-win32-x64": "7.0.2"
 			}
 		},
+		"node_modules/undici": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -5633,6 +6307,28 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC"
 		},
+		"node_modules/ws": {
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/wsl-utils": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -5647,6 +6343,41 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xml-crypto": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+			"integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/is-dom-node": "^1.0.1",
+				"@xmldom/xmldom": "^0.8.10",
+				"xpath": "^0.0.33"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/xml-crypto/node_modules/xpath": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+			"integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/xpath": {
+			"version": "0.0.34",
+			"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+			"integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"lint": "oxlint --tsconfig=./tsconfig.lint.json",
 		"typecheck": "tsc -p tsconfig.lint.json --noEmit",
 		"validate:server-json": "node scripts/validate-server-json.cjs",
+		"check:mcp": "node scripts/mcp-checks.cjs",
 		"preflight": "npm ci && npm run lint && npm run typecheck && npm run fmt:check && npm run validate:server-json && npm run test && npm run build && npm run bundle -- --clean",
 		"prepare": "lefthook install",
 		"inspector": "concurrently --kill-others \"tsc --watch\" \"npx -y @modelcontextprotocol/inspector@latest node dist/index.js\"",
@@ -77,6 +78,7 @@
 	},
 	"devDependencies": {
 		"@anthropic-ai/mcpb": "^2.1.2",
+		"@mcpjam/cli": "^3.16.0",
 		"@modelcontextprotocol/client": "^2.0.0",
 		"@types/express": "^5.0.2",
 		"@types/node": "^26.0.1",

--- a/scripts/mcp-checks.cjs
+++ b/scripts/mcp-checks.cjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+'use strict';
+
+// Runs the token-free MCPJam checks against the built server:
+// a stdio doctor sweep and an MCP protocol conformance run against
+// the HTTP transport. CI runs this via `npm run check:mcp`; the
+// tool-surface diff against the PR base lives in ci.yml because it
+// needs a second checkout to diff against.
+
+const { spawn, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DIST_ENTRY = path.join(REPO_ROOT, 'dist', 'index.js');
+const CONFIG_PATH = path.join(__dirname, 'mcp-checks.config.json');
+const MCPJAM_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', 'mcpjam');
+const PROTOCOL_VERSION = '2026-07-28';
+const PORT = Number(process.env.PORT) || 3117;
+const SERVER_URL = `http://127.0.0.1:${PORT}/mcp`;
+const STARTUP_TIMEOUT_MS = 15000;
+
+function runDoctor() {
+	console.log('\nRunning MCPJam server doctor (stdio)...');
+	const result = spawnSync(
+		MCPJAM_BIN,
+		[
+			'server',
+			'doctor',
+			'--transport',
+			'stdio',
+			'--command',
+			process.execPath,
+			'--args',
+			DIST_ENTRY,
+			'--cwd',
+			REPO_ROOT,
+			'--env',
+			`CONFIG=${CONFIG_PATH}`,
+			'--no-telemetry',
+			'--quiet',
+		],
+		{ encoding: 'utf8' },
+	);
+
+	if (result.error) {
+		console.error(`Doctor failed to start: ${result.error.message}`);
+		return false;
+	}
+
+	let report;
+	try {
+		report = JSON.parse(result.stdout);
+	} catch {
+		console.error('Doctor did not produce parseable JSON:');
+		console.error(result.stdout);
+		console.error(result.stderr);
+		return false;
+	}
+
+	const failed = Object.entries(report.checks ?? {}).filter(
+		([, check]) => check.status !== 'ok' && check.status !== 'skipped',
+	);
+	for (const [id, check] of failed) {
+		console.error(`✗ ${id}: ${check.status} — ${check.detail ?? ''}`);
+	}
+	if (report.status !== 'ready' || failed.length > 0) {
+		console.error(`Doctor status: ${report.status}`);
+		if (report.error) {
+			console.error(report.error);
+		}
+		return false;
+	}
+
+	const tools = report.tools?.length ?? 0;
+	const resources = report.resources?.length ?? 0;
+	console.log(`✓ Doctor ready: ${tools} tools, ${resources} resources`);
+	return true;
+}
+
+async function waitForServer(child) {
+	const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null) {
+			return false;
+		}
+		try {
+			// Any HTTP response, including an error status, means the
+			// transport is accepting connections.
+			await fetch(SERVER_URL, { method: 'GET' });
+			return true;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 250));
+		}
+	}
+	return false;
+}
+
+async function runConformance() {
+	console.log(`\nStarting HTTP transport on port ${PORT}...`);
+	const serverLog = [];
+	const child = spawn(process.execPath, [DIST_ENTRY], {
+		cwd: REPO_ROOT,
+		env: {
+			...process.env,
+			MCP_TRANSPORT: 'http',
+			CONFIG: CONFIG_PATH,
+			PORT: String(PORT),
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	child.stdout.on('data', (chunk) => serverLog.push(chunk));
+	child.stderr.on('data', (chunk) => serverLog.push(chunk));
+
+	try {
+		if (!(await waitForServer(child))) {
+			console.error('HTTP transport did not become reachable:');
+			console.error(serverLog.join(''));
+			return false;
+		}
+
+		console.log(`Running MCP protocol conformance (${PROTOCOL_VERSION})...`);
+		const result = spawnSync(
+			MCPJAM_BIN,
+			[
+				'protocol',
+				'conformance',
+				'--url',
+				SERVER_URL,
+				'--protocol-version',
+				PROTOCOL_VERSION,
+				'--no-telemetry',
+			],
+			{ stdio: 'inherit' },
+		);
+
+		if (result.status !== 0) {
+			console.error('Server log:');
+			console.error(serverLog.join(''));
+			return false;
+		}
+		return true;
+	} finally {
+		child.kill('SIGTERM');
+		await new Promise((resolve) => child.once('exit', resolve));
+	}
+}
+
+async function main() {
+	if (!fs.existsSync(DIST_ENTRY)) {
+		console.error('dist/index.js not found — run `npm run build` first.');
+		process.exitCode = 1;
+		return;
+	}
+
+	const doctorOk = runDoctor();
+	const conformanceOk = await runConformance();
+
+	if (!doctorOk || !conformanceOk) {
+		console.error('\nMCP checks failed.');
+		process.exitCode = 1;
+		return;
+	}
+	console.log('\n✓ MCP checks passed');
+}
+
+main().catch((err) => {
+	console.error(`Unexpected error running MCP checks: ${err?.message ?? err}`);
+	process.exitCode = 1;
+});

--- a/scripts/mcp-checks.cjs
+++ b/scripts/mcp-checks.cjs
@@ -37,6 +37,8 @@ function runDoctor() {
 			REPO_ROOT,
 			'--env',
 			`CONFIG=${CONFIG_PATH}`,
+			'--env',
+			'MCP_TRANSPORT=stdio',
 			'--no-telemetry',
 			'--quiet',
 		],
@@ -78,25 +80,37 @@ function runDoctor() {
 	return true;
 }
 
+async function respondsOverHttp() {
+	try {
+		// Any HTTP response, including an error status, means something
+		// is accepting connections on the port.
+		await fetch(SERVER_URL, { method: 'GET', signal: AbortSignal.timeout(2000) });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 async function waitForServer(child) {
 	const deadline = Date.now() + STARTUP_TIMEOUT_MS;
 	while (Date.now() < deadline) {
 		if (child.exitCode !== null) {
 			return false;
 		}
-		try {
-			// Any HTTP response, including an error status, means the
-			// transport is accepting connections.
-			await fetch(SERVER_URL, { method: 'GET' });
+		if (await respondsOverHttp()) {
 			return true;
-		} catch {
-			await new Promise((resolve) => setTimeout(resolve, 250));
 		}
+		await new Promise((resolve) => setTimeout(resolve, 250));
 	}
 	return false;
 }
 
 async function runConformance() {
+	if (await respondsOverHttp()) {
+		console.error(`Port ${PORT} is already in use by another process — set PORT to a free port.`);
+		return false;
+	}
+
 	console.log(`\nStarting HTTP transport on port ${PORT}...`);
 	const serverLog = [];
 	const child = spawn(process.execPath, [DIST_ENTRY], {
@@ -111,9 +125,12 @@ async function runConformance() {
 	});
 	child.stdout.on('data', (chunk) => serverLog.push(chunk));
 	child.stderr.on('data', (chunk) => serverLog.push(chunk));
+	// Armed before the child can possibly exit, so the finally block's
+	// await resolves even when the child is already dead by then.
+	const exited = new Promise((resolve) => child.once('exit', resolve));
 
 	try {
-		if (!(await waitForServer(child))) {
+		if (!(await waitForServer(child)) || child.exitCode !== null) {
 			console.error('HTTP transport did not become reachable:');
 			console.error(serverLog.join(''));
 			return false;
@@ -142,7 +159,7 @@ async function runConformance() {
 		return true;
 	} finally {
 		child.kill('SIGTERM');
-		await new Promise((resolve) => child.once('exit', resolve));
+		await exited;
 	}
 }
 

--- a/scripts/mcp-checks.config.json
+++ b/scripts/mcp-checks.config.json
@@ -1,0 +1,10 @@
+{
+	"wikis": {
+		"en.wikipedia.org": {
+			"server": "https://en.wikipedia.org",
+			"articlePath": "/wiki",
+			"scriptPath": "/w"
+		}
+	},
+	"defaultWiki": "en.wikipedia.org"
+}


### PR DESCRIPTION
Adds a second CI job, `mcp-checks`, running three structural checks against the built server, driven by the [MCPJam CLI](https://github.com/MCPJam/inspector) (an MCP server testing tool, pinned as a devDependency). None of the checks involve an LLM, so the job costs nothing beyond ~a minute of runner time.

- **Health check** (stdio) — smoke-checks that the shipped `dist/` artifact actually starts, completes an MCP handshake, and serves its tools and resources. Nothing else in CI boots the built artifact.
- **MCP protocol conformance** (pinned to `2026-07-28`) against the HTTP transport — an external implementation checking the spec-compliance surface. Currently 20/31 checks pass, 0 fail, 11 skip (legacy-era and SSE-session checks that don't apply to the stateless deployment).
- **Tool-surface diff against the PR base** — CI builds the base commit, exports its tool surface, and diffs the PR's surface against it. A removed or renamed tool fails the job (`--fail-on breaking`); description changes appear in the report without failing.

The health check and conformance run are also available locally as `npm run check:mcp` (build first). Both CI and the local script use the checked-in minimal wiki configuration in `scripts/mcp-checks.config.json`, so results are deterministic and independent of the developer's `config.json`. Telemetry is disabled on every invocation.

Preflight is deliberately untouched: these checks need a booted server, a port, and (for the diff) a base checkout, none of which belong in the hermetic local release gate.

## To review

- Whether `--fail-on breaking` is the right diff policy, or whether description changes should also fail (`--fail-on any`).
- The fixed local port (3117) for the conformance run; `PORT` overrides it.

## Verified

`npm run check:mcp` passes end-to-end locally (health check ready with 27 tools, conformance 20/31 passed, 0 failed). The exact export/diff commands from the workflow were run locally against the built server: identical surfaces exit 0, and a mutated baseline (removed tool) exits 1 under `--fail-on breaking`. Failure paths verified to actually fail: a crashed server process, an already-occupied port, and a polluted `MCP_TRANSPORT` environment each produce the intended outcome. Lint, typecheck, fmt, and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)