### PR TITLE
Send a bodyless GET after a 301, 302 or 303 redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- A redirected `POST` now continues the way the redirect status asks: a `301`, `302` or `303` becomes a GET with no body, where every hop used to re-send the original method and body and the target rejected it. This is reachable through a configured `sparqlEndpoint` that redirects, such as an `http` URL or a bare host. A `307` or `308` still re-sends the method and body.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- A redirected `POST` now continues the way the redirect status asks: a `301`, `302` or `303` becomes a GET with no body, where every hop used to re-send the original method and body and the target rejected it. This is reachable through a configured `sparqlEndpoint` that redirects, such as an `http` URL or a bare host. A `307` or `308` still re-sends the method and body.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/src/tools/extensions/wikibase/sparql.ts
+++ b/src/tools/extensions/wikibase/sparql.ts
@@ -1,5 +1,10 @@
 import type { ErrorCategory } from '../../../errors/classifyError.ts';
-import { FileTooLargeError, HttpStatusError, postForm } from '../../../transport/httpFetch.ts';
+import {
+	FileTooLargeError,
+	HttpStatusError,
+	postForm,
+	RedirectDropsBodyError,
+} from '../../../transport/httpFetch.ts';
 import { getRequestSignal } from '../../../runtime/requestContext.ts';
 
 /** Matches the query timeout most Wikibase query services enforce themselves. */
@@ -134,6 +139,12 @@ function renderRow(binding: unknown, columns: string[]): string {
 }
 
 function classifyQueryFailure(err: unknown, endpoint: string): SparqlError {
+	if (err instanceof RedirectDropsBodyError) {
+		return new SparqlError(
+			'upstream_failure',
+			`The query service redirected the query to ${originOf(err.target)} instead of answering it (HTTP ${err.status}), and a SPARQL query cannot survive that redirect. The wiki advertises this endpoint in its siteinfo as \`wikibase-sparql\`, so its operator has to point that at an address which answers directly.`,
+		);
+	}
 	if (err instanceof HttpStatusError) {
 		return new SparqlError(categoryForStatus(err.status), serviceMessage(err, endpoint));
 	}
@@ -151,6 +162,17 @@ function classifyQueryFailure(err: unknown, endpoint: string): SparqlError {
 	}
 	const message = err instanceof Error ? err.message : String(err);
 	return new SparqlError('upstream_failure', withoutEndpoint(message, endpoint));
+}
+
+/**
+ * Scheme and host of a redirect target, without its path or query. A target
+ * derived from the endpoint inherits whatever the endpoint carries, and differing
+ * in scheme it is not a substring `withoutEndpoint` can find — so the parts that
+ * can hold a token are dropped rather than substituted. Scheme and host are what
+ * an operator needs to recognise the redirect, and hold no credentials.
+ */
+function originOf(target: string): string {
+	return new URL(target).origin;
 }
 
 /**

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -41,6 +41,23 @@ function resolveUploadMaxBytes(): number {
 	return parsed;
 }
 
+/**
+ * A redirect asked for the request to be re-sent without its body. `target` is
+ * the absolute URL that was not followed; it is kept off the message, because a
+ * URL derived from a configured endpoint can carry that endpoint's credentials,
+ * and the message reaches both the caller and the logs.
+ */
+export class RedirectDropsBodyError extends Error {
+	public readonly status: number;
+	public readonly target: string;
+	public constructor(status: number, target: string) {
+		super(`Refusing to follow an HTTP ${status} redirect: it would drop the request body.`);
+		this.name = 'RedirectDropsBodyError';
+		this.status = status;
+		this.target = target;
+	}
+}
+
 /** A fetched URL responded with a non-2xx status: the source was reachable but rejected the request. */
 export class HttpStatusError extends Error {
 	public readonly status: number;
@@ -71,33 +88,16 @@ export class FileTooLargeError extends Error {
 // Only 307 and 308 ask for the original method and body again. RFC 9110 defines
 // a 303 as a GET on another resource, and browsers and every mainstream client
 // treat 301 and 302 the same way, which the Fetch standard writes down as a
-// rule. The requests this module sends are GET and POST, for which every status
-// but those two means GET; a caller sending PUT or DELETE would need the status
-// paired with the method, since 301 and 302 redirect only a POST.
+// rule: re-send as a GET, with no body.
+//
+// A body is the whole request for the one caller that sends one — a SPARQL query
+// travels in it — so following such a redirect would send a request that cannot
+// answer, and report whatever the target said about it instead of the redirect.
+// This module refuses that hop rather than performing it. Every other request it
+// sends is already a bodyless GET, which a redirect of any of these statuses
+// leaves unchanged; a caller that sent a bodyless POST would need the method
+// downgrade this deliberately does not implement.
 const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
-
-function downgradesToGet(status: number): boolean {
-	return !METHOD_PRESERVING_REDIRECTS.has(status);
-}
-
-// Headers that describe a request body go when the body goes: a bodyless GET
-// announcing a Content-Type describes something it is not sending. Fetch leaves
-// Content-Length out of this list because there the fetch layer always owns it;
-// node-fetch recomputes it only for a request that has a body, so a value a
-// caller set survives onto the bodyless GET unless it goes here too.
-const BODY_HEADERS = new Set([
-	'content-encoding',
-	'content-language',
-	'content-length',
-	'content-location',
-	'content-type',
-]);
-
-function withoutBodyHeaders(headers: Record<string, string>): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(headers).filter(([name]) => !BODY_HEADERS.has(name.toLowerCase())),
-	);
-}
 
 async function fetchCore(
 	baseUrl: string,
@@ -122,7 +122,7 @@ async function fetchCore(
 		}
 	}
 
