### PR TITLE
Judge the conformance report instead of the exit code

### DIFF
--- a/scripts/mcp-checks.cjs
+++ b/scripts/mcp-checks.cjs
@@ -20,6 +20,24 @@ const PORT = Number(process.env.PORT) || 3117;
 const SERVER_URL = `http://127.0.0.1:${PORT}/mcp`;
 const STARTUP_TIMEOUT_MS = 15000;
 
+// Neither check can run against this server, and neither is a gap to close.
+// modern-undeclared-capability-error needs a tool that asks the caller for
+// input, so that it can prove the server rejects a client which never
+// declared that capability; this server has no such tool, and the check
+// bails before it contacts the server at all. modern-subscription-graceful-close
+// waits for the completion result a server sends when it tears a subscription
+// down, which this server does send on shutdown, but the check only aborts
+// its own end of the stream and so can never observe one.
+const TOLERATED_UNRUN_CHECKS = [
+	'modern-undeclared-capability-error',
+	'modern-subscription-graceful-close',
+];
+
+// A run that selected next to nothing establishes nothing, and the suite
+// reports exactly that as an incomplete run with an empty check list. Real
+// runs select 31 checks against a 2025-era suite and 36 against a 2026-era one.
+const MIN_SELECTED_CHECKS = 20;
+
 function runDoctor() {
 	console.log('\nRunning MCPJam server doctor (stdio)...');
 	const result = spawnSync(
@@ -148,10 +166,10 @@ async function runConformance() {
 				PROTOCOL_VERSION,
 				'--no-telemetry',
 			],
-			{ stdio: 'inherit' },
+			{ encoding: 'utf8' },
 		);
 
-		if (result.status !== 0) {
+		if (!reportConformance(result)) {
 			console.error('Server log:');
 			console.error(serverLog.join(''));
 			return false;
@@ -161,6 +179,89 @@ async function runConformance() {
 		child.kill('SIGTERM');
 		await exited;
 	}
+}
+
+// The suite withholds a verdict whenever a check could not run, so its exit
+// code reads the same for a server that violated the protocol and for a run
+// that proved nothing. Judge the report instead.
+function reportConformance(result) {
+	if (result.error) {
+		console.error(`Conformance failed to start: ${result.error.message}`);
+		return false;
+	}
+
+	let report;
+	try {
+		report = JSON.parse(result.stdout);
+	} catch {
+		console.error(`Conformance did not produce parseable JSON (exit ${result.status}):`);
+		console.error(result.stdout);
+		console.error(result.stderr);
+		return false;
+	}
+
+	const problems = judgeConformanceReport(report);
+	if (problems.length > 0) {
+		for (const problem of problems) {
+			console.error(`✗ ${problem}`);
+		}
+		console.error('Conformance report:');
+		console.error(result.stdout);
+		return false;
+	}
+
+	console.log(`✓ Conformance: ${report.summary}`);
+	const tolerated = unrunCheckIds(report).join(', ');
+	if (tolerated) {
+		console.log(`  Tolerated as unrunnable, so not asserted: ${tolerated}`);
+	}
+	return true;
+}
+
+// Returns one message per reason to reject the run, so an empty list is a pass.
+function judgeConformanceReport(report) {
+	const checks = Array.isArray(report?.checks) ? report.checks : [];
+	const problems = [];
+
+	if (checks.length < MIN_SELECTED_CHECKS) {
+		problems.push(
+			`the run selected ${checks.length} of the ${MIN_SELECTED_CHECKS} checks it takes to establish anything`,
+		);
+	}
+
+	for (const check of checks) {
+		if (check.status === 'failed') {
+			problems.push(`${check.id} failed: ${check.error?.message ?? 'no message given'}`);
+		}
+	}
+
+	for (const id of unrunCheckIds(report)) {
+		if (!TOLERATED_UNRUN_CHECKS.includes(id)) {
+			problems.push(`${id} could not run, so conformance is unproven`);
+		}
+	}
+
+	if (report?.outcome === undefined) {
+		// A 2025-era suite reports a bare boolean and no skip reasons, leaving
+		// its own verdict as the only thing to go on.
+		if (report?.passed !== true) {
+			problems.push('the run reported itself as not passed');
+		}
+		return problems;
+	}
+
+	// An incomplete outcome is tolerable only because every check that could
+	// not run has already been vetted against the allowlist above.
+	if (report.outcome !== 'passed' && report.outcome !== 'incomplete') {
+		problems.push(`the run outcome was ${report.outcome}`);
+	}
+
+	return problems;
+}
+
+function unrunCheckIds(report) {
+	const checks = Array.isArray(report?.checks) ? report.checks : [];
+	return checks.filter((check) => check.skipReason === 'could-not-run').map((check) => check.id);
 }
 
 async function main() {
@@ -181,7 +282,11 @@ async function main() {
 	console.log('\n✓ MCP checks passed');
 }
 
-main().catch((err) => {
-	console.error(`Unexpected error running MCP checks: ${err?.message ?? err}`);
-	process.exitCode = 1;
-});
+if (require.main === module) {
+	main().catch((err) => {
+		console.error(`Unexpected error running MCP checks: ${err?.message ?? err}`);
+		process.exitCode = 1;
+	});
+}
+
+module.exports = { judgeConformanceReport };

--- a/tests/scripts/mcp-checks.test.ts
+++ b/tests/scripts/mcp-checks.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+type ConformanceCheck = {
+	id: string;
+	status: string;
+	skipReason?: string;
+	error?: { message: string };
+};
+
+type ConformanceReport = {
+	passed?: boolean;
+	outcome?: string;
+	checks?: unknown;
+};
+
+const { judgeConformanceReport } = createRequire(import.meta.url)(
+	'../../scripts/mcp-checks.cjs',
+) as {
+	judgeConformanceReport: (report: unknown) => string[];
+};
+
+function passingChecks(count: number): ConformanceCheck[] {
+	return Array.from({ length: count }, (_, index) => ({
+		id: `check-${index}`,
+		status: 'passed',
+	}));
+}
+
+function unrunCheck(id: string): ConformanceCheck {
+	return {
+		id,
+		status: 'skipped',
+		skipReason: 'could-not-run',
+		error: { message: 'No inputRequiredProbe configured' },
+	};
+}
+
+// The shape a 2026-era SDK reports: a verdict plus a reason per skip.
+function modernReport(overrides: Partial<ConformanceReport> = {}): ConformanceReport {
+	return {
+		passed: true,
+		outcome: 'passed',
+		checks: passingChecks(36),
+		...overrides,
+	};
+}
+
+// The shape the currently pinned SDK reports: a bare boolean, no outcome
+// and no skip reasons.
+function legacyReport(overrides: Partial<ConformanceReport> = {}): ConformanceReport {
+	return {
+		passed: true,
+		checks: passingChecks(31),
+		...overrides,
+	};
+}
+
+describe('judgeConformanceReport', () => {
+	it('accepts a run that passed every check', () => {
+		expect(judgeConformanceReport(modernReport())).toEqual([]);
+	});
+
+	it('accepts an incomplete run whose unrunnable checks are all tolerated', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'incomplete',
+			checks: [
+				...passingChecks(34),
+				unrunCheck('modern-undeclared-capability-error'),
+				unrunCheck('modern-subscription-graceful-close'),
+			],
+		});
+
+		expect(judgeConformanceReport(report)).toEqual([]);
+	});
+
+	it('rejects an unrunnable check that is not tolerated', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'incomplete',
+			checks: [
+				...passingChecks(34),
+				unrunCheck('modern-undeclared-capability-error'),
+				unrunCheck('modern-some-future-obligation'),
+			],
+		});
+
+		expect(judgeConformanceReport(report)).toEqual([
+			expect.stringContaining('modern-some-future-obligation'),
+		]);
+	});
+
+	it('rejects a check that failed', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'failed',
+			checks: [
+				...passingChecks(35),
+				{
+					id: 'post-response-content-type',
+					status: 'failed',
+					error: { message: 'unexpected content type text/plain' },
+				},
+			],
+		});
+
+		expect(judgeConformanceReport(report)).toContainEqual(
+			expect.stringContaining('post-response-content-type'),
+		);
+	});
+
+	it('rejects a run whose outcome is neither passed nor incomplete', () => {
+		expect(judgeConformanceReport(modernReport({ passed: false, outcome: 'failed' }))).toEqual([
+			expect.stringContaining('failed'),
+		]);
+	});
+
+	it('rejects a run that selected almost no checks', () => {
+		expect(judgeConformanceReport(modernReport({ checks: [] }))).toEqual([
+			expect.stringContaining('0 of the'),
+		]);
+	});
+
+	it('rejects a report carrying no checks at all', () => {
+		expect(judgeConformanceReport({ passed: true })).not.toEqual([]);
+	});
+
+	it('accepts a legacy report that reports itself as passed', () => {
+		expect(judgeConformanceReport(legacyReport())).toEqual([]);
+	});
+
+	it('rejects a legacy report that reports itself as not passed', () => {
+		expect(judgeConformanceReport(legacyReport({ passed: false }))).not.toEqual([]);
+	});
+});


