### PR TITLE
Stop declaring update-page idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `update-page` no longer creates sections: `section='new'` and `sectionTitle` are removed. Add a section with `mode='append'` and a source that begins with the heading, as in `"\n\n== History ==\n\nBody."`. A call still sending `section='new'` is refused with a message naming the replacement.
 - `update-page` now refuses a `section=N` replace whose source would delete the subsections nested under that section, which MediaWiki replaces along with it. Include the subsections in `source` to keep them, or pass `removeSubsections: true` to remove them deliberately. Appends, full-page replaces, and sections with no subsections are unaffected.
 
+### Fixed
+
+- `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
+
 ## [0.16.0] - 2026-07-30
 
 ### Security

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -169,6 +169,7 @@ Semantics (from the MCP 2025-11-25 spec):
 - Pure read-only tools: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: true` (for tools that read from the wiki).
 - Write tools that delete, overwrite, or remove: `readOnlyHint: false`, `destructiveHint: true`.
 - Write tools that only add (create, append, upload-new): `readOnlyHint: false`, `destructiveHint: false`.
+- If idempotency depends on which parameters a call uses (an `update-page` full-page replace is idempotent; `mode='append'` is not), declare the weakest case: `idempotentHint: false`.
 - If the tool does not make network calls and only mutates server-local state (e.g. `add-wiki` / `remove-wiki` editing the wiki registry), `openWorldHint: false`.
 
 #### Tool titles

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -136,13 +136,13 @@ async function subsectionRemovalError(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next.",
+		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next. Resending a mode='append' or 'prepend' call whose result never arrived adds the delta a second time.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',
 		readOnlyHint: false,
 		destructiveHint: true,
-		idempotentHint: true,
+		idempotentHint: false,
 		openWorldHint: true,
 	},
 	failureVerb: 'update page',


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/535

`update-page` declared `idempotentHint: true` for the whole tool, but the hint is per-tool while the behaviour is per-call: a full-page replace resends the same content, whereas `mode='append'`/`'prepend'` sends `appendtext`/`prependtext`, so a replayed call adds the delta twice. The tool now declares the weakest case.

Companion changes: `docs/tool-conventions.md` gains the rule its decision guide was missing (when idempotency depends on which parameters a call uses, declare the weakest case); the tool description gains one sentence, since the annotation is read by client code and the description by the model; `CHANGELOG.md` gains a `### Fixed` entry.

Swept the other 45 descriptors — no other tool has parameter-dependent idempotency, so the new rule costs no further changes. No test changes: nothing in `src/` reads `idempotentHint` (only `readOnlyHint`, in `src/runtime/wikiCapability.ts`), no behaviour changed, and no test asserts any hint value today.

Considered, omitted:

- Splitting append/prepend into its own tool (issue option 2). Keeps a true hint for the replace path, but re-expands the tool surface that #533 just shrank, to buy a hint nothing is shown to read.
- Requiring `latestId` when `mode` is set (issue option 3). It does work, which the issue left open: `baserevid` reaches `EditPage` for append and prepend edits, same-user conflict suppression cannot fire because the API omits `wpEdittime` whenever `baserevid` is set, and running MediaWiki's own `wfMerge()` over 13 replay scenarios refused every realistic append and prepend replay as an edit conflict. Omitted because it makes `latestId` conditionally required — a second breaking schema change straight after #533, plus a round trip per append — and rests the guarantee on diff3 declining a merge rather than on a documented API contract.

Verified: lint, typecheck, format check, 1753 tests, build and `npm run check:mcp` all pass. `tools/list` over stdio reports `idempotentHint: false` for `update-page`, carrying the new description.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; one-line ask from @alistair3149, who chose this option from a written comparison of the four the issue lists; diff not yet human-reviewed; no tests added (annotation and prose only), full local gate green and the served tool list checked over stdio.</sub>

<details><summary>Production notes</summary>

Every MediaWiki claim above was reproduced against a local MediaWiki 1.43.8 install rather than cited: the `baserevid` and conflict-suppression paths by reading `ApiEditPage`/`EditPage`, and the replay outcomes by calling `wfMerge()` directly on base/current/replay text triples.

</details>
