### PR TITLE
Accept numeric tool arguments sent as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- A numeric argument sent as a string, such as `section: "2"` on `update-page`, is now read as the number it spells. Clients that quote numbers were refused with `Invalid input`, which on `update-page` left a full-page rewrite as the only way to edit one section. Values that spell no number, including `""` and `null`, are still refused.
+
 ## [0.16.0] - 2026-07-30
 
 ### Security

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,6 +43,7 @@ Reach for a shared fixture rather than spelling a literal out. A field added to 
 - `fakeProxyConfig()` — a complete `ProxyConfig`.
 - `mockedLookupAll()` — the `node:dns/promises` `lookup` mock, typed at the `{ all: true }` overload production calls.
 - `toolArgs( tool, partial )` — runs partial input through a tool's own schema, so `.default()` values arrive the way a real call delivers them.
+- `callTool( ctx, name, args )` — issues the call over a real MCP session. `handle` and `dispatch` both take arguments the SDK has already validated, so neither can show what a tool's schema accepts or refuses; assertions about the schema go through this. Pair it with `assertRefusedArgument( result )`, since a refusal resolves with `isError` rather than throwing.
 
 Run:
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -129,6 +129,12 @@ Parameter descriptions must:
 - **Not restate the zod type.** `"Optional integer"` is redundant when the schema is `z.number().int().optional()`.
 - **Be concise.** A sentence or two per parameter. Complex behaviour belongs in the tool description, not in every parameter.
 
+#### Numeric parameters
+
+Wrap every numeric schema in `unquoteNumber()` from `src/runtime/numericArg.ts`, including the element schema of an array of numbers. Clients quote numeric arguments often enough that a bare `z.number()` refuses calls that are otherwise well formed. The published schema is unaffected, so callers are still asked for a number.
+
+Apply `.optional()`, `.default()` and `.describe()` to the result, not to the argument: `unquoteNumber( z.number().int() ).optional()`. The compiler refuses the two that would misreport the parameter as required. `.default()` applied outside takes effect at runtime but is not published, so state the default in the parameter description as well.
+
 ### Runtime behavior
 
 #### Result caps and truncation signaling

--- a/src/runtime/numericArg.ts
+++ b/src/runtime/numericArg.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+// A bare run of decimal digits, optionally signed. Deliberately narrow: no
+// surrounding whitespace, no decimal point, no exponent, no hex prefix. `\d`
+// without the `u` flag is ASCII-only, so `٢` and `２` are refused — which is
+// the right answer, since `Number()` reads both as NaN.
+const QUOTED_INTEGER = /^-?\d+$/;
+
+// Refuses a schema that already carries its own optionality. `.optional()` and
+// `.default()` belong on the result of unquoteNumber, never on its argument:
+// applied to the argument, the `.nonoptional()` below cancels them, and the
+// published schema then demands a value the tool treats as optional.
+type NotAlreadyOptional<T> = T extends z.ZodOptional<z.ZodType> | z.ZodDefault<z.ZodType>
+	? never
+	: T;
+
+/**
+ * Wraps a numeric argument schema so a client that spells the number as a
+ * string — `"2"` rather than `2` — is understood. MCP clients quote numeric
+ * tool arguments often enough that a strict schema turns an otherwise
+ * well-formed call into a failure the caller cannot account for from the
+ * request it sent.
+ *
+ * Only the digits form converts. Everything else reaches the wrapped schema
+ * untouched and is refused there, including every value `Number()` reads as
+ * zero: `""`, `" "`, `null`, `false`, `[]`. That distinction carries real
+ * weight on update-page, where section 0 is the page's lead.
+ *
+ * The published JSON Schema is the wrapped schema's, unchanged, so clients are
+ * still told to send a number.
+ */
+export function unquoteNumber<T extends z.ZodType>(schema: T & NotAlreadyOptional<T>) {
+	const unquoted = z.preprocess((value) => {
+		if (typeof value !== 'string' || !QUOTED_INTEGER.test(value)) {
+			return value;
+		}
+		// A digit run long enough to overflow to Infinity is handed back as the
+		// string it came in as, so the wrapped schema reports the type it was
+		// given rather than the nonsense number it would otherwise see.
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : value;
+	}, schema);
+
+	// A preprocess step accepts `unknown`, and `unknown` admits `undefined`, so
+	// wrapping alone would make every argument an optional one. Callers that want
+	// the argument optional say so themselves, after this.
+	return unquoted.nonoptional();
+}

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import { inlineDiffToText } from '../results/diffFormat.ts';
 import { truncateByBytes } from '../results/truncation.ts';
 
