### PR TITLE
Refuse a section replace that would delete its subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Breaking changes
 
 - `update-page` no longer creates sections: `section='new'` and `sectionTitle` are removed. Add a section with `mode='append'` and a source that begins with the heading, as in `"\n\n== History ==\n\nBody."`. A call still sending `section='new'` is refused with a message naming the replacement.
+- `update-page` now refuses a `section=N` replace whose source would delete the subsections nested under that section, which MediaWiki replaces along with it. Include the subsections in `source` to keep them, or pass `removeSubsections: true` to remove them deliberately. Appends, full-page replaces, and sections with no subsections are unaffected.
 
 ## [0.16.0] - 2026-07-30
 

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -1,24 +1,78 @@
 import type { Mwn } from 'mwn';
 
+export interface SectionEntry {
+	/** MediaWiki's own section id, as sent to `section=`. Non-numeric when transcluded. */
+	index: string;
+	/** Heading depth as an `=` count, 2..6, from the API's `level`. */
+	level: number;
+	/** Heading text. */
+	line: string;
+	/** False when the section is transcluded and cannot be edited on this page. */
+	editable: boolean;
+}
+
 export interface SectionService {
-	list(mwn: Mwn, title: string): Promise<string[]>;
+	list(mwn: Mwn, title: string): Promise<SectionEntry[]>;
+	listInSource(mwn: Mwn, title: string, source: string): Promise<SectionEntry[]>;
 }
 
 interface PageSectionsApi {
+	index?: string;
+	level?: string;
 	line?: string;
 }
 