### PR DESCRIPTION
The MCPJam conformance suite withholds its verdict whenever a check could not run, and exits with the same code it uses for a protocol violation. Two checks can never run against this server, so the exit code alone turns a clean run red.

Neither check reflects a gap to close. One needs a tool that asks the caller for input, so that it can prove the server rejects a client which never declared that capability, and it gives up before it contacts the server at all. The other waits for the completion result a server sends when it tears a subscription down, which this server does send on shutdown, but the check only aborts its own end of the stream and so can never observe one.

Parse the report and judge it instead: fail on any check that failed, on any check that could not run beyond those two, and on a run too small to establish anything. That last guard matters because the suite reports an empty check list as an incomplete run, which an allowlist alone would wave through as a pass.

A run now also names the checks it tolerated, so a green result is not mistaken for full conformance.

## Why this is needed

`mcp-checks` is red on #528. The visible bump there is `@mcpjam/cli` 3.16.0 to 3.17.0, but the conformance suite lives in `@mcpjam/sdk`, which the CLI depends on through a caret range. 3.17.0 only widens that range, so the lockfile re-resolves the SDK 2.1.0 to 2.4.0, and 2.4.0 changed `passed` from "no check failed" to "the outcome is passed". That run reports **0 failed checks**.

This is not specific to #528. `package.json` declares `^3.16.0` with no `overrides`, so any lockfile regeneration picks up SDK 2.4.0 and turns the job red with no bump involved. Master is green only because `npm ci` replays a lock that happens to pin 2.1.0.

