### PR TITLE
Document that section=N spans nested subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- `update-page` and `get-page` now state that `section=N` covers a section together with every subsection nested under it, up to the next heading at the same or a higher level. MediaWiki has always addressed sections this way, so an `update-page` call naming a section that has subsections replaced those subsections as well; the descriptions said only that it edits "one section", and the section outline gives no sign that a section has children. Behaviour is unchanged. (#530)
+
 ## [0.16.0] - 2026-07-30
 
 ### Security

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -26,7 +26,7 @@ const inputSchema = {
 		.nonnegative()
 		.optional()
 		.describe(
-			'Section number (0 = lead; 1..N = heading sections). Narrows content to one section.',
+			'Section number (0 = lead; 1..N = heading sections). Narrows content to that section together with the subsections nested under it.',
 		),
 } as const;
 

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -18,7 +18,7 @@ const inputSchema = {
 	source: z
 		.string()
 		.describe(
-			"The content to write, in the existing page's content model. Interpreted as the full page by default; as the given section's content when section is set; or as a delta (appended or prepended) when mode is set.",
+			"The content to write, in the existing page's content model. Interpreted as the full page by default; as the replacement for the given section and the subsections nested under it when section is set; or as a delta (appended or prepended) when mode is set.",
 		),
 	latestId: z
 		.number()
@@ -33,7 +33,7 @@ const inputSchema = {
 		.union([z.number().int().nonnegative(), z.literal('new')])
 		.optional()
 		.describe(
-			"Section to edit: 0 (lead), 1..N (existing heading sections), or 'new' to append a new heading section.",
+			"Section to edit: 0 (lead), 1..N (existing heading sections), or 'new' to append a new heading section. An existing section is replaced together with the subsections nested under it, so source must include them.",
 		),
 	mode: z
 		.enum(['append', 'prepend'])
@@ -90,7 +90,7 @@ function buildEditParams(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, three modifiers avoid shipping the full source: section=N edits one section (pairs with get-page section=N for reads), section='new' adds a new heading section, and mode='append' or 'prepend' sends a delta. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
+		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, three modifiers avoid shipping the full source: section=N edits one section (pairs with get-page section=N for reads), section='new' adds a new heading section, and mode='append' or 'prepend' sends a delta. A numbered section spans every subsection nested under it, up to the next heading at the same or a higher level, so source must carry those subsections back or they are removed. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -33,7 +33,7 @@ const inputSchema = {
 		.union([z.number().int().nonnegative(), z.literal('new')])
 		.optional()
 		.describe(
-			"Section to edit: 0 (lead), 1..N (existing heading sections), or 'new' to append a new heading section. An existing section is replaced together with the subsections nested under it, so source must include them.",
+			"Section to edit: 0 (lead), 1..N (existing heading sections), or 'new' to append a new heading section. An existing section is replaced in full — its own heading line and every subsection nested under it — so source must carry them back.",
 		),
 	mode: z
 		.enum(['append', 'prepend'])
@@ -90,7 +90,7 @@ function buildEditParams(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, three modifiers avoid shipping the full source: section=N edits one section (pairs with get-page section=N for reads), section='new' adds a new heading section, and mode='append' or 'prepend' sends a delta. A numbered section spans every subsection nested under it, up to the next heading at the same or a higher level, so source must carry those subsections back or they are removed. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
+		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, three modifiers avoid shipping the full source: section=N edits one section (pairs with get-page section=N for reads), section='new' adds a new heading section, and mode='append' or 'prepend' sends a delta. A numbered section spans its own heading line and every subsection nested under it, up to the next heading at the same or a higher level, so source must carry those subsections back or they are removed. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',


### PR DESCRIPTION
Fix B from #530. Descriptions only — no behaviour change, no new tests.

I'm not a native English speaker, and this was written with Claude Code. Please correct anything that reads wrong.

### What this changes

`update-page`'s `section=N` replaces the named section **together with every subsection nested under it**, because that is how MediaWiki's `section` / `rvsection` parameter addresses a section (`Parser::extractSections()` breaks at the next heading of the same or a higher level, in both `'get'` and `'replace'` mode). None of the three descriptions said so, and the section outline `get-page` returns is flat, so a caller has no cue that a section has children. Editing a parent section deletes them.

Four strings change:

| File | String |
|---|---|
| `src/tools/update-page.ts` | tool `description` — new sentence after the three-modifier list |
| `src/tools/update-page.ts` | `section` parameter |
| `src/tools/update-page.ts` | `source` parameter — "the given section's content" was part of the same wrong picture |
| `src/tools/get-page.ts` | `section` parameter — "Narrows content to one section" |

Plus a `### Changed` entry under `## [Unreleased]`.

The wording follows `docs/tool-conventions.md`: third-person descriptive voice, bare `section=N` for a primitive assignment, no hedging, and the consequence stated rather than the mechanism.

The wording differs slightly from the draft in #530: the three-modifier list keeps its shape and the subtree note is a separate sentence, and the `source` and `get-page` parameters are included for the same reason.

### Why this and not the real fix

#530 proposes carrying `level` and `index` through the outline (fix A), which is what actually lets a caller see the structure. That is a breaking change to tool output and needs a decision on the output shape first, so I kept it out of this PR. This one is the part that costs nothing and removes the surprise.

### Considered, omitted

- **README tool table** — this is a description change, not a change in what the tool does, so the one-line table entry still reads correctly.
- **The `get-page` tool description** (as opposed to its `section` parameter) — it mentions `section=N` only as a remedy for truncated content, where the subtree detail does not change what the caller does.
- **Tests** — nothing in the suite asserts on these strings, and asserting on description prose would just pin the wording.

### Checks

`npm run lint`, `npm run typecheck` and `npm run build` pass. The test suite is unchanged at 1717 passing; the failures I see locally (`tests/auth/paths.test.ts`, `tests/transport/uploadGuard.test.ts`, `tests/auth/browserAuth.test.ts`) reproduce on an unmodified checkout on Windows and are POSIX-path and socket-binding assumptions, not related to this change.

`npm run fmt:check` I could not run meaningfully — my clone has `core.autocrlf=true`, so oxfmt flags all 309 files including untouched ones. The edits are single-line string replacements inside existing `.describe()` calls, so formatting is unaffected.