### PR TITLE
Close the connection when an oversized fetch is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
-- `upload-file-from-url`, `update-file-from-url` and `wikibase-query` no longer leak a connection when they refuse an over-cap source or query result. Each refused call held one connection open for as long as the server ran.
+- `upload-file-from-url` and `update-file-from-url` no longer leak a connection when they refuse a source URL whose declared size is over `MCP_UPLOAD_MAX_BYTES`. Each refused call held one connection open for as long as the server ran.
 
 ## [0.16.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
-- A source URL whose declared size is over `MCP_UPLOAD_MAX_BYTES` no longer leaves its connection open once the fetch is refused. `upload-file-from-url` and `update-file-from-url` held one socket per such URL for as long as the server ran, and an over-cap query result in `wikibase-query` did the same.
+- `upload-file-from-url`, `update-file-from-url` and `wikibase-query` no longer leak a connection when they refuse an over-cap source or query result. Each refused call held one connection open for as long as the server ran.
 
 ## [0.16.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Fixed
 
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
+- A source URL whose declared size is over `MCP_UPLOAD_MAX_BYTES` no longer leaves its connection open once the fetch is refused. `upload-file-from-url` and `update-file-from-url` held one socket per such URL for as long as the server ran, and an over-cap query result in `wikibase-query` did the same.
 
 ## [0.16.0] - 2026-07-30
 

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -1,3 +1,4 @@
+import type { Readable } from 'node:stream';
 import fetch, { Response, FetchError } from 'node-fetch';
 import { USER_AGENT } from '../runtime/constants.ts';
 import { isErrnoException } from '../errors/isErrnoException.ts';