+// The API reports `index` as `T-1`, `T-2`, … for sections that arrive by
+// transclusion. Those cannot be edited on the host page, and their presence
+// shifts every later entry's position away from its section number.
+function isEditableIndex(index: string): boolean {
+	return /^[1-9]\d*$/.test(index);
+}
+
 export class SectionServiceImpl implements SectionService {
-	public async list(mwn: Mwn, title: string): Promise<string[]> {
+	public async list(mwn: Mwn, title: string): Promise<SectionEntry[]> {
+		return this.parseSections(mwn, {
+			action: 'parse',
+			page: title,
+			prop: 'sections',
+			formatversion: '2',
+		});
+	}
+
+	// Parses `source` the way the wiki itself will when an edit lands, so the
+	// sections found here agree with the outline `list` reports for the page —
+	// one parser decides what counts as a heading on both sides. `title` gives
+	// templates in the source their page context.
+	public async listInSource(mwn: Mwn, title: string, source: string): Promise<SectionEntry[]> {
+		return this.parseSections(mwn, {
+			action: 'parse',
+			text: source,
+			title,
+			contentmodel: 'wikitext',
+			prop: 'sections',
+			formatversion: '2',
+		});
+	}
+
+	private async parseSections(mwn: Mwn, params: Record<string, string>): Promise<SectionEntry[]> {
 		const response =
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
-			(await mwn.request({
-				action: 'parse',
-				page: title,
-				prop: 'sections',
-				formatversion: '2',
-			})) as { parse?: { sections?: PageSectionsApi[] } } | undefined;
-		const apiSections: PageSectionsApi[] = response?.parse?.sections ?? [];
-		return ['', ...apiSections.map((s) => s.line ?? '')];
+			(await mwn.request(params)) as { parse?: { sections?: PageSectionsApi[] } } | undefined;
+		return (response?.parse?.sections ?? []).map((s) => {
+			const index = s.index ?? '';
+			return {
+				index,
+				level: Number.parseInt(s.level ?? '', 10) || 0,
+				line: s.line ?? '',
+				editable: isEditableIndex(index),
+			};
+		});
 	}
+}
+
+// The outline shape tools publish today: the lead as an empty first entry, then
+// one heading line per section. Kept separate from the service so the richer
+// entries are available internally without changing any tool's output.
+export function toOutlineLines(entries: readonly SectionEntry[]): string[] {
+	return ['', ...entries.map((e) => e.line)];
 }

--- a/src/services/sectionSubtree.ts
+++ b/src/services/sectionSubtree.ts
@@ -1,0 +1,25 @@
+import type { SectionEntry } from './sectionService.ts';
+
+/**
+ * The sections nested under `index` — those following it with a deeper heading
+ * level, up to the first that is not deeper.
+ *
+ * This is the set MediaWiki replaces along with the section itself:
+ * `Parser::extractSections` breaks on `$curLevel <= $targetLevel`, comparing
+ * `=` counts, which is why `level` and not `toclevel` is the field consulted.
+ */
+export function childrenOf(entries: readonly SectionEntry[], index: string): SectionEntry[] {
+	const position = entries.findIndex((e) => e.index === index);
+	if (position === -1) {
+		return [];
+	}
+	const parentLevel = entries[position].level;
+	const children: SectionEntry[] = [];
+	for (const entry of entries.slice(position + 1)) {
+		if (entry.level <= parentLevel) {
+			break;
+		}
+		children.push(entry);
+	}
+	return children;
+}

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { ContentFormat } from '../results/contentFormat.ts';
 import { truncateByBytes, type TruncationInfo } from '../results/truncation.ts';
+import { toOutlineLines } from '../services/sectionService.ts';
 
 const inputSchema = {
 	title: z.string().describe('Wiki page title'),
@@ -92,7 +93,7 @@ export const getPage: Tool<typeof inputSchema> = {
 			const rev = page.revisions?.[0];
 
 			if (metadata) {
-				sections = await ctx.sections.list(mwn, title);
+				sections = toOutlineLines(await ctx.sections.list(mwn, title));
 			}
 
 			if (metadata || content === ContentFormat.none) {
@@ -115,7 +116,7 @@ export const getPage: Tool<typeof inputSchema> = {
 				payload.source = truncated.text;
 				if (truncated.truncated) {
 					if (sections === undefined) {
-						sections = await ctx.sections.list(mwn, title);
+						sections = toOutlineLines(await ctx.sections.list(mwn, title));
 					}
 					payload.truncation = {
 						reason: 'content-truncated',
@@ -158,7 +159,7 @@ export const getPage: Tool<typeof inputSchema> = {
 
 				if (truncated.truncated) {
 					if (sections === undefined) {
-						sections = await ctx.sections.list(mwn, title);
+						sections = toOutlineLines(await ctx.sections.list(mwn, title));
 					}
 					payload.truncation = {
 						reason: 'content-truncated',

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -5,6 +5,7 @@ import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { truncateByBytes, type TruncationInfo } from '../results/truncation.ts';
+import { toOutlineLines } from '../services/sectionService.ts';
 
 const MAX_TITLES = 50;
 
@@ -221,7 +222,9 @@ async function applyTruncations(
 	if (pending.length === 0) {
 		return;
 	}
-	const sectionLists = await Promise.all(pending.map((p) => ctx.sections.list(mwn, p.title)));
+	const sectionLists = await Promise.all(
+		pending.map(async (p) => toOutlineLines(await ctx.sections.list(mwn, p.title))),
+	);
 	pending.forEach((p, i) => {
 		entries[p.entryIndex].truncation = {
 			reason: 'content-truncated',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { Mwn } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
+import { childrenOf } from '../services/sectionSubtree.ts';
 
 interface ApiEditResponse {
 	result?: string;
@@ -44,7 +46,7 @@ const inputSchema = {
 		.nonnegative()
 		.optional()
 		.describe(
-			"Section number (0 = lead; 1..N = heading sections). Replaces that section's content.",
+			"Section number (0 = lead; 1..N = heading sections). Replaces that section's content, along with every subsection nested under it; see removeSubsections.",
 		),
 	mode: z
 		.enum(['append', 'prepend'])
@@ -57,6 +59,12 @@ const inputSchema = {
 		.optional()
 		.describe(
 			'Marks the edit as a bot edit, which Special:RecentChanges hides by default. Takes effect only when the authenticated account has the `bot` right (granted by the bot group, or by the high-volume grant on a bot password or OAuth consumer); without it the edit saves unflagged and the response reports botMarked: false. Use when performing bulk or automated edit runs, or when the user requests it.',
+		),
+	removeSubsections: z
+		.boolean()
+		.optional()
+		.describe(
+			'Confirms that replacing this section is meant to remove the subsections nested under it. Required only when section is set and source contains fewer subsection headings than the section currently has.',
 		),
 } as const;
 
@@ -80,10 +88,55 @@ function buildEditParams(
 	};
 }
 
+// Replacing a section replaces everything nested under it. A source that brings
+// the subsections back is not destructive; one that drops them deletes content
+// the caller may never have read. Both sides of the comparison are parsed by
+// the wiki itself, so what counts as a heading is decided once — a
+// heading-shaped line inside <nowiki> or a comment is not a section on either
+// side. Headings are counted rather than matched by text, so a rename passes.
+async function subsectionRemovalError(
+	args: UpdatePageArgs,
+	ctx: ToolContext,
+	mwn: Mwn,
+): Promise<string | undefined> {
+	const { section, source, mode, removeSubsections } = args;
+	if (section === undefined || mode !== undefined || removeSubsections === true) {
+		return undefined;
+	}
+	// The lead has no heading and cannot contain a subsection.
+	if (section === 0) {
+		return undefined;
+	}
+	const entries = await ctx.sections.list(mwn, args.title);
+	const index = String(section);
+	// childrenOf walks every entry so a transcluded heading still closes the
+	// subtree at the right point; transcluded children are filtered out here
+	// because they can never appear in source for the caller to carry back,
+	// and the guard must not refuse a write over content it cannot supply.
+	const children = childrenOf(entries, index).filter((c) => c.editable);
+	if (children.length === 0) {
+		return undefined;
+	}
+	const parent = entries.find((e) => e.index === index);
+	if (parent === undefined) {
+		return undefined;
+	}
+	// Sections a template in the source expands to carry `T-` ids and are
+	// excluded, mirroring the transcluded-children filter above: only headings
+	// the caller wrote count as carried back.
+	const sourceSections = await ctx.sections.listInSource(mwn, args.title, source);
+	const carriedBack = sourceSections.filter((e) => e.editable && e.level > parent.level).length;
+	if (carriedBack >= children.length) {
+		return undefined;
+	}
+	const names = children.map((c) => c.line).join(', ');
+	return `Section ${index} (${parent.line}) contains ${children.length} subsection${children.length === 1 ? '' : 's'}: ${names}. The source supplied would remove them. Include them in source to keep them, or pass removeSubsections: true to remove them deliberately.`;
+}
+
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section and, paired with get-page section=N, reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
+		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',
@@ -97,6 +150,10 @@ export const updatePage: Tool<typeof inputSchema> = {
 
 	async handle(args, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
+		const removalError = await subsectionRemovalError(args, ctx, mwn);
+		if (removalError) {
+			return ctx.format.invalidInput(removalError);
+		}
 		const response =
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
 			(await ctx.edit.submit(mwn, buildEditParams(ctx, args))) as

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -72,7 +72,10 @@ export function fakeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 			inspect: throws('wikiProbe.inspect') as never,
 			invalidate: throws('wikiProbe.invalidate') as never,
 		},
-		sections: { list: throws('sections.list') as never },
+		sections: {
+			list: throws('sections.list') as never,
+			listInSource: throws('sections.listInSource') as never,
+		},
 		edit: {
 			submit: throws('edit.submit') as never,
 			submitUpload: throws('edit.submitUpload') as never,

--- a/tests/services/sectionService.test.ts
+++ b/tests/services/sectionService.test.ts
@@ -1,32 +1,106 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../helpers/mock-mwn.ts';
-import { SectionServiceImpl } from '../../src/services/sectionService.ts';
+import { SectionServiceImpl, toOutlineLines } from '../../src/services/sectionService.ts';
+
+function mockWithSections(sections: unknown[]) {
+	return {
+		request: vi.fn().mockResolvedValue({ parse: { sections } }),
+	};
+}
 
 describe('SectionServiceImpl', () => {
-	it('returns lead-empty plus heading lines', async () => {
-		const mock = createMockMwn({
-			request: vi.fn().mockResolvedValue({
-				parse: {
-					sections: [{ line: 'Heading One' }, { line: 'Heading Two' }],
-				},
-			}),
-		});
-		const sections = new SectionServiceImpl();
-		const result = await sections.list(mock as never, 'Foo');
-		expect(result).toEqual(['', 'Heading One', 'Heading Two']);
+	it('carries the section id, heading level and text', async () => {
+		const mock = mockWithSections([
+			{ index: '1', level: '2', line: 'Etymology' },
+			{ index: '2', level: '2', line: 'History' },
+			{ index: '3', level: '3', line: 'Feudal era' },
+		]);
+
+		expect(await new SectionServiceImpl().list(mock as never, 'Japan')).toEqual([
+			{ index: '1', level: 2, line: 'Etymology', editable: true },
+			{ index: '2', level: 2, line: 'History', editable: true },
+			{ index: '3', level: 3, line: 'Feudal era', editable: true },
+		]);
+	});
+
+	// A transcluded section carries a `T-` prefixed id and cannot be edited on
+	// the host page, so a caller must never be handed it as a section number.
+	it('marks a transcluded section as not editable', async () => {
+		const mock = mockWithSections([
+			{ index: 'T-1', level: '2', line: 'About administrators' },
+			{ index: '1', level: '2', line: 'Current nominations' },
+		]);
+
+		const result = await new SectionServiceImpl().list(mock as never, 'RfA');
+		expect(result[0]).toMatchObject({ index: 'T-1', editable: false });
+		expect(result[1]).toMatchObject({ index: '1', editable: true });
+	});
+
+	it('returns an empty list for a page with no headings', async () => {
+		expect(await new SectionServiceImpl().list(mockWithSections([]) as never, 'Empty')).toEqual([]);
+	});
+});
+
+describe('listInSource', () => {
+	it('sends the source to be parsed in the context of the named page', async () => {
+		const mock = mockWithSections([]);
+
+		await new SectionServiceImpl().listInSource(mock as never, 'Japan', '== History ==\nBody.');
+
 		expect(mock.request).toHaveBeenCalledWith({
 			action: 'parse',
-			page: 'Foo',
+			text: '== History ==\nBody.',
+			title: 'Japan',
+			contentmodel: 'wikitext',
 			prop: 'sections',
 			formatversion: '2',
 		});
 	});
 
-	it('returns just lead when there are no sections', async () => {
-		const mock = createMockMwn({
-			request: vi.fn().mockResolvedValue({ parse: { sections: [] } }),
-		});
-		const sections = new SectionServiceImpl();
-		expect(await sections.list(mock as never, 'Empty')).toEqual(['']);
+	it('carries the section id, heading level and text', async () => {
+		const mock = mockWithSections([
+			{ index: '1', level: '2', line: 'History' },
+			{ index: '2', level: '3', line: 'Feudal era' },
+		]);
+
+		expect(
+			await new SectionServiceImpl().listInSource(mock as never, 'Japan', 'irrelevant'),
+		).toEqual([
+			{ index: '1', level: 2, line: 'History', editable: true },
+			{ index: '2', level: 3, line: 'Feudal era', editable: true },
+		]);
+	});
+
+	// A template in the source expands to sections the caller did not write;
+	// the parser reports them with `T-` ids, exactly as on a stored page.
+	it('marks a template-expanded section as not editable', async () => {
+		const mock = mockWithSections([
+			{ index: '1', level: '2', line: 'History' },
+			{ index: 'T-1', level: '3', line: 'Transcluded child' },
+		]);
+
+		const result = await new SectionServiceImpl().listInSource(
+			mock as never,
+			'Japan',
+			'== History ==\n{{Probe}}',
+		);
+
+		expect(result[1]).toMatchObject({ index: 'T-1', editable: false });
+	});
+});
+
+describe('toOutlineLines', () => {
+	// The published outline is unchanged by this task: a leading empty string
+	// for the lead, then one heading line per section.
+	it('renders the lead as an empty first entry', () => {
+		expect(
+			toOutlineLines([
+				{ index: '1', level: 2, line: 'Etymology', editable: true },
+				{ index: '2', level: 2, line: 'History', editable: true },
+			]),
+		).toEqual(['', 'Etymology', 'History']);
+	});
+
+	it('renders a page with no headings as the lead alone', () => {
+		expect(toOutlineLines([])).toEqual(['']);
 	});
 });

--- a/tests/services/sectionSubtree.test.ts
+++ b/tests/services/sectionSubtree.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import type { SectionEntry } from '../../src/services/sectionService.ts';
+import { childrenOf } from '../../src/services/sectionSubtree.ts';
+
+const entry = (index: string, level: number, line: string): SectionEntry => ({
+	index,
+	level,
+	line,
+	editable: true,
+});
+
+// Mirrors en.wikipedia's Japan: History is a level-2 heading with three
+// level-3 children, followed by another level-2 heading.
+const outline: SectionEntry[] = [
+	entry('1', 2, 'Etymology'),
+	entry('2', 2, 'History'),
+	entry('3', 3, 'Prehistoric to classical history'),
+	entry('4', 3, 'Feudal era'),
+	entry('5', 3, 'Modern era'),
+	entry('6', 2, 'Geography'),
+];
+
+describe('childrenOf', () => {
+	it('returns the sections nested under a heading', () => {
+		expect(childrenOf(outline, '2').map((e) => e.line)).toEqual([
+			'Prehistoric to classical history',
+			'Feudal era',
+			'Modern era',
+		]);
+	});
+
+	it('stops at the next heading of the same level', () => {
+		expect(childrenOf(outline, '6')).toEqual([]);
+	});
+
+	it('returns nothing for a leaf section', () => {
+		expect(childrenOf(outline, '1')).toEqual([]);
+	});
+
+	it('returns nothing for a section that is not in the outline', () => {
+		expect(childrenOf(outline, '99')).toEqual([]);
+	});
+
+	// A deeper child of a child is still inside the subtree being replaced.
+	it('includes grandchildren', () => {
+		const deep = [
+			entry('1', 2, 'A'),
+			entry('2', 3, 'A-1'),
+			entry('3', 4, 'A-1-a'),
+			entry('4', 2, 'B'),
+		];
+		expect(childrenOf(deep, '1').map((e) => e.line)).toEqual(['A-1', 'A-1-a']);
+	});
+});

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -6,6 +6,7 @@ import { updatePage } from '../../src/tools/update-page.ts';
 import { dispatch } from '../../src/runtime/dispatcher.ts';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.ts';
 import { assertRefusedArgument, callTool } from '../helpers/callTool.ts';
+import type { SectionEntry } from '../../src/services/sectionService.ts';
 
 // The default fake EditService; each test spreads it and replaces only the
 // slice it exercises, so an unexpected call to another member still throws.
@@ -48,6 +49,38 @@ function fakeEdit(response: unknown = successResponse()) {
 		},
 	});
 	return { mock, request, submit, botRight, ctx };
+}
+
+const JAPAN_OUTLINE: SectionEntry[] = [
+	{ index: '1', level: 2, line: 'Etymology', editable: true },
+	{ index: '2', level: 2, line: 'History', editable: true },
+	{ index: '3', level: 3, line: 'Prehistoric to classical history', editable: true },
+	{ index: '4', level: 3, line: 'Feudal era', editable: true },
+	{ index: '5', level: 3, line: 'Modern era', editable: true },
+	{ index: '6', level: 2, line: 'Geography', editable: true },
+];
+
+// `sourceSections` is what the wiki's parser reports for the submitted source.
+// Left out, the call throws, so a test that reaches the source parse without
+// having stated what it returns fails loudly rather than passing by accident.
+function fakeEditWithOutline(
+	outline: SectionEntry[] = JAPAN_OUTLINE,
+	sourceSections?: SectionEntry[],
+) {
+	const base = fakeEdit();
+	const list = vi.fn().mockResolvedValue(outline);
+	const listInSource =
+		sourceSections === undefined
+			? vi.fn(() => {
+					throw new Error('fakeEditWithOutline: listInSource called but not stubbed');
+				})
+			: vi.fn().mockResolvedValue(sourceSections);
+	const ctx = fakeContext({
+		mwn: async () => base.mock as never,
+		edit: base.ctx.edit,
+		sections: { list, listInSource },
+	});
+	return { ...base, ctx, list, listInSource };
 }
 
 describe('update-page', () => {
@@ -195,7 +228,7 @@ describe('update-page', () => {
 
 	describe('section editing', () => {
 		it("forwards section=2 as section='2' with text=source", async () => {
-			const { submit, ctx } = fakeEdit();
+			const { submit, ctx } = fakeEditWithOutline([]);
 
 			const result = await updatePage.handle(
 				{
@@ -234,6 +267,9 @@ describe('update-page', () => {
 					submit: vi.fn().mockRejectedValue(new Error('nosuchsection: There is no section 99.')),
 					applyTags: <T extends Record<string, unknown>>(o: T) => ({ ...o }),
 				},
+				// Section 99 does not exist, so a real outline would not contain it
+				// either; the guard must not fire and it must not eat this error.
+				sections: { list: vi.fn().mockResolvedValue([]), listInSource: vi.fn() },
 			});
 
 			const result = await dispatch(
@@ -283,7 +319,7 @@ describe('update-page', () => {
 		// spelling cannot fail loudly here. What matters is that it never reaches
 		// the wiki as a sectiontitle parameter.
 		it('ignores a sectionTitle left over from the old spelling', async () => {
-			const { submit, ctx } = fakeEdit();
+			const { submit, ctx } = fakeEditWithOutline([]);
 
 			const result = await callTool(ctx, 'update-page', {
 				title: 'My Page',
@@ -297,7 +333,7 @@ describe('update-page', () => {
 		});
 
 		it('accepts a numeric section over a real MCP call', async () => {
-			const { submit, ctx } = fakeEdit();
+			const { submit, ctx } = fakeEditWithOutline([]);
 
 			const result = await callTool(ctx, 'update-page', {
 				title: 'My Page',
@@ -438,6 +474,256 @@ describe('update-page', () => {
 				appendtext: '\n* row',
 				bot: true,
 			});
+		});
+	});
+
+	describe('subsection guard', () => {
+		it('refuses a replace that would drop the subsections, naming them', async () => {
+			const { submit, ctx, listInSource } = fakeEditWithOutline(JAPAN_OUTLINE, [
+				{ index: '1', level: 2, line: 'History', editable: true },
+			]);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== History ==\nRewritten.',
+				section: 2,
+			});
+
+			const envelope = assertStructuredError(result, 'invalid_input');
+			expect(envelope.message).toContain('Feudal era');
+			expect(envelope.message).toContain('removeSubsections');
+			expect(submit).not.toHaveBeenCalled();
+			// The source the caller sent is what gets parsed, in the page's context.
+			expect(listInSource).toHaveBeenCalledWith(
+				expect.anything(),
+				'Japan',
+				'== History ==\nRewritten.',
+			);
+		});
+
+		it('allows a replace that carries the subsections back', async () => {
+			const { submit, ctx } = fakeEditWithOutline(JAPAN_OUTLINE, [
+				{ index: '1', level: 2, line: 'History', editable: true },
+				{ index: '2', level: 3, line: 'Prehistoric to classical history', editable: true },
+				{ index: '3', level: 3, line: 'Feudal era', editable: true },
+				{ index: '4', level: 3, line: 'Modern era', editable: true },
+			]);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source:
+					'== History ==\nIntro.\n\n=== Prehistoric to classical history ===\na\n\n=== Feudal era ===\nb\n\n=== Modern era ===\nc',
+				section: 2,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit).toHaveBeenCalledTimes(1);
+		});
+
+		// Counting rather than matching names is what lets a rename through.
+		it('allows a replace that renames a subsection', async () => {
+			const { submit, ctx } = fakeEditWithOutline(JAPAN_OUTLINE, [
+				{ index: '1', level: 2, line: 'History', editable: true },
+				{ index: '2', level: 3, line: 'Prehistory', editable: true },
+				{ index: '3', level: 3, line: 'Feudal period', editable: true },
+				{ index: '4', level: 3, line: 'Modern era', editable: true },
+			]);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source:
+					'== History ==\nIntro.\n\n=== Prehistory ===\na\n\n=== Feudal period ===\nb\n\n=== Modern era ===\nc',
+				section: 2,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit).toHaveBeenCalledTimes(1);
+		});
+
+		// A template in the source may expand to headings, but those are not
+		// content the caller wrote back — dropping three written subsections in
+		// favour of a template that renders three is still a removal.
+		it('does not count template-expanded headings as carried back', async () => {
+			const { submit, ctx } = fakeEditWithOutline(JAPAN_OUTLINE, [
+				{ index: '1', level: 2, line: 'History', editable: true },
+				{ index: 'T-1', level: 3, line: 'Expanded a', editable: false },
+				{ index: 'T-2', level: 3, line: 'Expanded b', editable: false },
+				{ index: 'T-3', level: 3, line: 'Expanded c', editable: false },
+			]);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== History ==\n{{ThreeHeadings}}',
+				section: 2,
+			});
+
+			assertStructuredError(result, 'invalid_input');
+			expect(submit).not.toHaveBeenCalled();
+		});
+
+		it('allows the destructive replace when removeSubsections is set', async () => {
+			const { submit, ctx } = fakeEditWithOutline();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== History ==\nRewritten.',
+				section: 2,
+				removeSubsections: true,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not guard a section that has no subsections', async () => {
+			const { submit, ctx, listInSource } = fakeEditWithOutline();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== Etymology ==\nRewritten.',
+				section: 1,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit).toHaveBeenCalledTimes(1);
+			// The source parse is the guard's second request; a leaf section must
+			// not pay for it.
+			expect(listInSource).not.toHaveBeenCalled();
+		});
+
+		// A transcluded heading can never appear as an `=` run in the host page's
+		// wikitext, so the guard must not ask for something the caller cannot
+		// supply. Mirrors en.wikipedia's Requests for adminship, where each
+		// nomination is a transcluded subsection of the Nominations heading.
+		it('does not guard a section whose children are all transcluded', async () => {
+			const outline: SectionEntry[] = [
+				{ index: '1', level: 2, line: 'Nominations', editable: true },
+				{ index: 'T-1', level: 3, line: 'Candidate A', editable: false },
+				{ index: 'T-2', level: 3, line: 'Candidate B', editable: false },
+				{ index: '2', level: 2, line: 'Closed', editable: true },
+			];
+			const { submit, ctx, listInSource } = fakeEditWithOutline(outline);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Wikipedia:Requests for adminship',
+				source: '== Nominations ==\nIntro.\n{{RfA/Candidate A}}\n{{RfA/Candidate B}}',
+				section: 1,
+			});
+
+			assertStructuredSuccess(result);
+			expect(submit).toHaveBeenCalledTimes(1);
+			expect(listInSource).not.toHaveBeenCalled();
+		});
+
+		it('guards on an editable child only, naming just that child, when a sibling child is transcluded', async () => {
+			const outline: SectionEntry[] = [
+				{ index: '1', level: 2, line: 'Nominations', editable: true },
+				{ index: '2', level: 3, line: 'Discussion', editable: true },
+				{ index: 'T-1', level: 3, line: 'Candidate A', editable: false },
+				{ index: '3', level: 2, line: 'Closed', editable: true },
+			];
+			const { submit, ctx } = fakeEditWithOutline(outline, [
+				{ index: '1', level: 2, line: 'Nominations', editable: true },
+			]);
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Wikipedia:Requests for adminship',
+				source: '== Nominations ==\nRewritten, dropping the discussion subsection.',
+				section: 1,
+			});
+
+			const envelope = assertStructuredError(result, 'invalid_input');
+			expect(envelope.message).toContain('Discussion');
+			expect(envelope.message).not.toContain('Candidate A');
+			expect(submit).not.toHaveBeenCalled();
+		});
+
+		// An append cannot remove existing content, so there is nothing to guard.
+		it('does not guard an append to a parent section', async () => {
+			const { ctx, list } = fakeEditWithOutline();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '\n\nMore.',
+				section: 2,
+				mode: 'append',
+			});
+
+			assertStructuredSuccess(result);
+			expect(list).not.toHaveBeenCalled();
+		});
+
+		it('does not fetch an outline for a full-page replace', async () => {
+			const { ctx, list } = fakeEditWithOutline();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: 'Whole new page.',
+			});
+
+			assertStructuredSuccess(result);
+			expect(list).not.toHaveBeenCalled();
+		});
+
+		// The lead has no heading; rvsection=0 addresses only the text above the
+		// first heading, so it can never contain a subsection.
+		it('does not guard the lead section', async () => {
+			const { ctx, list } = fakeEditWithOutline();
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: 'New lead.',
+				section: 0,
+			});
+
+			assertStructuredSuccess(result);
+			expect(list).not.toHaveBeenCalled();
+		});
+
+		// Failing closed means the edit must not proceed on a best-effort basis
+		// when the outline itself cannot be fetched.
+		it('fails closed and never submits when the outline fetch fails', async () => {
+			const { submit, ctx: base } = fakeEdit();
+			const ctx = fakeContext({
+				...base,
+				sections: {
+					list: vi.fn().mockRejectedValue(new Error('parse request failed')),
+					listInSource: vi.fn(),
+				},
+			});
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== History ==\nRewritten.',
+				section: 2,
+			});
+
+			const envelope = assertStructuredError(result, 'upstream_failure');
+			expect(envelope.message).toContain('parse request failed');
+			expect(submit).not.toHaveBeenCalled();
+		});
+
+		// The source parse is the guard's other request; its failure must not
+		// downgrade the guard to best-effort either.
+		it('fails closed and never submits when the source parse fails', async () => {
+			const { submit, ctx: base } = fakeEdit();
+			const ctx = fakeContext({
+				...base,
+				sections: {
+					list: vi.fn().mockResolvedValue(JAPAN_OUTLINE),
+					listInSource: vi.fn().mockRejectedValue(new Error('source parse failed')),
+				},
+			});
+
+			const result = await callTool(ctx, 'update-page', {
+				title: 'Japan',
+				source: '== History ==\nRewritten.',
+				section: 2,
+			});
+
+			const envelope = assertStructuredError(result, 'upstream_failure');
+			expect(envelope.message).toContain('source parse failed');
+			expect(submit).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/530

MediaWiki's `section=N` addresses a heading together with every subsection nested under it. Verified against en.wikipedia: `rvsection=2` on `Japan` returns 30491 bytes containing `== History ==` and its three `===` children. A caller that replaces section 2 with fresh History prose deletes those children, and nothing tells it so.

`update-page` now refuses that write:

> Section 2 (History) contains 3 subsections: Prehistoric to classical history, Feudal era, Modern era. The source supplied would remove them. Include them in source to keep them, or pass removeSubsections: true to remove them deliberately.

## The guard keys on the write, not on the target

It compares the subsections a section currently has against the headings the submitted `source` contains, and refuses only when the source has fewer. A replace that carries the subsections back is allowed, because refusing on the target's shape alone would also refuse the corrective write and make parent sections permanently uneditable.

Both sides of the comparison come from the wiki's own parser: the sections the page currently has, and the sections MediaWiki finds when parsing the submitted `source` (`action=parse` with `text=`). One parser decides what counts as a heading, so a heading-shaped line inside `<nowiki>` or a comment is not a section on either side, and sections a template in the source expands to carry `T-` ids and do not count as carried back — mirroring how transcluded children do not count as removable. Headings are counted, not matched by name, so renaming `=== Feudal era ===` to `=== Feudal period ===` passes while dropping all three does not.

The guard does not fire for `mode='append'`/`'prepend'` (a delta cannot remove content), for a section with no subsections, or for `section=0`. It costs one `prop=sections` request on section replaces, plus a parse of the submitted source only when the replaced section actually has subsections.

## Why this is not what #530 proposes

#530 proposes carrying `level` and `index` into the published outline as the fix. Measured, that makes the failure substantially worse. Three arms of 10, one model, single-shot, task = "replace the History section with exactly this text" on a page whose section 2 has three children:

| outline shown to the caller | destroys the subsections |
|---|---|
| flat and unnumbered (today) | 1/10 |
| nested, with real section numbers | 9/10 |
| nested, plus wording stating the subtree semantics | 9/10 |

The flat outline was protecting callers by accident: without reliable numbers they read the section first to work out which `N` to use. Give them a trustworthy number and they write directly. The callers were not confused — they removed the subsections deliberately, and said so.

So the ordering is inverted: the guard lands first, and publishing the structured outline is a separate change to be specced once this is in place. Nothing in this PR changes what `get-page` or `get-pages` publish — that output is byte-identical to master, which the tests lock in.

The description-only change in #531 is superseded by the same measurement: the wording arm moved nothing, because the models already know MediaWiki's section semantics from pretraining and cited the rule unprompted even in the flat-outline arm.

## Deliberate omissions

**The tool description does not mention `removeSubsections`.** A second run measured what a caller does after being refused: a refusal naming an override moved reconsideration from 10/10 to 8/10. The refusal message names it at the moment it is needed; advertising it up front makes it likelier to be reached. This is a measured decision, not an oversight.

**`section='new'`, transclusion, and the outline shape** are untouched here.

## Known limits

- **Re-parenting is invisible to counting.** A source replacing three children with three different ones passes. Inherent to counting rather than matching, which is what lets renames through.
- **Replacing the last section still swallows trailing categories and navboxes**, because the last section runs to end of page. The guard does not fire there — that section has no subsections. That is #534's family, not this one.
- **A parent heading rewritten at a deeper level counts as its own child.** A source opening with `=== History ===` where the page has `== History ==` inflates the carried-back count by one, potentially masking one dropped subsection. Pre-existing in both mechanisms; kin to the re-parenting limit.
- **MediaWiki-side parsing behaviour is pinned by live probes, not CI.** The suite mocks the wiki everywhere, so the tests cover the comparison and its wiring; that the parser ignores nowiki'd headings and tags template-expanded ones is the wiki's contract, verified against MediaWiki 1.43.6 directly.

## Verified

`lint`, `typecheck`, `fmt:check`, `build`, `check:mcp` and 1749 tests all exit 0. The CI tool-surface diff exits 0: `removeSubsections` is classified `non_breaking` and no property is removed.

- **Output neutrality proven independently**, by running master's formula against head's over payloads with a missing `line`, a missing `index`, a `T-` index, an empty parse and an absent response — byte-identical every time.
- **Tests survive mutation.** Reviewers killed 11 separate mutants across the branch, including two proving the outline-fetch spy watches the real production call, and one proving the fail-closed test dies if the fetch is wrapped in a swallowing `try/catch`.
- Two defects were caught in review and fixed here rather than shipped: a section with **transcluded** children was permanently uneditable, since a transcluded heading can never appear in the host page's wikitext; and heading-shaped text inside `<nowiki>` fooled an earlier regex-based count. That second class is closed structurally rather than case by case — the submitted source is parsed by the wiki itself, verified end to end: a destructive replace smuggling three nowiki'd fake headings is refused, and a replace carrying the real subsections back lands.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; designed and built at @alistair3149's request after he ruled out #531 as the fix; diff not yet human-reviewed; verification as above, across five per-task reviews, a whole-branch review and a scoped re-review, with findings folded in.</sub>