## Verified

- `npm run check:mcp` exits 0 under CLI 3.16.0/SDK 2.1.0 (this branch as it stands), and under 3.17.0/2.4.0 and 3.19.0/2.4.0 in throwaway copies. The raw CLI exits 1 and 3 respectively in those last two.
- Emptying the allowlist makes it exit 1 naming both checks, so the allowlist is what makes it green rather than a vacuous parse.
- New unit tests cover the injected-failure, non-allowlisted, empty-report and legacy-report paths. Written first and seen failing.
- `npm run preflight` green; 1753 tests pass.

**CI on this PR does not exercise the new path.** The branch still pins SDK 2.1.0, whose report carries no `outcome` and no skip reasons, so CI takes the legacy branch of the judge. The 2.4.0 path was only verified locally.

## What you need to decide

Whether to retarget #528 at 3.19.0 rather than 3.17.0. 3.19.0 is current, and upstream added the distinct `incomplete` exit code 3 there. Either version goes green once this merges; 3.19.0 alone without this change does not, it only turns exit 1 into exit 3.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; one-line ask from @alistair3149 to investigate the CI failure, fix approach then chosen from offered options, no revisions; diff not yet human-reviewed; tests written TDD and run locally, preflight green, newer-SDK path verified in local copies only.</sub>