-	let requestHeaders: Record<string, string> = {
+	const requestHeaders: Record<string, string> = {
 		'User-Agent': USER_AGENT,
 	};
 
@@ -131,8 +131,6 @@ async function fetchCore(
 	}
 
 	let currentUrl = url;
-	let currentMethod = options?.method || 'GET';
-	let currentBody = options?.body;
 	let response: Response | undefined;
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		const addresses = await assertPublicDestination(currentUrl);
@@ -146,8 +144,8 @@ async function fetchCore(
 		options?.signal?.throwIfAborted();
 		response = await fetch(currentUrl, {
 			headers: requestHeaders,
-			method: currentMethod,
-			...(currentBody !== undefined ? { body: currentBody } : {}),
+			method: options?.method || 'GET',
+			...(options?.body !== undefined ? { body: options.body } : {}),
 			redirect: 'manual',
 			agent,
 			signal: options?.signal,
@@ -167,12 +165,11 @@ async function fetchCore(
 		}
 
 		currentUrl = new URL(location, currentUrl).toString();
-		// A downgrade holds for the rest of the chain: once the request is a
-		// bodyless GET, a later 307 has a bodyless GET to preserve.
-		if (downgradesToGet(response.status)) {
-			currentMethod = 'GET';
-			currentBody = undefined;
-			requestHeaders = withoutBodyHeaders(requestHeaders);
+		// Checked every hop, not just the first: a 307 that preserves the body can
+		// be followed by a 303 that would drop it.
+		if (options?.body !== undefined && !METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+			destroyBody(response);
+			throw new RedirectDropsBodyError(response.status, currentUrl);
 		}
 	}
 

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -67,6 +67,27 @@ export class FileTooLargeError extends Error {
 	}
 }
 
+// Only 307 and 308 ask for the original method and body again: RFC 9110 makes a
+// 303 a bodyless GET, and 301 and 302 are treated the same way. The requests
+// this module sends are GET and POST, for which every other status means GET; a
+// caller sending PUT or DELETE would need the status paired with the method.
+const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
+
+// Headers that describe a request body go when the body goes: a bodyless GET
+// announcing a Content-Type describes something it is not sending.
+const BODY_HEADERS = new Set([
+	'content-encoding',
+	'content-language',
+	'content-location',
+	'content-type',
+]);
+
+function withoutBodyHeaders(headers: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([name]) => !BODY_HEADERS.has(name.toLowerCase())),
+	);
+}
+
 async function fetchCore(
 	baseUrl: string,
 	options?: {
@@ -90,7 +111,7 @@ async function fetchCore(
 		}
 	}
 
-	const requestHeaders: Record<string, string> = {
+	let requestHeaders: Record<string, string> = {
 		'User-Agent': USER_AGENT,
 	};
 
@@ -99,6 +120,8 @@ async function fetchCore(
 	}
 
 	let currentUrl = url;
+	let currentMethod = options?.method || 'GET';
+	let currentBody = options?.body;
 	let response: Response | undefined;
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		const addresses = await assertPublicDestination(currentUrl);
@@ -112,8 +135,8 @@ async function fetchCore(
 		options?.signal?.throwIfAborted();
 		response = await fetch(currentUrl, {
 			headers: requestHeaders,
-			method: options?.method || 'GET',
-			...(options?.body !== undefined ? { body: options.body } : {}),
+			method: currentMethod,
+			...(currentBody !== undefined ? { body: currentBody } : {}),
 			redirect: 'manual',
 			agent,
 			signal: options?.signal,
@@ -133,6 +156,13 @@ async function fetchCore(
 		}
 
 		currentUrl = new URL(location, currentUrl).toString();
+		// A downgrade holds for the rest of the chain: once the request is a
+		// bodyless GET, a later 307 has a bodyless GET to preserve.
+		if (!METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+			currentMethod = 'GET';
+			currentBody = undefined;
+			requestHeaders = withoutBodyHeaders(requestHeaders);
+		}
 	}
 
 	// response is always assigned inside the loop (loop runs at least once).

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -67,17 +67,27 @@ export class FileTooLargeError extends Error {
 	}
 }
 
-// Only 307 and 308 ask for the original method and body again: RFC 9110 makes a
-// 303 a bodyless GET, and 301 and 302 are treated the same way. The requests
-// this module sends are GET and POST, for which every other status means GET; a
-// caller sending PUT or DELETE would need the status paired with the method.
+// Only 307 and 308 ask for the original method and body again. RFC 9110 defines
+// a 303 as a GET on another resource, and browsers and every mainstream client
+// treat 301 and 302 the same way, which the Fetch standard writes down as a
+// rule. The requests this module sends are GET and POST, for which every status
+// but those two means GET; a caller sending PUT or DELETE would need the status
+// paired with the method, since 301 and 302 redirect only a POST.
 const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
 
+function downgradesToGet(status: number): boolean {
+	return !METHOD_PRESERVING_REDIRECTS.has(status);
+}
+
 // Headers that describe a request body go when the body goes: a bodyless GET
-// announcing a Content-Type describes something it is not sending.
+// announcing a Content-Type describes something it is not sending. Fetch leaves
+// Content-Length out of this list because there the fetch layer always owns it;
+// node-fetch recomputes it only for a request that has a body, so a value a
+// caller set survives onto the bodyless GET unless it goes here too.
 const BODY_HEADERS = new Set([
 	'content-encoding',
 	'content-language',
+	'content-length',
 	'content-location',
 	'content-type',
 ]);
@@ -158,7 +168,7 @@ async function fetchCore(
 		currentUrl = new URL(location, currentUrl).toString();
 		// A downgrade holds for the rest of the chain: once the request is a
 		// bodyless GET, a later 307 has a bodyless GET to preserve.
-		if (!METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+		if (downgradesToGet(response.status)) {
 			currentMethod = 'GET';
 			currentBody = undefined;
 			requestHeaders = withoutBodyHeaders(requestHeaders);

--- a/tests/tools/extensions/wikibase/sparql.test.ts
+++ b/tests/tools/extensions/wikibase/sparql.test.ts
@@ -12,6 +12,7 @@ import {
 	FileTooLargeError,
 	HttpStatusError,
 	postForm,
+	RedirectDropsBodyError,
 } from '../../../../src/transport/httpFetch.ts';
 import { runSparqlQuery, SparqlError } from '../../../../src/tools/extensions/wikibase/sparql.ts';
 import { withRequestFields } from '../../../../src/runtime/requestContext.ts';
@@ -267,6 +268,34 @@ describe('runSparqlQuery', () => {
 		vi.mocked(postForm).mockRejectedValue(new FileTooLargeError(20_000_000, 10_485_760));
 
 		expect((await failureOf(runSparqlQuery(ENDPOINT, CATS, MANY_ROWS))).message).toContain('10 MB');
+	});
+
+	it('says which setting to change when the query service redirects the query', async () => {
+		vi.mocked(postForm).mockRejectedValue(
+			new RedirectDropsBodyError(303, 'https://elsewhere.example.org/sparql'),
+		);
+
+		const error = await failureOf(runSparqlQuery(ENDPOINT, CATS, MANY_ROWS));
+
+		expect(error.category).toBe('upstream_failure');
+		expect(error.message).toContain('303');
+		expect(error.message).toContain('wikibase-sparql');
+	});
+
+	// A redirect target derived from the endpoint inherits its credentials, and
+	// differing in scheme it is not a substring the endpoint substitution finds.
+	// Scheme and host are what identifies the redirect and carry no token.
+	it('names the redirect target by scheme and host only, not by its path or query', async () => {
+		const secret = 'http://query.example.org/sparql?token=hunter2';
+		vi.mocked(postForm).mockRejectedValue(
+			new RedirectDropsBodyError(301, 'https://query.example.org/sparql?token=hunter2'),
+		);
+
+		const error = await failureOf(runSparqlQuery(secret, CATS, MANY_ROWS));
+
+		expect(error.message).toContain('https://query.example.org');
+		expect(error.message).not.toContain('hunter2');
+		expect(error.message).not.toContain('/sparql');
 	});
 
 	// The endpoint is the operator's to know, and it can carry a token in its path

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -21,7 +21,12 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 
 import { createServer, type Server } from 'node:http';
 import type { Socket } from 'node:net';
-import { fetchFileBytes, postForm, FileTooLargeError } from '../../src/transport/httpFetch.ts';
+import {
+	fetchFileBytes,
+	postForm,
+	FileTooLargeError,
+	RedirectDropsBodyError,
+} from '../../src/transport/httpFetch.ts';
 
 let server: Server;
 let origin: string;
@@ -50,6 +55,16 @@ beforeAll(async () => {
 		if (req.url === '/streams-too-much') {
 			res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
 			res.write('x'.repeat(64));
+			return;
+		}
+		// A redirect whose own body stalls the same way, for the refusal that
+		// declines to re-send a request body across it.
+		if (req.url === '/redirect-and-stall') {
+			res.writeHead(301, {
+				Location: '/small',
+				'Content-Length': String(50 * 1024 * 1024),
+			});
+			res.write('x');
 			return;
 		}
 		// Anything else is a test asking for a route that does not exist. Refusing
@@ -117,6 +132,15 @@ describe('an over-cap body refused against a real server', () => {
 		);
 
 		expect(failure).toBeInstanceOf(FileTooLargeError);
+		expect(await connectionClosed(servingSocket)).toBe(true);
+	});
+
+	it('closes the connection behind a redirect it refuses to follow', async () => {
+		const failure = await postForm(`${origin}/redirect-and-stall`, {
+			query: 'SELECT ?x WHERE {}',
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(RedirectDropsBodyError);
 		expect(await connectionClosed(servingSocket)).toBe(true);
 	});
 

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+/**
+ * What a redirect target actually receives is the subject here, so this file
+ * runs the REAL node-fetch against a real loopback server that records the
+ * method, body and headers of every request it serves. Only the SSRF guard is
+ * stubbed, since a loopback destination is what a local test server is.
+ */
+vi.mock('../../src/transport/ssrfGuard.ts', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/ssrfGuard.ts')>(
+		'../../src/transport/ssrfGuard.ts',
+	);
+	return {
+		...actual,
+		assertPublicDestination: vi.fn(async () => [{ address: '127.0.0.1', family: 4 }]),
+		buildPinnedAgent: vi.fn(() => undefined),
+	};
+});
+
+import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
+import { makeApiRequest, postForm } from '../../src/transport/httpFetch.ts';
+
+type ServedRequest = {
+	method: string;
+	url: string;
+	body: string;
+	headers: IncomingHttpHeaders;
+};
+
+const FORM = { query: 'SELECT ?x WHERE {}' };
+const ENCODED_FORM = 'query=SELECT+%3Fx+WHERE+%7B%7D';
+
+let server: Server;
+let origin: string;
+let served: ServedRequest[] = [];
+
+/**
+ * `/redirect/<status>/<rest>` answers with that status and `Location: /<rest>`,
+ * so `/redirect/302/redirect/307/sparql` is a two-hop chain. Any other path is
+ * a target and answers 200.
+ */
+beforeAll(async () => {
+	server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (chunk: Buffer) => chunks.push(chunk));
+		req.on('end', () => {
+			served.push({
+				method: req.method ?? '',
+				url: req.url ?? '',
+				body: Buffer.concat(chunks).toString('utf8'),
+				headers: req.headers,
+			});
+			const hop = /^\/redirect\/(\d{3})\/(.+)$/.exec(req.url ?? '');
+			if (hop) {
+				res.writeHead(Number(hop[1]), { Location: `/${hop[2]}` });
+				res.end('redirect notice');
+				return;
+			}
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end('{"ok":true}');
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	origin = `http://127.0.0.1:${typeof address === 'object' && address !== null ? address.port : 0}`;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+	served = [];
+});
+
+function methodsAndBodies(): { method: string; body: string }[] {
+	return served.map(({ method, body }) => ({ method, body }));
+}
+
+function target(): ServedRequest {
+	return served[served.length - 1];
+}
+
+describe('redirected requests', () => {
+	it.each([301, 302, 303])(
+		'sends a bodyless GET to the target of a %i redirect',
+		async (status) => {
+			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+
+			expect(result).toBe('{"ok":true}');
+			expect(methodsAndBodies()).toEqual([
+				{ method: 'POST', body: ENCODED_FORM },
+				{ method: 'GET', body: '' },
+			]);
+		},
+	);
+
+	it.each([307, 308])(
+		're-sends the POST and its body to the target of a %i redirect',
+		async (status) => {
+			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+
+			expect(result).toBe('{"ok":true}');
+			expect(methodsAndBodies()).toEqual([
+				{ method: 'POST', body: ENCODED_FORM },
+				{ method: 'POST', body: ENCODED_FORM },
+			]);
+		},
+	);
+
+	it('stops describing a body the downgraded request no longer carries', async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM);
+
+		expect(target().headers['content-type']).toBeUndefined();
+		expect(target().headers['content-length']).toBeUndefined();
+	});
+
+	it('keeps the form content type on a hop that still sends the body', async () => {
+		await postForm(`${origin}/redirect/307/sparql`, FORM);
+
+		expect(target().headers['content-type']).toBe('application/x-www-form-urlencoded');
+	});
+
+	it('keeps a caller header unrelated to the body across a downgrade', async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+			headers: { Accept: 'application/sparql-results+json' },
+		});
+
+		expect(target().headers.accept).toBe('application/sparql-results+json');
+	});
+
+	it('does not resurrect the body when a later hop preserves the method', async () => {
+		await postForm(`${origin}/redirect/302/redirect/307/sparql`, FORM);
+
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
+	});
+
+	it('downgrades a preserved POST at the hop that asks for it', async () => {
+		await postForm(`${origin}/redirect/307/redirect/302/sparql`, FORM);
+
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'GET', body: '' },
+		]);
+	});
+
+	it('leaves a redirected GET a GET, query string and all', async () => {
+		const result = await makeApiRequest<{ ok: boolean }>(`${origin}/redirect/301/w/api.php`, {
+			action: 'query',
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
+		expect(target().url).toBe('/w/api.php?action=query');
+	});
+});

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -115,6 +115,20 @@ describe('redirected requests', () => {
 		expect(target().headers['content-length']).toBeUndefined();
 	});
 
+	it("drops the caller's other body-describing headers across a downgrade", async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+			headers: {
+				'Content-Encoding': 'identity',
+				'Content-Language': 'en',
+				'Content-Location': '/sparql',
+			},
+		});
+
+		expect(target().headers['content-encoding']).toBeUndefined();
+		expect(target().headers['content-language']).toBeUndefined();
+		expect(target().headers['content-location']).toBeUndefined();
+	});
+
 	it('keeps the form content type on a hop that still sends the body', async () => {
 		await postForm(`${origin}/redirect/307/sparql`, FORM);
 

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -120,12 +120,17 @@ describe('redirected requests', () => {
 			headers: {
 				'Content-Encoding': 'identity',
 				'Content-Language': 'en',
+				// node-fetch recomputes Content-Length only for a request that has
+				// a body, so a caller's value reaches the downgraded GET unless the
+				// downgrade removes it.
+				'Content-Length': '25',
 				'Content-Location': '/sparql',
 			},
 		});
 
 		expect(target().headers['content-encoding']).toBeUndefined();
 		expect(target().headers['content-language']).toBeUndefined();
+		expect(target().headers['content-length']).toBeUndefined();
 		expect(target().headers['content-location']).toBeUndefined();
 	});
 

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -18,7 +18,12 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 });
 
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
-import { makeApiRequest, postForm } from '../../src/transport/httpFetch.ts';
+import {
+	makeApiRequest,
+	postForm,
+	HttpStatusError,
+	RedirectDropsBodyError,
+} from '../../src/transport/httpFetch.ts';
 
 type ServedRequest = {
 	method: string;
@@ -50,6 +55,19 @@ beforeAll(async () => {
 				body: Buffer.concat(chunks).toString('utf8'),
 				headers: req.headers,
 			});
+			// A 3xx with no Location at all, which is not a redirect to follow.
+			if (req.url === '/locationless') {
+				res.writeHead(302);
+				res.end('going nowhere');
+				return;
+			}
+			// A target carrying a credential, which a query-service URL can do and
+			// the refusal must keep out of its message.
+			if (req.url === '/redirect-to-token') {
+				res.writeHead(301, { Location: '/sparql?token=hunter2' });
+				res.end('redirect notice');
+				return;
+			}
 			const hop = /^\/redirect\/(\d{3})\/(.+)$/.exec(req.url ?? '');
 			if (hop) {
 				res.writeHead(Number(hop[1]), { Location: `/${hop[2]}` });
@@ -81,19 +99,47 @@ function target(): ServedRequest {
 	return served[served.length - 1];
 }
 
+async function refusalFrom(url: string): Promise<RedirectDropsBodyError> {
+	const error = await postForm(url, FORM).catch((err: unknown) => err);
+	expect(error).toBeInstanceOf(RedirectDropsBodyError);
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pinned by the assertion above
+	return error as RedirectDropsBodyError;
+}
+
 describe('redirected requests', () => {
 	it.each([301, 302, 303])(
-		'sends a bodyless GET to the target of a %i redirect',
+		'refuses a %i redirect of a request that carries a body',
 		async (status) => {
-			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+			const error = await refusalFrom(`${origin}/redirect/${status}/sparql`);
 
-			expect(result).toBe('{"ok":true}');
-			expect(methodsAndBodies()).toEqual([
-				{ method: 'POST', body: ENCODED_FORM },
-				{ method: 'GET', body: '' },
-			]);
+			expect(error.status).toBe(status);
+			// The first hop went out whole; the target was never contacted, so the
+			// refusal is not a request that quietly lost what it was carrying.
+			expect(methodsAndBodies()).toEqual([{ method: 'POST', body: ENCODED_FORM }]);
 		},
 	);
+
+	it('names the redirect target it refused to follow, resolved absolutely', async () => {
+		const error = await refusalFrom(`${origin}/redirect/301/sparql`);
+
+		expect(error.target).toBe(`${origin}/sparql`);
+	});
+
+	it('keeps the refused target out of the message, which reaches the caller and the logs', async () => {
+		const error = await refusalFrom(`${origin}/redirect-to-token`);
+
+		expect(error.target).toBe(`${origin}/sparql?token=hunter2`);
+		expect(error.message).not.toContain('hunter2');
+		expect(error.message).not.toContain(origin);
+		expect(error.message).toContain('301');
+	});
+
+	it('reports a 3xx carrying no Location as the status it is, not as a refusal', async () => {
+		const error = await postForm(`${origin}/locationless`, FORM).catch((err: unknown) => err);
+
+		expect(error).toBeInstanceOf(HttpStatusError);
+		expect(error).not.toBeInstanceOf(RedirectDropsBodyError);
+	});
 
 	it.each([307, 308])(
 		're-sends the POST and its body to the target of a %i redirect',
@@ -108,30 +154,26 @@ describe('redirected requests', () => {
 		},
 	);
 
-	it('stops describing a body the downgraded request no longer carries', async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM);
+	it('re-sends the body across a chain of preserving hops', async () => {
+		const result = await postForm(`${origin}/redirect/307/redirect/308/sparql`, FORM);
 
-		expect(target().headers['content-type']).toBeUndefined();
-		expect(target().headers['content-length']).toBeUndefined();
+		expect(result).toBe('{"ok":true}');
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+		]);
 	});
 
-	it("drops the caller's other body-describing headers across a downgrade", async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM, {
-			headers: {
-				'Content-Encoding': 'identity',
-				'Content-Language': 'en',
-				// node-fetch recomputes Content-Length only for a request that has
-				// a body, so a caller's value reaches the downgraded GET unless the
-				// downgrade removes it.
-				'Content-Length': '25',
-				'Content-Location': '/sparql',
-			},
-		});
+	it('refuses at the hop that would drop the body, after the earlier hops were re-sent', async () => {
+		const error = await refusalFrom(`${origin}/redirect/307/redirect/302/sparql`);
 
-		expect(target().headers['content-encoding']).toBeUndefined();
-		expect(target().headers['content-language']).toBeUndefined();
-		expect(target().headers['content-length']).toBeUndefined();
-		expect(target().headers['content-location']).toBeUndefined();
+		expect(error.status).toBe(302);
+		expect(error.target).toBe(`${origin}/sparql`);
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+		]);
 	});
 
 	it('keeps the form content type on a hop that still sends the body', async () => {
@@ -140,32 +182,12 @@ describe('redirected requests', () => {
 		expect(target().headers['content-type']).toBe('application/x-www-form-urlencoded');
 	});
 
-	it('keeps a caller header unrelated to the body across a downgrade', async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+	it('keeps a caller header on a hop that re-sends the body', async () => {
+		await postForm(`${origin}/redirect/307/sparql`, FORM, {
 			headers: { Accept: 'application/sparql-results+json' },
 		});
 
 		expect(target().headers.accept).toBe('application/sparql-results+json');
-	});
-
-	it('does not resurrect the body when a later hop preserves the method', async () => {
-		await postForm(`${origin}/redirect/302/redirect/307/sparql`, FORM);
-
-		expect(methodsAndBodies()).toEqual([
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'GET', body: '' },
-			{ method: 'GET', body: '' },
-		]);
-	});
-
-	it('downgrades a preserved POST at the hop that asks for it', async () => {
-		await postForm(`${origin}/redirect/307/redirect/302/sparql`, FORM);
-
-		expect(methodsAndBodies()).toEqual([
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'GET', body: '' },
-		]);
 	});
 
 	it('leaves a redirected GET a GET, query string and all', async () => {
@@ -179,5 +201,19 @@ describe('redirected requests', () => {
 			{ method: 'GET', body: '' },
 		]);
 		expect(target().url).toBe('/w/api.php?action=query');
+	});
+
+	it('follows a multi-hop redirect of a bodyless request to the target', async () => {
+		const result = await makeApiRequest<{ ok: boolean }>(
+			`${origin}/redirect/301/redirect/303/w/api.php`,
+			{ action: 'query' },
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/549

The redirect loop in `fetchCore` re-sent the original method and body on every hop, where only 307 and 308 ask for them again. A 301, 302 or 303 asks for the request to be re-sent as a GET with no body.

Sending that GET is not an option here. `postForm` is the only path that sends a body, `wikibase-query` is its only caller, and a SPARQL query travels entirely in that body — so the GET arrives with nothing to run, and the service answers about a request the caller never made. Reporting that answer hides the actual fault, which is that the endpoint URL the wiki publishes has moved.

So the loop now refuses such a hop instead of performing it. 307 and 308 re-send the method and body as before, and a request with no body — every other request this module sends, all of them already GETs — follows any redirect unchanged. The 3xx body is destroyed on the way out, so the refusal does not strand the connection it declined to follow.

The Wikibase layer turns the refusal into a message naming the setting to change, and names the redirect target by scheme and host only. That is a deliberate limit: a query-service URL can carry a token in its path or query, which is why that layer already substitutes the endpoint out of everything it reports, and a target derived from that URL inherits the token while — differing in scheme — not being a substring that substitution can find. Scheme and host identify the redirect and carry no credential.

## What this costs, measured

**A wiki publishing a 301/302/303-redirecting query-service URL loses queries that worked before this change.** Verified live against two real endpoints:

| Published endpoint | Answers a form POST with | Target answers the same POST |
|---|---|---|
| `http://database.factgrid.de/sparql` | `301` → `https://database.factgrid.de/sparql` | `200` |
| `http://dbpedia.org/sparql` | `303` → `https://dbpedia.org/sparql` | `200` |

On master the replayed POST reached those targets and the query ran. It now fails with a message naming the target's origin and the `wikibase-sparql` siteinfo value to correct.

I think that is the right trade, for a reason beyond spec compliance: both cases are a plaintext endpoint upgrading to TLS, so the first request already went out in the clear, query and all. Silently following the upgrade hides that the wiki is advertising an `http` endpoint; refusing surfaces it, and the fix is a one-line siteinfo change on the wiki. Endpoints that answer `307`/`308` — which is what wikibase.cloud and QLever serve — are unaffected either way.

**If you would rather not pay that**, the alternative is to replay the body when the redirect only upgrades the scheme on the same host, and refuse otherwise. That keeps both endpoints above working. I did not build it because it re-introduces POST replay for the case where the query has already been sent in cleartext, which is the case worth surfacing.

## Decisions for the reviewer

- **No CHANGELOG entry.** `postForm` and `wikibase-query` both arrived with the Wikibase pack in this same unreleased cycle, so no released version can send a body through the redirect loop. An entry under `### Fixed` would describe a failure no released version can produce.
- **The downgrade machinery is gone, not kept for a future caller.** With the refusal in place, the only request that still follows a non-preserving hop has no body, and every such request in the tree is already a GET carrying no body-describing header — so the method reset, the body reset and the header stripping were all unreachable. Deleting them keeps every remaining line testable. The consequence is recorded in a comment: a future caller sending a bodyless POST would need the method downgrade this deliberately does not implement.
- **The refusal keys on the body, not the method.** A reviewer argued for refusing any non-GET, so a future bodyless POST fails loudly rather than being replayed. I kept the body predicate: the two are identical for every current caller, and adding a stricter branch no test can reach would re-introduce exactly the unreachable code the previous point deletes. Worth overruling if you disagree.

## Verification

`tests/transport/httpFetch.redirect.test.ts` drives the real node-fetch against a loopback server recording what each hop receives: 301/302/303 refuse with the first hop sent whole and the target never contacted; 307/308 re-send method and body, singly and chained; a 307-then-302 chain refuses at the second hop, proving the check runs per hop; a 3xx with no `Location` still reports as `HttpStatusError`; and a bodyless GET still follows single and multi-hop chains. `tests/transport/httpFetch.disposal.test.ts` covers the connection behind the refused redirect, and two tests in the Wikibase suite pin the operator-facing message and its redaction.

Ten mutations were applied one at a time and all are caught, including the four that survived an earlier round: removing the body destroy, putting the target in either message, hardcoding the status, and returning the full target where only the origin belongs.

Gates run individually, all exit 0: `npm run lint`, `npm run typecheck`, `npm run fmt:check`, `npm test` (150 files, 2082 tests).

## Noticed, not fixed

The generic branch of `classifyQueryFailure` still leaks a token that a query-service URL carries in its path, whenever the failing URL is a redirect target rather than the endpoint itself — filed as #561. It is adjacent to this change rather than caused by it: the refusal added here is the one path that is clean.

`fetchCore` still leaves the body of every redirect it *follows* unread, and this change fixes only the hop it refuses; #555 covers the rest.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; filed by @alistair3149, then redesigned on their instruction after a review found the original fix silently discarded the query; diff not yet human-reviewed; tests seen failing before the change and passing after, ten mutations verified caught, the two live endpoint measurements above reproduced with curl, gates and CI green.</sub>
