### PR TITLE
Attribute NeoWiki subject writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix and honour a wiki's `attributeEdits: false` setting, which they previously ignored.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix and honour a wiki's `attributeEdits: false` setting; they previously did neither.
+- NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix, as every other write already did. A wiki that sets `attributeEdits: false` sees no change.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix and honour a wiki's `attributeEdits: false` setting, which they previously ignored.
+- NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix and honour a wiki's `attributeEdits: false` setting; they previously did neither.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ Accepts a string or an array of strings:
 
 Every write appends `(via <tool> on MediaWiki MCP Server)` to its edit summary — for example `Fix typo (via update-page on MediaWiki MCP Server)`. With no caller comment, the summary is `Automated edit (via <tool> on MediaWiki MCP Server)`. This is the default (`true`).
 
-Set `attributeEdits` to `false` to drop the suffix. The write then carries only the caller's comment, or the wiki's own default summary when none was given:
+Set `attributeEdits` to `false` to drop the suffix. The write then carries the caller's comment alone, and no summary from the server when none was given:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ Accepts a string or an array of strings:
 
 Every write appends `(via <tool> on MediaWiki MCP Server)` to its edit summary — for example `Fix typo (via update-page on MediaWiki MCP Server)`. With no caller comment, the summary is `Automated edit (via <tool> on MediaWiki MCP Server)`. This is the default (`true`).
 