@@ -193,30 +194,49 @@ export async function postForm(
  * Reads a response body into memory under a byte cap, checked twice: the
  * declared content-length rejects an over-cap body before a byte is read, and
  * the running total catches one that under-declares or declares nothing.
+ *
+ * Either refusal disposes of the body first: the connection is held for as long
+ * as the body stream is neither consumed nor destroyed, so a body left unread
+ * strands a socket for the life of the process.
  */
 async function readCapped(
 	response: Response,
 	maxBytes: number,
 	limitName?: string,
 ): Promise<Buffer> {
-	const declared = Number(response.headers.get('content-length'));
-	if (Number.isFinite(declared) && declared > maxBytes) {
-		throw new FileTooLargeError(declared, maxBytes, limitName);
-	}
-	const chunks: Buffer[] = [];
-	let total = 0;
-	if (response.body !== null) {
-		// node-fetch v3 exposes the body as a Node Readable (async-iterable).
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; narrowing to AsyncIterable<Buffer> is safe at this boundary
-		for await (const chunk of response.body as AsyncIterable<Buffer>) {
-			total += chunk.length;
-			if (total > maxBytes) {
-				throw new FileTooLargeError(total, maxBytes, limitName);
-			}
-			chunks.push(chunk);
+	try {
+		const declared = Number(response.headers.get('content-length'));
+		if (Number.isFinite(declared) && declared > maxBytes) {
+			throw new FileTooLargeError(declared, maxBytes, limitName);
 		}
+		const chunks: Buffer[] = [];
+		let total = 0;
+		if (response.body !== null) {
+			// node-fetch v3 exposes the body as a Node Readable (async-iterable).
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; narrowing to AsyncIterable<Buffer> is safe at this boundary
+			for await (const chunk of response.body as AsyncIterable<Buffer>) {
+				total += chunk.length;
+				if (total > maxBytes) {
+					throw new FileTooLargeError(total, maxBytes, limitName);
+				}
+				chunks.push(chunk);
+			}
+		}
+		return Buffer.concat(chunks);
+	} catch (error) {
+		destroyBody(response);
+		throw error;
 	}
-	return Buffer.concat(chunks);
+}
+
+/**
+ * Releases the connection behind a response body that will not be read. Leaving
+ * the read loop above destroys the stream on its way out, but a refusal that
+ * never subscribes to it has to do this itself.
+ */
+function destroyBody(response: Response): void {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; the published type narrows it to ReadableStream, which omits destroy()
+	(response.body as Readable | null)?.destroy();
 }
 
 export async function fetchPageHtml(url: string): Promise<string | null> {

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'node:stream';
+import { Readable } from 'node:stream';
 import fetch, { Response, FetchError } from 'node-fetch';
 import { USER_AGENT } from '../runtime/constants.ts';
 import { isErrnoException } from '../errors/isErrnoException.ts';
@@ -197,7 +197,8 @@ export async function postForm(
  *
  * Either refusal disposes of the body first: the connection is held for as long
  * as the body stream is neither consumed nor destroyed, so a body left unread
- * strands a socket for the life of the process.
+ * strands a socket until something aborts the request — which, on the upload
+ * path, nothing does.
  */
 async function readCapped(
 	response: Response,
@@ -235,8 +236,13 @@ async function readCapped(
  * never subscribes to it has to do this itself.
  */
 function destroyBody(response: Response): void {
-	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; the published type narrows it to ReadableStream, which omits destroy()
-	(response.body as Readable | null)?.destroy();
+	// node-fetch v3 hands back a Node Readable, but declares it as the wider
+	// NodeJS.ReadableStream, which has no destroy(). Narrowing by instanceof
+	// rather than asserting means a body that is not a Node stream is left
+	// alone instead of throwing over the refusal being reported.
+	if (response.body instanceof Readable) {
+		response.body.destroy();
+	}
 }
 
 export async function fetchPageHtml(url: string): Promise<string | null> {

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 
 /**
  * What an over-cap refusal does to the connection is only visible against a
@@ -26,7 +26,7 @@ import { fetchFileBytes, postForm, FileTooLargeError } from '../../src/transport
 let server: Server;
 let origin: string;
 let openSockets: Set<Socket>;
-let servingSocket: Socket;
+let servingSocket: Socket | undefined;
 
 beforeAll(async () => {
 	openSockets = new Set();
@@ -47,8 +47,15 @@ beforeAll(async () => {
 			res.write('x');
 			return;
 		}
-		res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
-		res.write('x'.repeat(64));
+		if (req.url === '/streams-too-much') {
+			res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
+			res.write('x'.repeat(64));
+			return;
+		}
+		// Anything else is a test asking for a route that does not exist. Refusing
+		// it keeps a mistyped path from quietly getting a different route's answer.
+		res.writeHead(404);
+		res.end();
 	});
 	// A client destroying its socket reaches the server as a reset.
 	server.on('connection', (socket) => {
@@ -61,6 +68,10 @@ beforeAll(async () => {
 	origin = `http://127.0.0.1:${typeof address === 'object' && address !== null ? address.port : 0}`;
 });
 
+beforeEach(() => {
+	servingSocket = undefined;
+});
+
 afterAll(async () => {
 	for (const socket of openSockets) {
 		socket.destroy();
@@ -68,8 +79,16 @@ afterAll(async () => {
 	await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-/** Whether the server's end of the connection goes away once the client is done with it. */
-async function connectionClosed(socket: Socket, withinMs = 1000): Promise<boolean> {
+/**
+ * Whether the server's end of the connection goes away once the client is done
+ * with it. No recorded socket means the request never reached the server, so
+ * there is nothing to observe: say so, rather than read a socket an earlier test
+ * left behind and report its closure as this one's.
+ */
+async function connectionClosed(socket: Socket | undefined, withinMs = 1000): Promise<boolean> {
+	if (socket === undefined) {
+		throw new Error('The server served no request, so no connection was observed.');
+	}
 	if (socket.destroyed) {
 		return true;
 	}

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+/**
+ * What an over-cap refusal does to the connection is only visible against a
+ * real server: the rest of the httpFetch suite mocks node-fetch wholesale, so
+ * it never sees a socket. node-fetch holds the connection until the response
+ * body is consumed or destroyed, so a refusal that leaves the body untouched
+ * strands the socket. Only the SSRF guard is stubbed, since a loopback
+ * destination is what a local test server is.
+ */
+vi.mock('../../src/transport/ssrfGuard.ts', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/ssrfGuard.ts')>(
+		'../../src/transport/ssrfGuard.ts',
+	);
+	return {
+		...actual,
+		assertPublicDestination: vi.fn(async () => [{ address: '127.0.0.1', family: 4 }]),
+		buildPinnedAgent: vi.fn(() => undefined),
+	};
+});
+
+import { createServer, type Server } from 'node:http';
+import type { Socket } from 'node:net';
+import { fetchFileBytes, postForm, FileTooLargeError } from '../../src/transport/httpFetch.ts';
+
+let server: Server;
+let origin: string;
+let openSockets: Set<Socket>;
+let servingSocket: Socket;
+
+beforeAll(async () => {
+	openSockets = new Set();
+	server = createServer((req, res) => {
+		servingSocket = req.socket;
+		if (req.url === '/small') {
+			res.writeHead(200, { 'Content-Length': '7' });
+			res.end('results');
+			return;
+		}
+		// The over-cap routes send their headers and then stall, never ending the
+		// response. A client that drops such a body without destroying it holds
+		// the socket open for as long as it lives, which is what these tests
+		// measure; one that completes normally would return the socket to the
+		// keep-alive pool and hide the difference.
+		if (req.url === '/declares-too-much') {
+			res.writeHead(200, { 'Content-Length': String(50 * 1024 * 1024) });
+			res.write('x');
+			return;
+		}
+		res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
+		res.write('x'.repeat(64));
+	});
+	// A client destroying its socket reaches the server as a reset.
+	server.on('connection', (socket) => {
+		openSockets.add(socket);
+		socket.on('error', () => {});
+		socket.on('close', () => openSockets.delete(socket));
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	origin = `http://127.0.0.1:${typeof address === 'object' && address !== null ? address.port : 0}`;
+});
+
+afterAll(async () => {
+	for (const socket of openSockets) {
+		socket.destroy();
+	}
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+/** Whether the server's end of the connection goes away once the client is done with it. */
+async function connectionClosed(socket: Socket, withinMs = 1000): Promise<boolean> {
+	if (socket.destroyed) {
+		return true;
+	}
+	return await new Promise<boolean>((resolve) => {
+		const timer = setTimeout(() => resolve(false), withinMs);
+		socket.once('close', () => {
+			clearTimeout(timer);
+			resolve(true);
+		});
+	});
+}
+
+describe('an over-cap body refused against a real server', () => {
+	it('closes the connection when the declared content-length is over the cap', async () => {
+		const failure = await fetchFileBytes(`${origin}/declares-too-much`, {
+			maxBytes: 1024,
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(FileTooLargeError);
+		expect(await connectionClosed(servingSocket)).toBe(true);
+	});
+
+	it('closes the connection when the streamed body passes the cap', async () => {
+		const failure = await fetchFileBytes(`${origin}/streams-too-much`, { maxBytes: 10 }).catch(
+			(error: unknown) => error,
+		);
+
+		expect(failure).toBeInstanceOf(FileTooLargeError);
+		expect(await connectionClosed(servingSocket)).toBe(true);
+	});
+
+	it('closes the connection when a capped postForm refuses the body', async () => {
+		const failure = await postForm(
+			`${origin}/declares-too-much`,
+			{ query: 'SELECT ?x WHERE {}' },
+			{ maxBytes: 1024 },
+		).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(FileTooLargeError);
+		expect(await connectionClosed(servingSocket)).toBe(true);
+	});
+
+	it('still returns a body that fits the cap', async () => {
+		const body = await postForm(`${origin}/small`, { query: 'x' }, { maxBytes: 1024 });
+
+		expect(body).toBe('results');
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/545

A response body refused for exceeding a byte cap was left unread, and node-fetch holds the connection until the body stream is either consumed or destroyed. The declared-content-length check refuses before anything subscribes to the stream, so an over-cap source URL stranded one socket for as long as the server ran. The streamed-total check already disposed of the body, because leaving the read loop destroys the stream on the way out; only the declared-length path leaked.

`readCapped` now destroys the body on any refusal, so the invariant holds at both cap checks and for both callers: the `*-from-url` upload tools and the capped SPARQL read behind `wikibase-query`. Only the upload path held its socket for the life of the process — `wikibase-query` passes a 60-second timeout signal, which eventually freed the connection on its own. Aborting the `AbortController` that `fetchFileBytes` owns would close its own connection too, but it is neither necessary nor available to `postForm`, whose signal belongs to the caller.

The body is narrowed with `instanceof Readable` rather than a type assertion: node-fetch declares it as the wider `NodeJS.ReadableStream`, which has no `destroy()`, and a body that turned out not to be a Node stream should be left alone rather than throwing a `TypeError` over the refusal being reported — which would also stop `upload-file-from-url` falling back to wiki-side copy-upload.

The regression test drives the real client against a loopback server, since the rest of the suite mocks node-fetch and cannot see a socket, and asserts that the server's end of the connection goes away. The server stalls its over-cap responses on purpose: node-fetch pumps a body that arrives complete into a buffer before the cap check runs, which returns the socket to the pool and hides the difference. An unknown route answers `404`, and an assertion with no connection to observe fails rather than reading one an earlier test left behind.

To decide: whether `fetchCore` needs the same treatment, which this change deliberately leaves alone. It never reads a redirect response's body, so each hop leaves one behind — on the success path as well as at its three early exits (the redirect cap, a `Location` the guard refuses, and a cancellation between hops). Measured the same way, a 302 whose body the client never reads holds its socket indefinitely, while the socket of the hop that was followed returns to the pool. A short 3xx body is buffered whole and costs nothing, so this bites only where a source stalls or sends a large redirect body — which a caller-supplied URL can arrange. Worth its own change rather than widening this one.

Verified: the two declared-length tests fail on master (`expected false to be true`, the connection never closing) and pass with the fix; the streamed-total test passes on both, confirming the issue's reading of the `for await` path. `npm run lint`, `npm run typecheck`, `npm run fmt:check` and `npm test` (2050 tests) pass locally.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; filed by @alistair3149, fixed by an unattended batch run with no human steering; diff not yet human-reviewed; regression test seen failing before the fix and passing after, full local suite green, CI green.</sub>