@@ -21,13 +22,17 @@ interface CompareResponse {
 type Side = 'from' | 'to';
 
 const inputSchema = {
-	fromRevision: z.number().int().positive().optional().describe('Revision ID for the "from" side'),
+	fromRevision: unquoteNumber(z.number().int().positive())
+		.optional()
+		.describe('Revision ID for the "from" side'),
 	fromTitle: z
 		.string()
 		.optional()
 		.describe('Wiki page title for the "from" side (latest revision is used)'),
 	fromText: z.string().optional().describe('Supplied wikitext for the "from" side'),
-	toRevision: z.number().int().positive().optional().describe('Revision ID for the "to" side'),
+	toRevision: unquoteNumber(z.number().int().positive())
+		.optional()
+		.describe('Revision ID for the "to" side'),
 	toTitle: z
 		.string()
 		.optional()

--- a/src/tools/extensions/bucket/bucket-query.ts
+++ b/src/tools/extensions/bucket/bucket-query.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
 
 const HARD_LIMIT = 500;
@@ -12,11 +13,7 @@ const inputSchema = {
 		.describe(
 			'Bucket Lua chain ending in `.run()`. Example: bucket("exchange").select("name","high_alch").where("name","Abyssal whip").run()',
 		),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(HARD_LIMIT)
+	limit: unquoteNumber(z.number().int().min(1).max(HARD_LIMIT))
 		.optional()
 		.describe('Appended as `.limit(N)` before `.run()`. Hard cap 500.'),
 	continueFrom: z

--- a/src/tools/extensions/cargo/cargo-query.ts
+++ b/src/tools/extensions/cargo/cargo-query.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
 
 const HARD_LIMIT = 500;
@@ -32,11 +33,7 @@ const inputSchema = {
 	groupBy: z.string().optional().describe('SQL GROUP BY clause fragment.'),
 	having: z.string().optional().describe('SQL HAVING clause fragment (requires groupBy).'),
 	orderBy: z.string().optional().describe('SQL ORDER BY clause fragment (e.g. `drop_level DESC`).'),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(HARD_LIMIT)
+	limit: unquoteNumber(z.number().int().min(1).max(HARD_LIMIT))
 		.optional()
 		.describe('Maximum rows to return. Hard cap 500. Defaults to 500 when omitted.'),
 	continueFrom: z

--- a/src/tools/extensions/neowiki/neowiki-create-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-create-subject.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
 import { resolvePageId, hasOnePageRef } from './pageId.ts';
 
@@ -26,10 +27,7 @@ const inputSchema = {
 		.min(1)
 		.optional()
 		.describe('Wiki page title to attach the Subject to. Provide this OR pageId.'),
-	pageId: z
-		.number()
-		.int()
-		.positive()
+	pageId: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe('Numeric MediaWiki page ID. Provide this OR title.'),
 	isMain: z

--- a/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
+++ b/src/tools/extensions/neowiki/neowiki-get-page-subjects.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
 import { flattenSubject } from './neowiki-get-subject.ts';
 import { resolvePageId, hasOnePageRef } from './pageId.ts';
@@ -12,10 +13,7 @@ const inputSchema = {
 		.min(1)
 		.optional()
 		.describe('Wiki page title. Provide this OR pageId, not both.'),
-	pageId: z
-		.number()
-		.int()
-		.positive()
+	pageId: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe('Numeric MediaWiki page ID. Provide this OR title, not both.'),
 } as const;

--- a/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
@@ -2,15 +2,13 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
 import { resolvePageId, hasOnePageRef } from './pageId.ts';
 
 const inputSchema = {
 	title: z.string().min(1).optional().describe('Wiki page title. Provide this OR pageId.'),
-	pageId: z
-		.number()
-		.int()
-		.positive()
+	pageId: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe('Numeric MediaWiki page ID. Provide this OR title.'),
 	subjectId: z

--- a/src/tools/extensions/smw/smw-list-properties.ts
+++ b/src/tools/extensions/smw/smw-list-properties.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
 
 const DEFAULT_LIMIT = 50;
@@ -12,11 +13,7 @@ const inputSchema = {
 		.string()
 		.optional()
 		.describe('Substring filter on property name (case-insensitive). Omit to list all properties.'),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(MAX_LIMIT)
+	limit: unquoteNumber(z.number().int().min(1).max(MAX_LIMIT))
 		.optional()
 		.describe('Maximum properties to return.'),
 	continueFrom: z

--- a/src/tools/extensions/smw/smw-query.ts
+++ b/src/tools/extensions/smw/smw-query.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { unquoteNumber } from '../../../runtime/numericArg.ts';
 import type { TruncationInfo } from '../../../results/truncation.ts';
 
 const HARD_LIMIT = 500;
@@ -13,11 +14,7 @@ const inputSchema = {
 			'SMW #ask query. Conditions: `[[Property::value]]`. Printouts: `|?Property`. ' +
 				'Parameters: `|limit=N`, `|offset=N`, `|sort=Property`, `|order=asc/desc`.',
 		),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(HARD_LIMIT)
+	limit: unquoteNumber(z.number().int().min(1).max(HARD_LIMIT))
 		.optional()
 		.describe('Overrides |limit= in query if both are set.'),
 	continueFrom: z

--- a/src/tools/get-category-members.ts
+++ b/src/tools/get-category-members.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 enum CategoryMemberType {
@@ -28,10 +29,12 @@ const inputSchema = {
 		.optional()
 		.describe('Types of members to include'),
 	namespaces: z
-		.array(z.number().int().nonnegative())
+		.array(unquoteNumber(z.number().int().nonnegative()))
 		.optional()
 		.describe('Namespace IDs to filter by'),
-	limit: z.number().int().min(1).max(500).optional().describe('Maximum members to return (1..500)'),
+	limit: unquoteNumber(z.number().int().min(1).max(500))
+		.optional()
+		.describe('Maximum members to return (1..500)'),
 	continueFrom: z
 		.string()
 		.optional()

--- a/src/tools/get-file-data.ts
+++ b/src/tools/get-file-data.ts
@@ -3,6 +3,7 @@ import type { CallToolResult, ImageContent, TextContent } from '@modelcontextpro
 import type { ApiPage, ImageInfo } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 
 const DEFAULT_IMAGE_WIDTH = 1024;
 const DEFAULT_TEXT_WIDTH = 512;
@@ -27,10 +28,7 @@ function resolveFileDataMaxBytes(): number {
 
 const inputSchema = {
 	title: z.string().describe('File title (with or without the "File:" prefix)'),
-	width: z
-		.number()
-		.int()
-		.positive()
+	width: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe(
 			'Pixel width of the scaled rendition. A quality/detail knob: in image mode the model caps image tokens regardless of size, so larger mainly means more detail. Defaults to 1024 (512 when format is "text"); values above 1568 are clamped.',

--- a/src/tools/get-links-here.ts
+++ b/src/tools/get-links-here.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 export enum LinkType {
@@ -49,7 +50,7 @@ const inputSchema = {
 			'Inbound relationship to list: wikilinks (pages that link to the target), transclusions (pages that embed it), or fileusage (pages that display it)',
 		),
 	namespaces: z
-		.array(z.number().int().nonnegative())
+		.array(unquoteNumber(z.number().int().nonnegative()))
 		.optional()
 		.describe('Namespace IDs to filter the referencing pages by'),
 	filter: z
@@ -62,11 +63,7 @@ const inputSchema = {
 		.describe(
 			'When a referencing page is a redirect to the target, also return the pages that link through it. Applies to wikilinks and fileusage only.',
 		),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(500)
+	limit: unquoteNumber(z.number().int().min(1).max(500))
 		.optional()
 		.describe('Maximum referencing pages to return (1..500)'),
 	continueFrom: z

--- a/src/tools/get-page-history.ts
+++ b/src/tools/get-page-history.ts
@@ -3,24 +3,19 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiPage, ApiRevision } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 const PAGE_HISTORY_LIMIT = 20;
 
 const inputSchema = {
 	title: z.string().describe('Wiki page title'),
-	olderThan: z
-		.number()
-		.int()
-		.positive()
+	olderThan: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe(
 			'Revision ID — return revisions older than this (exclusive). Mutually exclusive with newerThan.',
 		),
-	newerThan: z
-		.number()
-		.int()
-		.positive()
+	newerThan: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe(
 			'Revision ID — return revisions newer than this (exclusive). Mutually exclusive with olderThan.',

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { ContentFormat } from '../results/contentFormat.ts';
 import { truncateByBytes, type TruncationInfo } from '../results/truncation.ts';
@@ -20,10 +21,7 @@ const inputSchema = {
 		.describe(
 			'Whether to include metadata (page ID, revision info, size, section outline) in the response',
 		),
-	section: z
-		.number()
-		.int()
-		.nonnegative()
+	section: unquoteNumber(z.number().int().nonnegative())
 		.optional()
 		.describe(
 			'Section number (0 = lead; 1..N = heading sections). Narrows content to one section.',

--- a/src/tools/get-recent-changes.ts
+++ b/src/tools/get-recent-changes.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 const RC_LIMIT = 50;
@@ -19,7 +20,7 @@ const inputSchema = {
 		.optional()
 		.describe('ISO 8601 timestamp — only return changes at or before this time'),
 	namespace: z
-		.array(z.number().int().nonnegative())
+		.array(unquoteNumber(z.number().int().nonnegative()))
 		.nonempty()
 		.optional()
 		.describe('Namespace IDs to restrict the feed to — e.g. [0, 1] for main and talk'),

--- a/src/tools/get-revision.ts
+++ b/src/tools/get-revision.ts
@@ -3,11 +3,12 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiPage, ApiRevision } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { ContentFormat } from '../results/contentFormat.ts';
 
 const inputSchema = {
-	revisionId: z.number().int().positive().describe('Revision ID'),
+	revisionId: unquoteNumber(z.number().int().positive().describe('Revision ID')),
 	content: z
 		.nativeEnum(ContentFormat)
 		.describe('Type of content to return')

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -76,6 +76,16 @@ const standardTools: Tool<any>[] = [
 // oxlint-disable-next-line typescript/no-explicit-any
 const managementTools: Tool<any, ManagementContext>[] = [addWiki, removeWiki];
 
+// Every tool the server can register, in one list, so a test can hold the whole
+// surface to a convention rather than one tool at a time. Registration below
+// still separates them, since the management tools take a wider context.
+// oxlint-disable-next-line typescript/no-explicit-any
+export const allTools: readonly Tool<any, any>[] = [
+	...standardTools,
+	...extensionPacks.flatMap((p) => p.tools),
+	...managementTools,
+];
+
 export function registerAllTools(
 	server: McpServer,
 	reconcile: Reconcile,

--- a/src/tools/search-page-by-prefix.ts
+++ b/src/tools/search-page-by-prefix.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 interface AllPagesEntry {
@@ -12,17 +13,10 @@ interface AllPagesEntry {
 
 const inputSchema = {
 	prefix: z.string().describe('Wiki page title prefix'),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(500)
+	limit: unquoteNumber(z.number().int().min(1).max(500))
 		.optional()
 		.describe('Maximum number of results to return'),
-	namespace: z
-		.number()
-		.int()
-		.nonnegative()
+	namespace: unquoteNumber(z.number().int().nonnegative())
 		.optional()
 		.describe('Namespace ID to restrict the search to'),
 } as const;

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -3,16 +3,13 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ApiSearchResult } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 const inputSchema = {
 	query: z.string().describe('Search terms'),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(100)
+	limit: unquoteNumber(z.number().int().min(1).max(100))
 		.optional()
 		.describe('Maximum number of search results to return'),
 } as const;

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
+import { unquoteNumber } from '../runtime/numericArg.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
 
 interface ApiEditResponse {
@@ -20,17 +21,14 @@ const inputSchema = {
 		.describe(
 			"The content to write, in the existing page's content model. Interpreted as the full page by default; as the given section's content when section is set; or as a delta (appended or prepended) when mode is set.",
 		),
-	latestId: z
-		.number()
-		.int()
-		.positive()
+	latestId: unquoteNumber(z.number().int().positive())
 		.optional()
 		.describe(
 			'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.',
 		),
 	comment: z.string().optional().describe('Summary of the edit'),
 	section: z
-		.union([z.number().int().nonnegative(), z.literal('new')])
+		.union([unquoteNumber(z.number().int().nonnegative()), z.literal('new')])
 		.optional()
 		.describe(
 			"Section to edit: 0 (lead), 1..N (existing heading sections), or 'new' to append a new heading section.",

--- a/tests/helpers/callTool.ts
+++ b/tests/helpers/callTool.ts
@@ -1,0 +1,49 @@
+import { expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport } from '@modelcontextprotocol/server';
+import type { CallToolResult, TextContent } from '@modelcontextprotocol/server';
+import { createServer } from '../../src/server.ts';
+import type { ToolContext } from '../../src/runtime/context.ts';
+
+// Calls a tool the way a client does: over a real MCP session, so the arguments
+// pass through the registered zod schema on their way to the handler.
+//
+// Tests that call `tool.handle(...)` or `dispatch(...)` supply already-parsed
+// arguments, because the SDK owns validation and neither of those goes through
+// it. They therefore cannot see a schema that rejects a well-formed call, and a
+// literal in the test satisfies a schema the wire never would. Use this helper
+// whenever the assertion is about what the schema accepts or refuses.
+//
+// A rejected call resolves with `isError: true` rather than throwing, so assert
+// on the result content. The message names the offending argument, which
+// distinguishes a schema rejection from a handler that failed for its own
+// reasons and set the same flag.
+export async function callTool(
+	ctx: ToolContext,
+	name: string,
+	args: Record<string, unknown>,
+): Promise<CallToolResult> {
+	const server = await createServer(ctx);
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: 'call-tool-helper', version: '0.0.0' });
+	await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+	try {
+		return (await client.callTool({ name, arguments: args })) as CallToolResult;
+	} finally {
+		await client.close();
+		await server.close();
+	}
+}
+
+// Asserts the schema refused the call, and returns the message so a test can
+// name the argument at fault. A handler that failed for its own reasons sets
+// `isError` too, so the marker text is what tells the two apart. Schema
+// rejections carry no ErrorEnvelope, which is why assertStructuredError from
+// structuredResult.ts does not fit here.
+export function assertRefusedArgument(result: CallToolResult): string {
+	expect(result.isError).toBe(true);
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- validation errors always carry a single text block
+	const text = (result.content![0] as TextContent).text;
+	expect(text).toContain('Input validation error');
+	return text;
+}

--- a/tests/runtime/numericArg.test.ts
+++ b/tests/runtime/numericArg.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { unquoteNumber } from '../../src/runtime/numericArg.ts';
+
+const limit = unquoteNumber(z.number().int().min(1).max(500));
+
+// Mirrors update-page's section, the parameter where a wrongly accepted zero
+// does damage, and the only one whose lower bound cannot mask a bad conversion.
+const section = unquoteNumber(z.number().int().nonnegative());
+
+function parse(value: unknown): z.ZodSafeParseResult<number> {
+	return limit.safeParse(value) as z.ZodSafeParseResult<number>;
+}
+
+function accepts(value: unknown): boolean {
+	return parse(value).success;
+}
+
+// The conversion the MCP SDK runs over a tool's schema to publish it: zod 4.2
+// and later carry it on the schema itself, and the SDK prefers that over
+// z.toJSONSchema.
+function toJsonSchema(schema: z.ZodType): Record<string, unknown> {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Standard Schema's JSON Schema extension is untyped in zod's public surface
+	const std = schema['~standard'] as {
+		jsonSchema: { input: (options: { target: string }) => Record<string, unknown> };
+	};
+	return std.jsonSchema.input({ target: 'draft-2020-12' });
+}
+
+describe('unquoteNumber', () => {
+	it('reads a quoted number as the number it spells', () => {
+		expect(parse('42').data).toBe(42);
+	});
+
+	it('reads a quoted zero as zero', () => {
+		expect(section.safeParse('0').data).toBe(0);
+	});
+
+	it('leaves an unquoted number alone', () => {
+		expect(parse(42).data).toBe(42);
+	});
+
+	// Asserted against `section`, not `limit`: a lower bound of 1 would refuse
+	// these on its own and the conversion would never be under test. `section`
+	// accepts zero, so anything that wrongly converts to zero gets through.
+	it('refuses the values that would otherwise coerce to zero', () => {
+		expect(section.safeParse('').success).toBe(false);
+		expect(section.safeParse(' ').success).toBe(false);
+		expect(section.safeParse(null).success).toBe(false);
+		expect(section.safeParse(false).success).toBe(false);
+		expect(section.safeParse([]).success).toBe(false);
+	});
+
+	it('refuses a number spelled in a notation the wire never uses', () => {
+		expect(accepts('0x10')).toBe(false);
+		expect(accepts('1e3')).toBe(false);
+		expect(accepts(' 7 ')).toBe(false);
+	});
+
+	it('refuses a string that spells no number', () => {
+		expect(accepts('all')).toBe(false);
+	});
+
+	it('holds a quoted number to the bounds the wrapped schema sets', () => {
+		expect(accepts('501')).toBe(false);
+		expect(accepts('500')).toBe(true);
+	});
+
+	it('reports a quoted number out of bounds the way the unquoted one is reported', () => {
+		expect(parse('501').error?.issues[0].message).toBe(parse(501).error?.issues[0].message);
+	});
+
+	it('reports a digit run too long to be a number as the string it is', () => {
+		expect(parse('9'.repeat(320)).error?.issues[0].message).toContain('received string');
+	});
+
+	// The arrangement update-page uses: the wrapper goes on the numeric member,
+	// so a value the numeric branch cannot read falls through to the literal.
+	it('lets a value it does not convert fall through to a sibling union branch', () => {
+		const sectionOrNew = z.union([section, z.literal('new')]);
+
+		expect(sectionOrNew.safeParse('new').data).toBe('new');
+		expect(sectionOrNew.safeParse('2').data).toBe(2);
+	});
+
+	it('converts inside an array of numbers', () => {
+		const namespaces = z.array(section);
+
+		expect(namespaces.safeParse(['0', '14']).data).toEqual([0, 14]);
+	});
+
+	// Wrapping must not quietly relax a required argument into an optional one.
+	// The runtime refuses the omission either way, so only the published schema
+	// shows the difference — and a caller reading it would omit the argument and
+	// get an error the schema said could not happen.
+	it('still asks for a required argument', () => {
+		const args = z.object({ revisionId: unquoteNumber(z.number().int().positive()) });
+
+		expect(toJsonSchema(args).required).toEqual(['revisionId']);
+	});
+
+	it('still lets a caller omit an argument marked optional', () => {
+		const args = z.object({ limit: limit.optional() });
+
+		expect(toJsonSchema(args).required).toBeUndefined();
+		expect(args.safeParse({}).success).toBe(true);
+	});
+
+	it('publishes the wrapped schema, so callers are still asked for a number', () => {
+		const plain = z.number().int().min(1).max(500);
+
+		expect(toJsonSchema(unquoteNumber(plain))).toEqual(toJsonSchema(plain));
+	});
+
+	// A compile-time assertion, not a runtime one: applying optionality to the
+	// argument instead of the result publishes a schema that demands a value the
+	// tool treats as optional. `npm run typecheck` fails if the guard is dropped,
+	// because an unused @ts-expect-error is itself an error.
+	it('refuses optionality applied to its argument rather than its result', () => {
+		// @ts-expect-error .optional() belongs outside unquoteNumber
+		expect(() => unquoteNumber(z.number().int().optional())).toBeDefined();
+		// @ts-expect-error .default() belongs outside unquoteNumber
+		expect(() => unquoteNumber(z.number().int().default(50))).toBeDefined();
+	});
+});

--- a/tests/tools/extensions/cargo/cargo-describe-table.test.ts
+++ b/tests/tools/extensions/cargo/cargo-describe-table.test.ts
@@ -150,9 +150,9 @@ describe('cargo-describe-table', () => {
 	});
 
 	it('rejects an empty table parameter at the schema layer', () => {
-		// zod validation runs in the dispatcher before reaching handle()
-		// — this is asserted indirectly by the schema definition; explicit
-		// dispatcher-level rejection is covered by dispatcher.test.ts.
+		// The SDK validates arguments at registration's schema, not the
+		// dispatcher, so this parses the schema directly. To assert on what a
+		// client's call does with the rejection, go through callTool instead.
 		expect(cargoDescribeTable.inputSchema.table.safeParse('').success).toBe(false);
 		expect(cargoDescribeTable.inputSchema.table.safeParse('items').success).toBe(true);
 	});

--- a/tests/tools/numericArguments.test.ts
+++ b/tests/tools/numericArguments.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import { allTools } from '../../src/tools/index.ts';
+
+// Every tool argument that accepts an unquoted number, found by probing the
+// schema rather than by reading the JSON Schema it publishes. Probing is what
+// makes update-page's section show up: a union publishes `anyOf` with no
+// top-level `type`, so a walk looking for `type: integer` would skip it.
+//
+// The convention this enforces is in docs/tool-conventions.md: every numeric
+// argument is wrapped in unquoteNumber, because clients send numbers as
+// strings. An argument added without the wrapper appears here as a failure
+// instead of as a bug report.
+const numericArguments = allTools.flatMap((tool) =>
+	Object.entries<z.ZodType>(tool.inputSchema).flatMap(([argument, schema]) => {
+		if (schema.safeParse(1).success) {
+			return [{ tool: tool.name, argument, schema, quoted: '1' as unknown }];
+		}
+		if (schema.safeParse([1]).success) {
+			return [{ tool: tool.name, argument, schema, quoted: ['1'] as unknown }];
+		}
+		return [];
+	}),
+);
+
+describe('numeric tool arguments', () => {
+	// Without this, an it.each over an empty list reports success having asserted
+	// nothing, and a refactor that stopped finding arguments would look green.
+	it('finds the numeric arguments across the tool surface', () => {
+		expect(numericArguments.length).toBeGreaterThan(20);
+	});
+
+	it.each(numericArguments)('$tool $argument accepts a quoted number', ({ schema, quoted }) => {
+		expect(schema.safeParse(quoted).success).toBe(true);
+	});
+});

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -5,6 +5,7 @@ import { fakeContext } from '../helpers/fakeContext.ts';
 import { updatePage } from '../../src/tools/update-page.ts';
 import { dispatch } from '../../src/runtime/dispatcher.ts';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.ts';
+import { assertRefusedArgument, callTool } from '../helpers/callTool.ts';
 
 // The default fake EditService; each test spreads it and replaces only the
 // slice it exercises, so an unexpected call to another member still throws.
@@ -461,6 +462,81 @@ describe('update-page', () => {
 				appendtext: '\n* row',
 				bot: true,
 			});
+		});
+	});
+
+	// These go over a real MCP session rather than calling handle() directly,
+	// because the schema is what is under test and handle() never sees it.
+	describe('numbers sent as strings', () => {
+		it('edits the section a client named as "2"', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'My Page',
+				source: 'new section body',
+				section: '2',
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit.mock.calls[0][1]).toMatchObject({ section: '2' });
+		});
+
+		// The twin of the test above with an unquoted 2. It passes either way,
+		// which is the point: if the session harness itself broke, both would
+		// fail together and the quoted case would look like a schema problem.
+		it('edits the same section when the client sends 2', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'My Page',
+				source: 'new section body',
+				section: 2,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit.mock.calls[0][1]).toMatchObject({ section: '2' });
+		});
+
+		it('detects edit conflicts against a latestId sent as "41"', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'My Page',
+				source: 'body',
+				latestId: '41',
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit.mock.calls[0][1]).toMatchObject({ baserevid: 41 });
+		});
+
+		it('still refuses a section that names no number', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'My Page',
+				source: 'body',
+				section: 'lead',
+			});
+
+			expect(assertRefusedArgument(result)).toContain('section');
+			expect(submit).not.toHaveBeenCalled();
+		});
+
+		// The empty string is the value a naive conversion turns into 0, which is
+		// the lead. Refusing it is what stops a stray argument from rewriting the
+		// top of the page.
+		it('refuses an empty section rather than reading it as the lead', async () => {
+			const { submit, ctx } = fakeEdit();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'My Page',
+				source: 'body',
+				section: '',
+			});
+
+			expect(assertRefusedArgument(result)).toContain('section');
+			expect(submit).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/526

MCP clients quote numeric arguments often enough that a bare `z.number()` refuses calls that are otherwise well formed. `update-page` was the visible case: a quoted section number was rejected with `Invalid input`, leaving a full-page rewrite as the only way to edit one section. The same refusal applied to all 24 numeric parameters, among them `update-page`'s own `latestId`, which its description tells callers to pair with `section=N`.

`unquoteNumber()` reads a bare run of digits as the number it spells and hands everything else to the wrapped schema to refuse. So `""`, `null`, `false` and `[]` are still rejected rather than read as zero the way `z.coerce.number()` would, zero being a page's lead section.

The published JSON Schema is unchanged, byte for byte across all 46 tools, so callers are still asked for a number. Optionality belongs on the wrapper's result rather than its argument, or the published schema would demand a value the tool treats as optional; the compiler refuses the wrong order.

Tool tests call `handle()` or `dispatch()` with already-parsed arguments and so never reach the schema, which is why this went unnoticed. The regression tests go over a real MCP session, and a sweep over every numeric argument on the tool surface fails if one is ever left unwrapped.

## To decide

**Scope.** The issue asks only for `update-page`'s `section`. That fix alone leaves `latestId` refusing quoted numbers in the very workflow the issue reproduces, so this covers all numeric parameters. Say the word if you want it narrowed.

**`z.boolean()` has the identical bug**, left out of this PR: six parameters (`get-recent-changes`'s five `hide*` flags, `move-page.moveTalk`) still refuse `"true"`. A client that quotes `2` will quote `true`. Worth a follow-up issue.

**Read #526's diagnosis with care.** Its title says `update-page` "rejects all numeric section values" and its suspected cause says `get-page` coerces. Both are wrong: `section: 2` passes on master, and nothing coerces anywhere — `get-page section:"1"`, `search-page limit:"3"` and `get-revision revisionId:"123"` all fail identically. Only callers that quote the number were affected.

## Considered, omitted

- **README tool table** — no name, description or grant changes.
- **`neowiki-cypher-query.parameters`** — `z.record(z.string(), z.unknown())` forwards `{"minYear": "2000"}` to Neo4j as a string. No declared numeric type to wrap, so out of reach here.
- **Folding `tests/runtime/cancellation.test.ts`'s hand-rolled sessions onto the new helper** — unrelated churn.

## Verified

`lint`, `typecheck`, `fmt:check`, `build`, `check:mcp` and 1766 tests green.

- Published schema dumped for all 46 descriptors through the SDK's own conversion path and diffed against master: identical, key order and error text included.
- End-to-end over raw JSON-RPC against en.wikipedia: quoted `section`, `latestId`, `limit`, `revisionId` and `namespaces` reach the handler and return real results; `"lead"`, `""`, `null` and an omitted `revisionId` are still refused.
- New tests mutation-tested rather than assumed: reverting the helper fails 6, dropping `.nonoptional()` fails only the test that names it, swapping in `Number()` coercion fails the zero test, and unwrapping one parameter fails the sweep naming that parameter.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; one-line ask from @alistair3149, who set the wide scope and ruled #530 out of this PR; diff not yet human-reviewed; verification as above, and three independent AI review passes whose findings are folded in.</sub>