-Set `attributeEdits` to `false` to drop the suffix. The write then carries only the caller's comment, or an empty summary when none was given:
+Set `attributeEdits` to `false` to drop the suffix. The write then carries only the caller's comment, or the wiki's own default summary when none was given:
 
 ```json
 {

--- a/src/tools/extensions/neowiki/editComment.ts
+++ b/src/tools/extensions/neowiki/editComment.ts
@@ -1,0 +1,18 @@
+import type { ToolContext } from '../../../runtime/context.ts';
+import { formatEditComment } from '../../../wikis/utils.ts';
+
+/**
+ * The edit summary a NeoWiki write should carry, attributed to the tool making
+ * it, or `undefined` when there is none to send: a wiki that has turned
+ * attribution off and a caller that gave no comment. NeoWiki reads an absent
+ * comment as "use my own default summary" and an empty one as the summary
+ * itself, so the two cases must stay distinct.
+ */
+export function attributedComment(
+	ctx: ToolContext,
+	tool: string,
+	comment?: string,
+): string | undefined {
+	const attributed = formatEditComment(ctx, tool, comment);
+	return attributed === '' ? undefined : attributed;
+}

--- a/src/tools/extensions/neowiki/neowiki-create-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-create-subject.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
+import { attributedComment } from './editComment.ts';
 import { resolvePageId, hasOnePageRef } from './pageId.ts';
 
 // A statement keyed by property name. The write API reads `propertyType` (NOT
@@ -90,12 +91,18 @@ export const neowikiCreateSubject: Tool<typeof inputSchema> = {
 			}
 
 			const segment = isMain === true ? 'mainSubject' : 'childSubjects';
+			const editComment = attributedComment(ctx, 'neowiki-create-subject', comment);
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki create response shape; trusted at this boundary
 			const data = (await neowikiRequest(mwn, {
 				method: 'POST',
 				path: `/page/${resolvedPageId}/${segment}`,
 				csrf: true,
-				body: { label, schema, statements, ...(comment !== undefined ? { comment } : {}) },
+				body: {
+					label,
+					schema,
+					statements,
+					...(editComment !== undefined ? { comment: editComment } : {}),
+				},
 			})) as CreateResponse;
 
 			// Upstream returns HTTP 201 with { status: "error" } when a main subject

--- a/src/tools/extensions/neowiki/neowiki-create-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-create-subject.ts
@@ -84,6 +84,7 @@ export const neowikiCreateSubject: Tool<typeof inputSchema> = {
 		}
 
 		const mwn = await ctx.mwn();
+		const editComment = attributedComment(ctx, 'neowiki-create-subject', comment);
 		try {
 			const resolvedPageId = await resolvePageId(mwn, { title, pageId });
 			if (resolvedPageId === null) {
@@ -91,7 +92,6 @@ export const neowikiCreateSubject: Tool<typeof inputSchema> = {
 			}
 
 			const segment = isMain === true ? 'mainSubject' : 'childSubjects';
-			const editComment = attributedComment(ctx, 'neowiki-create-subject', comment);
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki create response shape; trusted at this boundary
 			const data = (await neowikiRequest(mwn, {
 				method: 'POST',

--- a/src/tools/extensions/neowiki/neowiki-delete-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-delete-subject.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
+import { attributedComment } from './editComment.ts';
 
 const inputSchema = {
 	id: z
@@ -29,13 +30,14 @@ export const neowikiDeleteSubject: Tool<typeof inputSchema> = {
 
 	async handle({ id, comment }, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
+		const editComment = attributedComment(ctx, 'neowiki-delete-subject', comment);
 		try {
 			// The endpoint returns an empty 200 body on success; ignore it.
 			await neowikiRequest(mwn, {
 				method: 'DELETE',
 				path: `/subject/${encodeURIComponent(id)}`,
 				csrf: true,
-				...(comment !== undefined ? { body: { comment } } : {}),
+				...(editComment !== undefined ? { body: { comment: editComment } } : {}),
 			});
 
 			return ctx.format.ok({ subjectId: id, status: 'deleted' });

--- a/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
@@ -49,13 +49,13 @@ export const neowikiSetMainSubject: Tool<typeof inputSchema> = {
 		}
 
 		const mwn = await ctx.mwn();
+		const editComment = attributedComment(ctx, 'neowiki-set-main-subject', comment);
 		try {
 			const resolvedPageId = await resolvePageId(mwn, { title, pageId });
 			if (resolvedPageId === null) {
 				return ctx.format.notFound(`Page "${title}" not found`);
 			}
 
-			const editComment = attributedComment(ctx, 'neowiki-set-main-subject', comment);
 			// Always send the subjectId key: omitting it is a 400 upstream, whereas
 			// an explicit null is the documented way to clear the Main Subject.
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki set-main response shape; trusted at this boundary

--- a/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-set-main-subject.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
+import { attributedComment } from './editComment.ts';
 import { resolvePageId, hasOnePageRef } from './pageId.ts';
 
 const inputSchema = {
@@ -54,6 +55,7 @@ export const neowikiSetMainSubject: Tool<typeof inputSchema> = {
 				return ctx.format.notFound(`Page "${title}" not found`);
 			}
 
+			const editComment = attributedComment(ctx, 'neowiki-set-main-subject', comment);
 			// Always send the subjectId key: omitting it is a 400 upstream, whereas
 			// an explicit null is the documented way to clear the Main Subject.
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki set-main response shape; trusted at this boundary
@@ -61,7 +63,7 @@ export const neowikiSetMainSubject: Tool<typeof inputSchema> = {
 				method: 'PUT',
 				path: `/page/${resolvedPageId}/mainSubject`,
 				csrf: true,
-				body: { subjectId, ...(comment !== undefined ? { comment } : {}) },
+				body: { subjectId, ...(editComment !== undefined ? { comment: editComment } : {}) },
 			})) as SetMainResponse;
 
 			return ctx.format.ok({ pageId: resolvedPageId, status: data.status ?? 'changed' });

--- a/src/tools/extensions/neowiki/neowiki-update-subject.ts
+++ b/src/tools/extensions/neowiki/neowiki-update-subject.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../../../runtime/tool.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
 import { neowikiRequest, neowikiErrorResult } from './neowikiRequest.ts';
+import { attributedComment } from './editComment.ts';
 
 const statementSchema = z.object({
 	propertyType: z
@@ -52,13 +53,14 @@ export const neowikiUpdateSubject: Tool<typeof inputSchema> = {
 
 	async handle({ id, label, statements, comment }, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
+		const editComment = attributedComment(ctx, 'neowiki-update-subject', comment);
 		try {
 			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- NeoWiki replace response shape; trusted at this boundary
 			const data = (await neowikiRequest(mwn, {
 				method: 'PUT',
 				path: `/subject/${encodeURIComponent(id)}`,
 				csrf: true,
-				body: { label, statements, ...(comment !== undefined ? { comment } : {}) },
+				body: { label, statements, ...(editComment !== undefined ? { comment: editComment } : {}) },
 			})) as UpdateResponse;
 
 			return ctx.format.ok({ subjectId: data.subjectId ?? id, status: data.status ?? 'updated' });

--- a/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
@@ -113,7 +113,10 @@ describe('neowiki-create-subject', () => {
 			ctx,
 		);
 
-		expect(sentBody(mock)).toMatchObject({
+		expect(sentBody(mock)).toEqual({
+			label: 'X',
+			schema: 'City',
+			statements: stmts,
 			comment: 'seed the city (via neowiki-create-subject on MediaWiki MCP Server)',
 		});
 	});

--- a/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-create-subject.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../../../helpers/mock-mwn.ts';
-import { fakeContext } from '../../../helpers/fakeContext.ts';
+import { createMockMwn, type MockMwn } from '../../../helpers/mock-mwn.ts';
+import { fakeContext, withoutEditAttribution } from '../../../helpers/fakeContext.ts';
+import type { ToolContext } from '../../../../src/runtime/context.ts';
 import { neowikiCreateSubject } from '../../../../src/tools/extensions/neowiki/neowiki-create-subject.ts';
 import { assertStructuredError } from '../../../helpers/structuredResult.ts';
 
 const stmts = { Country: { propertyType: 'text', value: ['Germany'] } };
+
+function contextWith(): { mock: MockMwn; ctx: ToolContext } {
+	const mock = createMockMwn({
+		getCsrfToken: vi.fn().mockResolvedValue('tok'),
+		rawRequest: vi.fn().mockResolvedValue({ data: { status: 'created', subjectId: 's1' } }),
+	});
+	return { mock, ctx: fakeContext({ mwn: async () => mock as never }) };
+}
+
+function sentBody(mock: MockMwn): Record<string, unknown> {
+	const { data } = mock.rawRequest.mock.calls[0][0] as { data: string };
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON body the tool sent
+	return JSON.parse(data) as Record<string, unknown>;
+}
 
 describe('neowiki-create-subject', () => {
 	it('resolves a title and posts a child subject with a CSRF token', async () => {
@@ -88,5 +103,53 @@ describe('neowiki-create-subject', () => {
 			ctx,
 		);
 		assertStructuredError(result, 'not_found');
+	});
+
+	it('attributes the write to the tool that made it, after the caller comment', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiCreateSubject.handle(
+			{ pageId: 7, label: 'X', schema: 'City', statements: stmts, comment: 'seed the city' },
+			ctx,
+		);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'seed the city (via neowiki-create-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('attributes a write the caller gave no comment for', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiCreateSubject.handle(
+			{ pageId: 7, label: 'X', schema: 'City', statements: stmts },
+			ctx,
+		);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'Automated edit (via neowiki-create-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('drops the attribution for a wiki that opts out of it', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiCreateSubject.handle(
+			{ pageId: 7, label: 'X', schema: 'City', statements: stmts, comment: 'seed the city' },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).toMatchObject({ comment: 'seed the city' });
+	});
+
+	it('sends no comment at all when a wiki opts out and the caller gave none', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiCreateSubject.handle(
+			{ pageId: 7, label: 'X', schema: 'City', statements: stmts },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).not.toHaveProperty('comment');
 	});
 });

--- a/tests/tools/extensions/neowiki/neowiki-delete-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-delete-subject.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../../../helpers/mock-mwn.ts';
-import { fakeContext } from '../../../helpers/fakeContext.ts';
+import { createMockMwn, type MockMwn } from '../../../helpers/mock-mwn.ts';
+import { fakeContext, withoutEditAttribution } from '../../../helpers/fakeContext.ts';
+import type { ToolContext } from '../../../../src/runtime/context.ts';
 import { neowikiDeleteSubject } from '../../../../src/tools/extensions/neowiki/neowiki-delete-subject.ts';
 import { assertStructuredError } from '../../../helpers/structuredResult.ts';
 
@@ -10,35 +11,72 @@ function httpError(status: number, data: unknown): Error & { response: unknown }
 	return err;
 }
 
+function contextWith(): { mock: MockMwn; ctx: ToolContext } {
+	const mock = createMockMwn({
+		getCsrfToken: vi.fn().mockResolvedValue('tok'),
+		rawRequest: vi.fn().mockResolvedValue({ data: '' }),
+	});
+	return { mock, ctx: fakeContext({ mwn: async () => mock as never }) };
+}
+
+function sentBody(mock: MockMwn): Record<string, unknown> | undefined {
+	const { data } = mock.rawRequest.mock.calls[0][0] as { data?: string };
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON body the tool sent
+	return data === undefined ? undefined : (JSON.parse(data) as Record<string, unknown>);
+}
+
 describe('neowiki-delete-subject', () => {
 	it('DELETEs with a CSRF token and reports deleted', async () => {
-		const mock = createMockMwn({
-			getCsrfToken: vi.fn().mockResolvedValue('tok'),
-			rawRequest: vi.fn().mockResolvedValue({ data: '' }),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		const { mock, ctx } = contextWith();
 		const result = await neowikiDeleteSubject.handle({ id: 's1demo', comment: 'spam' }, ctx);
 		const call = mock.rawRequest.mock.calls[0][0] as {
 			url: string;
 			method: string;
-			data: string;
 			headers: Record<string, string>;
 		};
 		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1demo');
 		expect(call.method).toBe('DELETE');
 		expect(call.headers['X-CSRF-TOKEN']).toBe('tok');
-		expect(JSON.parse(call.data)).toEqual({ comment: 'spam' });
 		expect(result.structuredContent).toMatchObject({ subjectId: 's1demo', status: 'deleted' });
 	});
 
-	it('omits the body when no comment is given', async () => {
-		const mock = createMockMwn({
-			getCsrfToken: vi.fn().mockResolvedValue('tok'),
-			rawRequest: vi.fn().mockResolvedValue({ data: '' }),
+	it('attributes the write to the tool that made it, after the caller comment', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiDeleteSubject.handle({ id: 's1demo', comment: 'spam' }, ctx);
+
+		expect(sentBody(mock)).toEqual({
+			comment: 'spam (via neowiki-delete-subject on MediaWiki MCP Server)',
 		});
-		const ctx = fakeContext({ mwn: async () => mock as never });
+	});
+
+	it('attributes a write the caller gave no comment for', async () => {
+		const { mock, ctx } = contextWith();
+
 		await neowikiDeleteSubject.handle({ id: 's1demo' }, ctx);
-		expect((mock.rawRequest.mock.calls[0][0] as { data?: unknown }).data).toBeUndefined();
+
+		expect(sentBody(mock)).toEqual({
+			comment: 'Automated edit (via neowiki-delete-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('drops the attribution for a wiki that opts out of it', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiDeleteSubject.handle(
+			{ id: 's1demo', comment: 'spam' },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).toEqual({ comment: 'spam' });
+	});
+
+	it('omits the body when a wiki opts out and the caller gave no comment', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiDeleteSubject.handle({ id: 's1demo' }, withoutEditAttribution(ctx));
+
+		expect(sentBody(mock)).toBeUndefined();
 	});
 
 	it('maps a 403 to permission_denied', async () => {

--- a/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
@@ -60,7 +60,8 @@ describe('neowiki-set-main-subject', () => {
 			ctx,
 		);
 
-		expect(sentBody(mock)).toMatchObject({
+		expect(sentBody(mock)).toEqual({
+			subjectId: 's1demo',
 			comment: 'promote Berlin (via neowiki-set-main-subject on MediaWiki MCP Server)',
 		});
 	});

--- a/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-set-main-subject.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../../../helpers/mock-mwn.ts';
-import { fakeContext } from '../../../helpers/fakeContext.ts';
+import { createMockMwn, type MockMwn } from '../../../helpers/mock-mwn.ts';
+import { fakeContext, withoutEditAttribution } from '../../../helpers/fakeContext.ts';
+import type { ToolContext } from '../../../../src/runtime/context.ts';
 import { neowikiSetMainSubject } from '../../../../src/tools/extensions/neowiki/neowiki-set-main-subject.ts';
 import { assertStructuredError } from '../../../helpers/structuredResult.ts';
 
@@ -8,6 +9,20 @@ function httpError(status: number, data: unknown): Error & { response: unknown }
 	const err = new Error(`HTTP ${status}`) as Error & { response: unknown };
 	err.response = { status, data };
 	return err;
+}
+
+function contextWith(): { mock: MockMwn; ctx: ToolContext } {
+	const mock = createMockMwn({
+		getCsrfToken: vi.fn().mockResolvedValue('tok'),
+		rawRequest: vi.fn().mockResolvedValue({ data: { status: 'changed' } }),
+	});
+	return { mock, ctx: fakeContext({ mwn: async () => mock as never }) };
+}
+
+function sentBody(mock: MockMwn): Record<string, unknown> {
+	const { data } = mock.rawRequest.mock.calls[0][0] as { data: string };
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON body the tool sent
+	return JSON.parse(data) as Record<string, unknown>;
 }
 
 describe('neowiki-set-main-subject', () => {
@@ -21,7 +36,7 @@ describe('neowiki-set-main-subject', () => {
 		const call = mock.rawRequest.mock.calls[0][0] as { url: string; method: string; data: string };
 		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/page/7/mainSubject');
 		expect(call.method).toBe('PUT');
-		expect(JSON.parse(call.data)).toEqual({ subjectId: 's1demo' });
+		expect(JSON.parse(call.data)).toMatchObject({ subjectId: 's1demo' });
 		expect(result.structuredContent).toMatchObject({ pageId: 7, status: 'changed' });
 	});
 
@@ -32,9 +47,54 @@ describe('neowiki-set-main-subject', () => {
 		});
 		const ctx = fakeContext({ mwn: async () => mock as never });
 		await neowikiSetMainSubject.handle({ pageId: 7, subjectId: null }, ctx);
-		expect(JSON.parse((mock.rawRequest.mock.calls[0][0] as { data: string }).data)).toEqual({
+		expect(JSON.parse((mock.rawRequest.mock.calls[0][0] as { data: string }).data)).toMatchObject({
 			subjectId: null,
 		});
+	});
+
+	it('attributes the write to the tool that made it, after the caller comment', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiSetMainSubject.handle(
+			{ pageId: 7, subjectId: 's1demo', comment: 'promote Berlin' },
+			ctx,
+		);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'promote Berlin (via neowiki-set-main-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('attributes a write the caller gave no comment for', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiSetMainSubject.handle({ pageId: 7, subjectId: 's1demo' }, ctx);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'Automated edit (via neowiki-set-main-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('drops the attribution for a wiki that opts out of it', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiSetMainSubject.handle(
+			{ pageId: 7, subjectId: 's1demo', comment: 'promote Berlin' },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).toMatchObject({ comment: 'promote Berlin' });
+	});
+
+	it('sends no comment at all when a wiki opts out and the caller gave none', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiSetMainSubject.handle(
+			{ pageId: 7, subjectId: 's1demo' },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).not.toHaveProperty('comment');
 	});
 
 	it('rejects when neither title nor pageId is given', async () => {

--- a/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createMockMwn } from '../../../helpers/mock-mwn.ts';
-import { fakeContext } from '../../../helpers/fakeContext.ts';
+import { createMockMwn, type MockMwn } from '../../../helpers/mock-mwn.ts';
+import { fakeContext, withoutEditAttribution } from '../../../helpers/fakeContext.ts';
+import type { ToolContext } from '../../../../src/runtime/context.ts';
 import { neowikiUpdateSubject } from '../../../../src/tools/extensions/neowiki/neowiki-update-subject.ts';
 import { assertStructuredError } from '../../../helpers/structuredResult.ts';
 
@@ -11,6 +12,20 @@ function httpError(status: number, data: unknown): Error & { response: unknown }
 }
 
 const stmts = { Founded: { propertyType: 'number', value: 2019 } };
+
+function contextWith(): { mock: MockMwn; ctx: ToolContext } {
+	const mock = createMockMwn({
+		getCsrfToken: vi.fn().mockResolvedValue('tok'),
+		rawRequest: vi.fn().mockResolvedValue({ data: { status: 'updated', subjectId: 's1demo' } }),
+	});
+	return { mock, ctx: fakeContext({ mwn: async () => mock as never }) };
+}
+
+function sentBody(mock: MockMwn): Record<string, unknown> {
+	const { data } = mock.rawRequest.mock.calls[0][0] as { data: string };
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON body the tool sent
+	return JSON.parse(data) as Record<string, unknown>;
+}
 
 describe('neowiki-update-subject', () => {
 	it('PUTs a full replace with a CSRF token', async () => {
@@ -32,8 +47,53 @@ describe('neowiki-update-subject', () => {
 		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/subject/s1demo');
 		expect(call.method).toBe('PUT');
 		expect(call.headers['X-CSRF-TOKEN']).toBe('tok');
-		expect(JSON.parse(call.data)).toEqual({ label: 'ACME', statements: stmts, comment: 'tidy' });
+		expect(JSON.parse(call.data)).toMatchObject({ label: 'ACME', statements: stmts });
 		expect(result.structuredContent).toMatchObject({ subjectId: 's1demo', status: 'updated' });
+	});
+
+	it('attributes the write to the tool that made it, after the caller comment', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiUpdateSubject.handle(
+			{ id: 's1demo', label: 'ACME', statements: stmts, comment: 'tidy' },
+			ctx,
+		);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'tidy (via neowiki-update-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('attributes a write the caller gave no comment for', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiUpdateSubject.handle({ id: 's1demo', label: 'ACME', statements: stmts }, ctx);
+
+		expect(sentBody(mock)).toMatchObject({
+			comment: 'Automated edit (via neowiki-update-subject on MediaWiki MCP Server)',
+		});
+	});
+
+	it('drops the attribution for a wiki that opts out of it', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiUpdateSubject.handle(
+			{ id: 's1demo', label: 'ACME', statements: stmts, comment: 'tidy' },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).toMatchObject({ comment: 'tidy' });
+	});
+
+	it('sends no comment at all when a wiki opts out and the caller gave none', async () => {
+		const { mock, ctx } = contextWith();
+
+		await neowikiUpdateSubject.handle(
+			{ id: 's1demo', label: 'ACME', statements: stmts },
+			withoutEditAttribution(ctx),
+		);
+
+		expect(sentBody(mock)).not.toHaveProperty('comment');
 	});
 
 	it('maps a 404 to not_found', async () => {

--- a/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
+++ b/tests/tools/extensions/neowiki/neowiki-update-subject.test.ts
@@ -59,7 +59,9 @@ describe('neowiki-update-subject', () => {
 			ctx,
 		);
 
-		expect(sentBody(mock)).toMatchObject({
+		expect(sentBody(mock)).toEqual({
+			label: 'ACME',
+			statements: stmts,
 			comment: 'tidy (via neowiki-update-subject on MediaWiki MCP Server)',
 		});
 	});


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/550

The four NeoWiki write tools passed the caller's comment straight to the NeoWiki REST API, so a subject write carried no `(via <tool> on MediaWiki MCP Server)` suffix and a wiki setting `attributeEdits: false` saw no change from them. Every other write tool composed its summary through `formatEditComment` already; this was the last pack that did not.

Each tool now composes its summary the same way. A wiki that opts out and a caller that gave no comment leave nothing to send, and the tools then omit the `comment` field rather than sending an empty one: NeoWiki reads an absent comment as "use my own default summary" and an empty one as the summary itself. `neowiki-delete-subject` sends no request body at all in that case.

A subject write with no caller comment now lands `Automated edit (via <tool> on MediaWiki MCP Server)` in page history, where it previously landed NeoWiki's own default summary.

`docs/configuration.md` said an opted-out write with no caller comment carries an empty summary. That was never quite right and is not right now: these four tools send no summary field at all, so NeoWiki's own default stands, while every other write tool sends an empty string and the wiki substitutes a default only in the few cases its own autosummary rules cover. The page now states what the server sends and leaves what gets recorded to MediaWiki.

## For the reviewer

Two decisions the issue left open, both worth a second opinion:

- **The empty case omits the field rather than sending `""`.** NeoWiki's write paths all reach `CommentStoreComment::newUnsavedComment( $comment ?? 'Update NeoWiki subject' )`, so an empty string would replace NeoWiki's own default summary with a blank one. The four tools are consistent in this.
- **`neowiki-delete-subject` now sends a body on almost every call.** MediaWiki's REST framework puts `DELETE` in neither `NO_BODY_METHODS` nor `BODY_METHODS`, so it parses a JSON body when one is present and does not require one — both shapes are valid, and `DeleteSubjectApi` reads `getValidatedBody() ?? []` for exactly this reason.

## Verification

`npm test`, `npm run lint`, `npm run typecheck`, `npm run fmt:check` all clean. CI green. Sixteen attribution tests, four per tool, each pinning the JSON body the tool hands to mwn; the eight opt-out cases pass against the old code as well, so they were confirmed against a helper mutated to attribute unconditionally.

The tools were **not** exercised against a running NeoWiki: the SSRF guard refuses a loopback wiki, so no extension pack registers against a local one. The composed string's fate was read from the NeoWiki source instead — it reaches the revision comment verbatim, with no structured autocomment of the API's own for the suffix to land after.

Considered, omitted: an example of the opted-out no-comment summary in `docs/configuration.md` (the section already carries two examples for the attributed case, and the exact default text is not what the operator's decision turns on).

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; filed by @alistair3149, fixed by an unattended batch run with no human steering; diff not yet human-reviewed; tests written first and run locally, gates clean, NeoWiki tools not exercised against a live wiki (see Verification).</sub>


