### PR TITLE
Stop the rate-limit transport tests failing intermittently

### DIFF
--- a/tests/transport/mcpRoute.test.ts
+++ b/tests/transport/mcpRoute.test.ts
@@ -213,9 +213,11 @@ describe('bearer threading through the route', () => {
 	});
 });
 
-// The limiter refills from the clock it is handed, so on the real clock a drained
-// bucket earns a token back while the next supertest round-trip is in flight, and
-// a request these tests expect to be refused is served. No rate-limit test below
+// The limiter refills from the clock it is handed, so any wall-clock advance of
+// about a second between two of these requests earns a drained bucket a token
+// back and serves a request the test expects to be refused. A slow round-trip
+// does it; so does a Date.now() that steps, which a virtualised host can do
+// while the requests themselves take milliseconds. No rate-limit test below
 // exercises refill: the bucket must stay exactly as drained as the requests left it.
 const frozenClock = () => 1_000_000;
 

--- a/tests/transport/mcpRoute.test.ts
+++ b/tests/transport/mcpRoute.test.ts
@@ -213,6 +213,12 @@ describe('bearer threading through the route', () => {
 	});
 });
 
+// The limiter refills from the clock it is handed, so on the real clock a drained
+// bucket earns a token back while the next supertest round-trip is in flight, and
+// a request these tests expect to be refused is served. No rate-limit test below
+// exercises refill: the bucket must stay exactly as drained as the requests left it.
+const frozenClock = () => 1_000_000;
+
 describe('rate limiting on /mcp', () => {
 	const SETTINGS = {
 		ratePerSecond: 1,
@@ -239,7 +245,7 @@ describe('rate limiting on /mcp', () => {
 		app.post(
 			'/mcp',
 			createMcpRouteHandler(fakeHandler, {
-				rateLimiter: createRateLimiter(SETTINGS),
+				rateLimiter: createRateLimiter(SETTINGS, frozenClock),
 				...options,
 			}),
 		);
@@ -406,7 +412,10 @@ describe('rate limiting cannot be bypassed by request shape', () => {
 			},
 			{ legacy: 'stateless' },
 		);
-		app.post('/mcp', createMcpRouteHandler(handler, { rateLimiter: createRateLimiter(SETTINGS) }));
+		app.post(
+			'/mcp',
+			createMcpRouteHandler(handler, { rateLimiter: createRateLimiter(SETTINGS, frozenClock) }),
+		);
 		return app;
 	}
 

--- a/tests/transport/streamableHttp.rateLimit.test.ts
+++ b/tests/transport/streamableHttp.rateLimit.test.ts
@@ -20,6 +20,12 @@ const SETTINGS = {
 	anonymousBurst: 2,
 };
 
+// The limiter refills from the clock it is handed, so on the real clock a drained
+// bucket earns a token back while the next supertest round-trip is in flight, and
+// a request these tests expect to be refused is served. Nothing here exercises
+// refill: the bucket must stay exactly as drained as the requests left it.
+const frozenClock = () => 1_000_000;
+
 function makeDeps(calls: { count: number }): BuildAppDeps {
 	return {
 		state: createAppState({
@@ -58,7 +64,7 @@ function makeDeps(calls: { count: number }): BuildAppDeps {
 		allowedHosts: undefined,
 		allowedOrigins: [],
 		maxRequestBody: '1mb',
-		rateLimiter: createRateLimiter(SETTINGS),
+		rateLimiter: createRateLimiter(SETTINGS, frozenClock),
 	};
 }
 

--- a/tests/transport/streamableHttp.rateLimit.test.ts
+++ b/tests/transport/streamableHttp.rateLimit.test.ts
@@ -20,9 +20,11 @@ const SETTINGS = {
 	anonymousBurst: 2,
 };
 
-// The limiter refills from the clock it is handed, so on the real clock a drained
-// bucket earns a token back while the next supertest round-trip is in flight, and
-// a request these tests expect to be refused is served. Nothing here exercises
+// The limiter refills from the clock it is handed, so any wall-clock advance of
+// about a second between two of these requests earns a drained bucket a token
+// back and serves a request the test expects to be refused. A slow round-trip
+// does it; so does a Date.now() that steps, which a virtualised host can do
+// while the requests themselves take milliseconds. Nothing here exercises
 // refill: the bucket must stay exactly as drained as the requests left it.
 const frozenClock = () => 1_000_000;
 


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/548

Both transport rate-limit suites built their limiter with the real clock, so the token bucket refilled from
wall-clock time between requests. Each test sends three sequential requests through a real express app and expects
the third to be refused. At a sustained rate of one call per second, any wall-clock advance of about a second
between the first and third request returns a token, and the request the test expects to be refused is served
instead. Slow round-trips do that on a loaded machine, and so does a `Date.now()` that steps: on a WSL2 host it was
measured jumping about eleven seconds forward and back every few seconds, which flips the assertion while the
requests themselves take milliseconds. Either way it happened often enough to block a push through the pre-push
hook.

`createRateLimiter` already accepts an injected clock, which is how the limiter's own unit tests drive refill. The
three transport call sites now pass a frozen clock, leaving a drained bucket drained. Neither file has a test that
exercises refill over time, so freezing costs no coverage; a refill test added later wants an advancing clock rather
than a sleep.

Verified by raising the sustained rate so refill is effectively instant, which turns the intermittent failure into a
certain one. With that raised rate, 11 tests across the two files fail on 4 of 4 runs before the change and on 0 of
4 runs after it. Back at the original rate the two files pass 6 of 6 runs, and the full suite passes locally and on
CI.

## Noticed, not fixed

`refill()` does not clamp its elapsed delta, so the same non-monotonic clock drives a live caller's bucket negative
on a backwards step and hands out a free refill on a forward one. Filed separately; it is a production one-liner, not
a test change.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; issue filed by @alistair3149, fixed in an unattended batch run with no steering; diff not yet human-reviewed; deterministic repro watched failing then passing, two affected files run 6/6 green, full suite green three times locally, lint and format checks clean, CI green.</sub>
