### PR TITLE
Decide redirects in one place instead of along a loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- A redirected `POST` now continues the way the redirect status asks: a `301`, `302` or `303` becomes a GET with no body, where every hop used to re-send the original method and body and the target rejected it. This is reachable through a configured `sparqlEndpoint` that redirects, such as an `http` URL or a bare host. A `307` or `308` still re-sends the method and body.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- A redirected `POST` now continues the way the redirect status asks: a `301`, `302` or `303` becomes a GET with no body, where every hop used to re-send the original method and body and the target rejected it. This is reachable through a configured `sparqlEndpoint` that redirects, such as an `http` URL or a bare host. A `307` or `308` still re-sends the method and body.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 
 ## [0.16.0] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
+- Following a redirect no longer holds a connection open for every hop it followed, no longer drops from `https` to `http` without saying so, and no longer treats a `300` or a `305` as an address to follow. This affects the siteinfo probe, wiki discovery and the `*-from-url` tools; a wiki whose published URL redirects to an `http` address is now reported rather than quietly used.
 - NeoWiki subject writes now carry the `(via <tool> on MediaWiki MCP Server)` edit-summary suffix, as every other write already did. A wiki that sets `attributeEdits: false` sees no change.
 - `update-page` no longer advertises itself as idempotent: in `mode='append'` and `mode='prepend'` it never was, so a client replaying a call whose result never arrived adds the content a second time. A replace resends the same content rather than adding to it.
 - `upload-file-from-url` and `update-file-from-url` no longer leak a connection when they refuse a source URL whose declared size is over `MCP_UPLOAD_MAX_BYTES`. Each refused call held one connection open for as long as the server ran.

--- a/src/tools/extensions/wikibase/sparql.ts
+++ b/src/tools/extensions/wikibase/sparql.ts
@@ -1,5 +1,10 @@
 import type { ErrorCategory } from '../../../errors/classifyError.ts';
-import { FileTooLargeError, HttpStatusError, postForm } from '../../../transport/httpFetch.ts';
+import {
+	FileTooLargeError,
+	HttpStatusError,
+	postForm,
+	RedirectDropsBodyError,
+} from '../../../transport/httpFetch.ts';
 import { getRequestSignal } from '../../../runtime/requestContext.ts';
 
 /** Matches the query timeout most Wikibase query services enforce themselves. */
@@ -134,6 +139,12 @@ function renderRow(binding: unknown, columns: string[]): string {
 }
 
 function classifyQueryFailure(err: unknown, endpoint: string): SparqlError {
+	if (err instanceof RedirectDropsBodyError) {
+		return new SparqlError(
+			'upstream_failure',
+			`The query service redirected the query to ${originOf(err.target)} instead of answering it (HTTP ${err.status}), and a SPARQL query cannot survive that redirect. The wiki advertises this endpoint in its siteinfo as \`wikibase-sparql\`, so its operator has to point that at an address which answers directly.`,
+		);
+	}
 	if (err instanceof HttpStatusError) {
 		return new SparqlError(categoryForStatus(err.status), serviceMessage(err, endpoint));
 	}
@@ -151,6 +162,17 @@ function classifyQueryFailure(err: unknown, endpoint: string): SparqlError {
 	}
 	const message = err instanceof Error ? err.message : String(err);
 	return new SparqlError('upstream_failure', withoutEndpoint(message, endpoint));
+}
+
+/**
+ * Scheme and host of a redirect target, without its path or query. A target
+ * derived from the endpoint inherits whatever the endpoint carries, and differing
+ * in scheme it is not a substring `withoutEndpoint` can find — so the parts that
+ * can hold a token are dropped rather than substituted. Scheme and host are what
+ * an operator needs to recognise the redirect, and hold no credentials.
+ */
+function originOf(target: string): string {
+	return new URL(target).origin;
 }
 
 /**

--- a/src/tools/extensions/wikibase/sparql.ts
+++ b/src/tools/extensions/wikibase/sparql.ts
@@ -1,10 +1,6 @@
 import type { ErrorCategory } from '../../../errors/classifyError.ts';
-import {
-	FileTooLargeError,
-	HttpStatusError,
-	postForm,
-	RedirectDropsBodyError,
-} from '../../../transport/httpFetch.ts';
+import { FileTooLargeError, HttpStatusError, postForm } from '../../../transport/httpFetch.ts';
+import { RedirectDropsBodyError } from '../../../transport/requestChain.ts';
 import { getRequestSignal } from '../../../runtime/requestContext.ts';
 
 /** Matches the query timeout most Wikibase query services enforce themselves. */

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -41,6 +41,23 @@ function resolveUploadMaxBytes(): number {
 	return parsed;
 }
 
+/**
+ * A redirect asked for the request to be re-sent without its body. `target` is
+ * the absolute URL that was not followed; it is kept off the message, because a
+ * URL derived from a configured endpoint can carry that endpoint's credentials,
+ * and the message reaches both the caller and the logs.
+ */
+export class RedirectDropsBodyError extends Error {
+	public readonly status: number;
+	public readonly target: string;
+	public constructor(status: number, target: string) {
+		super(`Refusing to follow an HTTP ${status} redirect: it would drop the request body.`);
+		this.name = 'RedirectDropsBodyError';
+		this.status = status;
+		this.target = target;
+	}
+}
+
 /** A fetched URL responded with a non-2xx status: the source was reachable but rejected the request. */
 export class HttpStatusError extends Error {
 	public readonly status: number;
@@ -71,33 +88,16 @@ export class FileTooLargeError extends Error {
 // Only 307 and 308 ask for the original method and body again. RFC 9110 defines
 // a 303 as a GET on another resource, and browsers and every mainstream client
 // treat 301 and 302 the same way, which the Fetch standard writes down as a
-// rule. The requests this module sends are GET and POST, for which every status
-// but those two means GET; a caller sending PUT or DELETE would need the status
-// paired with the method, since 301 and 302 redirect only a POST.
+// rule: re-send as a GET, with no body.
+//
+// A body is the whole request for the one caller that sends one — a SPARQL query
+// travels in it — so following such a redirect would send a request that cannot
+// answer, and report whatever the target said about it instead of the redirect.
+// This module refuses that hop rather than performing it. Every other request it
+// sends is already a bodyless GET, which a redirect of any of these statuses
+// leaves unchanged; a caller that sent a bodyless POST would need the method
+// downgrade this deliberately does not implement.
 const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
-
-function downgradesToGet(status: number): boolean {
-	return !METHOD_PRESERVING_REDIRECTS.has(status);
-}
-
-// Headers that describe a request body go when the body goes: a bodyless GET
-// announcing a Content-Type describes something it is not sending. Fetch leaves
-// Content-Length out of this list because there the fetch layer always owns it;
-// node-fetch recomputes it only for a request that has a body, so a value a
-// caller set survives onto the bodyless GET unless it goes here too.
-const BODY_HEADERS = new Set([
-	'content-encoding',
-	'content-language',
-	'content-length',
-	'content-location',
-	'content-type',
-]);
-
-function withoutBodyHeaders(headers: Record<string, string>): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(headers).filter(([name]) => !BODY_HEADERS.has(name.toLowerCase())),
-	);
-}
 
 async function fetchCore(
 	baseUrl: string,
@@ -122,7 +122,7 @@ async function fetchCore(
 		}
 	}
 
-	let requestHeaders: Record<string, string> = {
+	const requestHeaders: Record<string, string> = {
 		'User-Agent': USER_AGENT,
 	};
 
@@ -131,8 +131,6 @@ async function fetchCore(
 	}
 
 	let currentUrl = url;
-	let currentMethod = options?.method || 'GET';
-	let currentBody = options?.body;
 	let response: Response | undefined;
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		const addresses = await assertPublicDestination(currentUrl);
@@ -146,8 +144,8 @@ async function fetchCore(
 		options?.signal?.throwIfAborted();
 		response = await fetch(currentUrl, {
 			headers: requestHeaders,
-			method: currentMethod,
-			...(currentBody !== undefined ? { body: currentBody } : {}),
+			method: options?.method || 'GET',
+			...(options?.body !== undefined ? { body: options.body } : {}),
 			redirect: 'manual',
 			agent,
 			signal: options?.signal,
@@ -167,12 +165,11 @@ async function fetchCore(
 		}
 
 		currentUrl = new URL(location, currentUrl).toString();
-		// A downgrade holds for the rest of the chain: once the request is a
-		// bodyless GET, a later 307 has a bodyless GET to preserve.
-		if (downgradesToGet(response.status)) {
-			currentMethod = 'GET';
-			currentBody = undefined;
-			requestHeaders = withoutBodyHeaders(requestHeaders);
+		// Checked every hop, not just the first: a 307 that preserves the body can
+		// be followed by a 303 that would drop it.
+		if (options?.body !== undefined && !METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+			destroyBody(response);
+			throw new RedirectDropsBodyError(response.status, currentUrl);
 		}
 	}
 

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -3,8 +3,22 @@ import fetch, { Response, FetchError } from 'node-fetch';
 import { USER_AGENT } from '../runtime/constants.ts';
 import { isErrnoException } from '../errors/isErrnoException.ts';
 import { assertPublicDestination, buildPinnedAgent, SsrfValidationError } from './ssrfGuard.ts';
+import {
+	firstRequest,
+	nextHop,
+	type FetchSpec,
+	type HopRequest,
+	type HopResponse,
+} from './requestChain.ts';
 
-const MAX_REDIRECTS = 5;
+/** What a caller passes to `fetchCore`: the request itself, plus its cancellation. */
+type FetchOptions = FetchSpec & { signal?: AbortSignal };
+
+/**
+ * A failing source's own explanation is worth reporting, and its length is the
+ * source's choice, so this much of it is read and the rest abandoned.
+ */
+const MAX_ERROR_BODY_BYTES = 8 * 1024;
 
 // Node syscall error codes that mean "the server could not reach the source"
 // (DNS failure, connection refused/reset, unreachable/timed-out). These should
@@ -41,23 +55,6 @@ function resolveUploadMaxBytes(): number {
 	return parsed;
 }
 
-/**
- * A redirect asked for the request to be re-sent without its body. `target` is
- * the absolute URL that was not followed; it is kept off the message, because a
- * URL derived from a configured endpoint can carry that endpoint's credentials,
- * and the message reaches both the caller and the logs.
- */
-export class RedirectDropsBodyError extends Error {
-	public readonly status: number;
-	public readonly target: string;
-	public constructor(status: number, target: string) {
-		super(`Refusing to follow an HTTP ${status} redirect: it would drop the request body.`);
-		this.name = 'RedirectDropsBodyError';
-		this.status = status;
-		this.target = target;
-	}
-}
-
 /** A fetched URL responded with a non-2xx status: the source was reachable but rejected the request. */
 export class HttpStatusError extends Error {
 	public readonly status: number;
@@ -85,102 +82,85 @@ export class FileTooLargeError extends Error {
 	}
 }
 
-// Only 307 and 308 ask for the original method and body again. RFC 9110 defines
-// a 303 as a GET on another resource, and browsers and every mainstream client
-// treat 301 and 302 the same way, which the Fetch standard writes down as a
-// rule: re-send as a GET, with no body.
-//
-// A body is the whole request for the one caller that sends one — a SPARQL query
-// travels in it — so following such a redirect would send a request that cannot
-// answer, and report whatever the target said about it instead of the redirect.
-// This module refuses that hop rather than performing it. Every other request it
-// sends is already a bodyless GET, which a redirect of any of these statuses
-// leaves unchanged; a caller that sent a bodyless POST would need the method
-// downgrade this deliberately does not implement.
-const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
-
-async function fetchCore(
-	baseUrl: string,
-	options?: {
-		params?: Record<string, string>;
-		headers?: Record<string, string>;
-		method?: string;
-		body?: string;
-		signal?: AbortSignal;
-	},
-): Promise<Response> {
-	let url = baseUrl;
-
-	if (url.startsWith('//')) {
-		url = 'https:' + url;
+/**
+ * Drives a request through its redirect chain. Every rule about which hops to
+ * follow lives in `nextHop`; this performs the I/O each decision asks for. A
+ * response that is not delivered leaves through one place, which is what keeps
+ * every abandoned body — followed hop, refusal and cap alike — from stranding
+ * its connection.
+ */
+async function fetchCore(baseUrl: string, options?: FetchOptions): Promise<Response> {
+	let request = firstRequest(baseUrl, options);
+	for (;;) {
+		const response = await sendHop(request, options?.signal);
+		const decision = nextHop(request, readHop(response));
+		if (decision.kind === 'deliver') {
+			return await delivered(response);
+		}
+		destroyBody(response);
+		if (decision.kind === 'refuse') {
+			throw decision.error;
+		}
+		request = decision.request;
 	}
+}
 
-	if (options?.params) {
-		const queryString = new URLSearchParams(options.params).toString();
-		if (queryString) {
-			url = `${url}?${queryString}`;
+/** Sends one hop, through the SSRF guard and an agent pinned to what it resolved. */
+async function sendHop(request: HopRequest, signal?: AbortSignal): Promise<Response> {
+	const addresses = await assertPublicDestination(request.url);
+	const agent = buildPinnedAgent(request.url, addresses);
+	// Handed a body and a signal that is already aborted, node-fetch destroys
+	// the body stream before anything subscribes to it, and the unhandled
+	// 'error' event takes the process down. The DNS lookup above is a window
+	// wide enough for a cancellation to land in, once per hop, so refuse the
+	// request here instead. Throwing the signal's own reason keeps the
+	// AbortError callers classify on.
+	signal?.throwIfAborted();
+	return await fetch(request.url, {
+		headers: { 'User-Agent': USER_AGENT, ...request.headers },
+		method: request.method,
+		...(request.body === undefined ? {} : { body: request.body }),
+		redirect: 'manual',
+		agent,
+		signal,
+	});
+}
+
+/** The two fields the redirect decision reads, and nothing else. */
+function readHop(response: Response): HopResponse {
+	return { status: response.status, location: response.headers.get('location') };
+}
+
+/** A 2xx passes through; anything else becomes the source's own diagnostics. */
+async function delivered(response: Response): Promise<Response> {
+	if (response.ok) {
+		return response;
+	}
+	const errorBody = await readTruncated(response, MAX_ERROR_BODY_BYTES).catch(() => '');
+	throw new HttpStatusError(response.status, response.url, errorBody);
+}
+
+/**
+ * Reads at most `maxBytes` of a body and abandons the rest. Truncating rather
+ * than refusing, because this reads the diagnostics of a failure that is already
+ * being reported: a cap that threw would replace the source's explanation with
+ * nothing, on a body whose size the source chooses.
+ */
+async function readTruncated(response: Response, maxBytes: number): Promise<string> {
+	const chunks: Buffer[] = [];
+	let total = 0;
+	if (response.body !== null) {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- node-fetch v3 body is always a Node.js Readable; narrowing to AsyncIterable<Buffer> is safe at this boundary
+		for await (const chunk of response.body as AsyncIterable<Buffer>) {
+			chunks.push(chunk);
+			total += chunk.length;
+			if (total >= maxBytes) {
+				break;
+			}
 		}
 	}
-
-	const requestHeaders: Record<string, string> = {
-		'User-Agent': USER_AGENT,
-	};
-
-	if (options?.headers) {
-		Object.assign(requestHeaders, options.headers);
-	}
-
-	let currentUrl = url;
-	let response: Response | undefined;
-	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-		const addresses = await assertPublicDestination(currentUrl);
-		const agent = buildPinnedAgent(currentUrl, addresses);
-		// Handed a body and a signal that is already aborted, node-fetch destroys
-		// the body stream before anything subscribes to it, and the unhandled
-		// 'error' event takes the process down. The DNS lookup above is a window
-		// wide enough for a cancellation to land in, once per hop, so refuse the
-		// request here instead. Throwing the signal's own reason keeps the
-		// AbortError callers classify on.
-		options?.signal?.throwIfAborted();
-		response = await fetch(currentUrl, {
-			headers: requestHeaders,
-			method: options?.method || 'GET',
-			...(options?.body !== undefined ? { body: options.body } : {}),
-			redirect: 'manual',
-			agent,
-			signal: options?.signal,
-		});
-
-		if (response.status < 300 || response.status >= 400) {
-			break;
-		}
-
-		const location = response.headers.get('location');
-		if (!location) {
-			break;
-		}
-
-		if (hop === MAX_REDIRECTS) {
-			throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting from ${url}`);
-		}
-
-		currentUrl = new URL(location, currentUrl).toString();
-		// Checked every hop, not just the first: a 307 that preserves the body can
-		// be followed by a 303 that would drop it.
-		if (options?.body !== undefined && !METHOD_PRESERVING_REDIRECTS.has(response.status)) {
-			destroyBody(response);
-			throw new RedirectDropsBodyError(response.status, currentUrl);
-		}
-	}
-
-	// response is always assigned inside the loop (loop runs at least once).
-	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- definite-assignment via the loop's at-least-once invariant; TS can't prove it
-	const finalResponse = response as Response;
-	if (!finalResponse.ok) {
-		const errorBody = await finalResponse.text().catch(() => '');
-		throw new HttpStatusError(finalResponse.status, finalResponse.url, errorBody);
-	}
-	return finalResponse;
+	destroyBody(response);
+	return Buffer.concat(chunks).toString('utf8').slice(0, maxBytes);
 }
 
 export async function makeApiRequest<T>(
@@ -216,7 +196,6 @@ export async function postForm(
 	options?: { headers?: Record<string, string>; signal?: AbortSignal; maxBytes?: number },
 ): Promise<string> {
 	const response = await fetchCore(url, {
-		method: 'POST',
 		body: new URLSearchParams(form).toString(),
 		headers: { ...options?.headers, 'Content-Type': 'application/x-www-form-urlencoded' },
 		signal: options?.signal,

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -67,6 +67,27 @@ export class FileTooLargeError extends Error {
 	}
 }
 
+// Only 307 and 308 ask for the original method and body again: RFC 9110 makes a
+// 303 a bodyless GET, and 301 and 302 are treated the same way. The requests
+// this module sends are GET and POST, for which every other status means GET; a
+// caller sending PUT or DELETE would need the status paired with the method.
+const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
+
+// Headers that describe a request body go when the body goes: a bodyless GET
+// announcing a Content-Type describes something it is not sending.
+const BODY_HEADERS = new Set([
+	'content-encoding',
+	'content-language',
+	'content-location',
+	'content-type',
+]);
+
+function withoutBodyHeaders(headers: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([name]) => !BODY_HEADERS.has(name.toLowerCase())),
+	);
+}
+
 async function fetchCore(
 	baseUrl: string,
 	options?: {
@@ -90,7 +111,7 @@ async function fetchCore(
 		}
 	}
 
-	const requestHeaders: Record<string, string> = {
+	let requestHeaders: Record<string, string> = {
 		'User-Agent': USER_AGENT,
 	};
 
@@ -99,6 +120,8 @@ async function fetchCore(
 	}
 
 	let currentUrl = url;
+	let currentMethod = options?.method || 'GET';
+	let currentBody = options?.body;
 	let response: Response | undefined;
 	for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
 		const addresses = await assertPublicDestination(currentUrl);
@@ -112,8 +135,8 @@ async function fetchCore(
 		options?.signal?.throwIfAborted();
 		response = await fetch(currentUrl, {
 			headers: requestHeaders,
-			method: options?.method || 'GET',
-			...(options?.body !== undefined ? { body: options.body } : {}),
+			method: currentMethod,
+			...(currentBody !== undefined ? { body: currentBody } : {}),
 			redirect: 'manual',
 			agent,
 			signal: options?.signal,
@@ -133,6 +156,13 @@ async function fetchCore(
 		}
 
 		currentUrl = new URL(location, currentUrl).toString();
+		// A downgrade holds for the rest of the chain: once the request is a
+		// bodyless GET, a later 307 has a bodyless GET to preserve.
+		if (!METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+			currentMethod = 'GET';
+			currentBody = undefined;
+			requestHeaders = withoutBodyHeaders(requestHeaders);
+		}
 	}
 
 	// response is always assigned inside the loop (loop runs at least once).

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -67,17 +67,27 @@ export class FileTooLargeError extends Error {
 	}
 }
 
-// Only 307 and 308 ask for the original method and body again: RFC 9110 makes a
-// 303 a bodyless GET, and 301 and 302 are treated the same way. The requests
-// this module sends are GET and POST, for which every other status means GET; a
-// caller sending PUT or DELETE would need the status paired with the method.
+// Only 307 and 308 ask for the original method and body again. RFC 9110 defines
+// a 303 as a GET on another resource, and browsers and every mainstream client
+// treat 301 and 302 the same way, which the Fetch standard writes down as a
+// rule. The requests this module sends are GET and POST, for which every status
+// but those two means GET; a caller sending PUT or DELETE would need the status
+// paired with the method, since 301 and 302 redirect only a POST.
 const METHOD_PRESERVING_REDIRECTS = new Set([307, 308]);
 
+function downgradesToGet(status: number): boolean {
+	return !METHOD_PRESERVING_REDIRECTS.has(status);
+}
+
 // Headers that describe a request body go when the body goes: a bodyless GET
-// announcing a Content-Type describes something it is not sending.
+// announcing a Content-Type describes something it is not sending. Fetch leaves
+// Content-Length out of this list because there the fetch layer always owns it;
+// node-fetch recomputes it only for a request that has a body, so a value a
+// caller set survives onto the bodyless GET unless it goes here too.
 const BODY_HEADERS = new Set([
 	'content-encoding',
 	'content-language',
+	'content-length',
 	'content-location',
 	'content-type',
 ]);
@@ -158,7 +168,7 @@ async function fetchCore(
 		currentUrl = new URL(location, currentUrl).toString();
 		// A downgrade holds for the rest of the chain: once the request is a
 		// bodyless GET, a later 307 has a bodyless GET to preserve.
-		if (!METHOD_PRESERVING_REDIRECTS.has(response.status)) {
+		if (downgradesToGet(response.status)) {
 			currentMethod = 'GET';
 			currentBody = undefined;
 			requestHeaders = withoutBodyHeaders(requestHeaders);

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -11,13 +11,10 @@ import {
 	type HopResponse,
 } from './requestChain.ts';
 
-/** What a caller passes to `fetchCore`: the request itself, plus its cancellation. */
+/** The request, plus its cancellation. */
 type FetchOptions = FetchSpec & { signal?: AbortSignal };
 
-/**
- * A failing source's own explanation is worth reporting, and its length is the
- * source's choice, so this much of it is read and the rest abandoned.
- */
+/** A failing source's explanation is worth reporting; its length is the source's choice. */
 const MAX_ERROR_BODY_BYTES = 8 * 1024;
 
 // Node syscall error codes that mean "the server could not reach the source"
@@ -83,11 +80,9 @@ export class FileTooLargeError extends Error {
 }
 
 /**
- * Drives a request through its redirect chain. Every rule about which hops to
- * follow lives in `nextHop`; this performs the I/O each decision asks for. A
- * response that is not delivered leaves through one place, which is what keeps
- * every abandoned body — followed hop, refusal and cap alike — from stranding
- * its connection.
+ * Drives a request through its redirect chain, performing the I/O `nextHop` asks
+ * for. Every response that is not delivered leaves through one place, which is
+ * what keeps an abandoned body from stranding its connection.
  */
 async function fetchCore(baseUrl: string, options?: FetchOptions): Promise<Response> {
 	let request = firstRequest(baseUrl, options);
@@ -105,7 +100,7 @@ async function fetchCore(baseUrl: string, options?: FetchOptions): Promise<Respo
 	}
 }
 
-/** Sends one hop, through the SSRF guard and an agent pinned to what it resolved. */
+/** One hop, through the SSRF guard and an agent pinned to what it resolved. */
 async function sendHop(request: HopRequest, signal?: AbortSignal): Promise<Response> {
 	const addresses = await assertPublicDestination(request.url);
 	const agent = buildPinnedAgent(request.url, addresses);
@@ -126,7 +121,7 @@ async function sendHop(request: HopRequest, signal?: AbortSignal): Promise<Respo
 	});
 }
 
-/** The two fields the redirect decision reads, and nothing else. */
+/** The two fields the decision reads. */
 function readHop(response: Response): HopResponse {
 	return { status: response.status, location: response.headers.get('location') };
 }
@@ -141,10 +136,9 @@ async function delivered(response: Response): Promise<Response> {
 }
 
 /**
- * Reads at most `maxBytes` of a body and abandons the rest. Truncating rather
- * than refusing, because this reads the diagnostics of a failure that is already
- * being reported: a cap that threw would replace the source's explanation with
- * nothing, on a body whose size the source chooses.
+ * Reads at most `maxBytes` and abandons the rest. Truncating rather than
+ * refusing: a cap that threw would replace the failure being reported with
+ * nothing.
  */
 async function readTruncated(response: Response, maxBytes: number): Promise<string> {
 	const chunks: Buffer[] = [];

--- a/src/transport/requestChain.ts
+++ b/src/transport/requestChain.ts
@@ -1,0 +1,224 @@
+/**
+ * The rules for following a redirect, as one pure decision.
+ *
+ * This module owns no sockets, no DNS and no clock: `nextHop` reads what was
+ * sent and the status and Location that came back, and says whether to deliver
+ * the response, send another request, or refuse. The transport drives it and
+ * performs whatever the decision asks for, so each rule below is a value
+ * assertion in a test rather than something only observable through a server.
+ *
+ * It follows the Fetch standard's HTTP-redirect fetch, with two deliberate
+ * departures, both of which exist because this server fetches URLs a caller
+ * chose:
+ *
+ * 1. A hop that would drop the request body is refused rather than performed.
+ *    The standard re-sends a 301, 302 or 303 as a bodyless GET, but the one
+ *    caller here that sends a body sends a SPARQL query in it, so that GET
+ *    reaches the target with nothing to run and the target's answer describes a
+ *    request nobody made. The published endpoint URL having moved is the fault
+ *    worth reporting.
+ * 2. A hop that drops from `https` to `http` is refused. The standard follows
+ *    it, having only stripped the credentials.
+ *
+ * Credential headers are dropped across any change of origin, which is stricter
+ * than node-fetch: it keeps them for a subdomain of the current host and ignores
+ * the port, so a host that hands its tenants subdomains would forward one
+ * tenant's credentials to another.
+ */
+
+/** Redirects this server follows. Every other 3xx is delivered as the status it is. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** The two that ask for the original method and body again. */
+const BODY_PRESERVING_STATUSES = new Set([307, 308]);
+
+/** Headers that authenticate the request they are sent on, and so belong to one origin. */
+const CREDENTIAL_HEADERS = new Set(['authorization', 'www-authenticate', 'cookie', 'cookie2']);
+
+/** Hops followed before the chain is refused. */
+export const MAX_REDIRECTS = 5;
+
+/**
+ * A redirect asked for the request to be re-sent without its body. `target` is
+ * the absolute URL that was not followed; it is kept off the message, because a
+ * URL derived from a configured endpoint can carry that endpoint's credentials,
+ * and the message reaches both the caller and the logs.
+ */
+export class RedirectDropsBodyError extends Error {
+	public readonly status: number;
+	public readonly target: string;
+	public constructor(status: number, target: string) {
+		super(`Refusing to follow an HTTP ${status} redirect: it would drop the request body.`);
+		this.name = 'RedirectDropsBodyError';
+		this.status = status;
+		this.target = target;
+	}
+}
+
+/**
+ * A redirect pointed from `https` to `http`. Following it would put the rest of
+ * the exchange, including anything already sent, on the wire in clear text.
+ * `target` is withheld from the message for the same reason as above.
+ */
+export class InsecureRedirectError extends Error {
+	public readonly status: number;
+	public readonly target: string;
+	public constructor(status: number, target: string) {
+		super(`Refusing to follow an HTTP ${status} redirect from https to http.`);
+		this.name = 'InsecureRedirectError';
+		this.status = status;
+		this.target = target;
+	}
+}
+
+/** A redirect's Location is not a URL, even read against the hop that sent it. */
+export class UnusableLocationError extends Error {
+	public readonly status: number;
+	public constructor(status: number) {
+		super(`An HTTP ${status} redirect gave a Location that is not a URL.`);
+		this.name = 'UnusableLocationError';
+		this.status = status;
+	}
+}
+
+/** A chain asked for more hops than this server follows. */
+export class TooManyRedirectsError extends Error {
+	public readonly startUrl: string;
+	public constructor(startUrl: string) {
+		super(`Refusing to follow more than ${MAX_REDIRECTS} redirects starting from ${startUrl}.`);
+		this.name = 'TooManyRedirectsError';
+		this.startUrl = startUrl;
+	}
+}
+
+/** A refusal to continue a chain. Every member carries the status that asked for it. */
+export type RedirectRefusal =
+	| RedirectDropsBodyError
+	| InsecureRedirectError
+	| UnusableLocationError
+	| TooManyRedirectsError;
+
+/** What a caller asks for, before any of it reaches a socket. */
+export interface FetchSpec {
+	params?: Record<string, string>;
+	headers?: Record<string, string>;
+	/** Present means POST; absent means GET. A bodyless POST is not representable. */
+	body?: string;
+}
+
+/** One request in a chain: what to send, and where it sits in the chain. */
+export interface HopRequest {
+	/** Absolute, with `params` already applied. */
+	readonly url: string;
+	readonly method: 'GET' | 'POST';
+	readonly body?: string;
+	readonly headers: Readonly<Record<string, string>>;
+	readonly redirectsFollowed: number;
+	/** The URL the chain began at, which the cap refusal names. Constant across the chain. */
+	readonly startUrl: string;
+}
+
+/** The only parts of a response the decision reads. */
+export interface HopResponse {
+	readonly status: number;
+	readonly location: string | null;
+}
+
+export type HopDecision =
+	| { readonly kind: 'deliver' }
+	| { readonly kind: 'follow'; readonly request: HopRequest }
+	| { readonly kind: 'refuse'; readonly error: RedirectRefusal };
+
+/** The first request of a chain, from what the caller asked for. */
+export function firstRequest(baseUrl: string, spec?: FetchSpec): HopRequest {
+	const url = withParams(absolute(baseUrl), spec?.params);
+	return {
+		url,
+		method: spec?.body === undefined ? 'GET' : 'POST',
+		...(spec?.body === undefined ? {} : { body: spec.body }),
+		headers: { ...spec?.headers },
+		redirectsFollowed: 0,
+		startUrl: url,
+	};
+}
+
+/**
+ * What to do with the response to `sent`. Guard clauses in the order the rules
+ * apply: a non-redirect is delivered, then the cap, then the Location has to
+ * parse, then the two refusals, then the hop is followed.
+ *
+ * These rules all precede the transport's own per-hop address check, since they
+ * cost nothing and it costs a DNS lookup. So a hop that is both insecure and
+ * bound for a private address is reported as the insecure one; both refuse it.
+ */
+export function nextHop(sent: HopRequest, received: HopResponse): HopDecision {
+	if (!REDIRECT_STATUSES.has(received.status) || received.location === null) {
+		return { kind: 'deliver' };
+	}
+	if (sent.redirectsFollowed === MAX_REDIRECTS) {
+		return { kind: 'refuse', error: new TooManyRedirectsError(sent.startUrl) };
+	}
+	const target = resolveLocation(received.location, sent.url);
+	if (target === undefined) {
+		return { kind: 'refuse', error: new UnusableLocationError(received.status) };
+	}
+	const refusal = refusalFor(sent, received.status, target);
+	if (refusal !== undefined) {
+		return { kind: 'refuse', error: refusal };
+	}
+	return { kind: 'follow', request: followRequest(sent, target) };
+}
+
+function refusalFor(sent: HopRequest, status: number, target: URL): RedirectRefusal | undefined {
+	const from = new URL(sent.url);
+	if (from.protocol === 'https:' && target.protocol === 'http:') {
+		return new InsecureRedirectError(status, target.toString());
+	}
+	if (sent.body !== undefined && !BODY_PRESERVING_STATUSES.has(status)) {
+		return new RedirectDropsBodyError(status, target.toString());
+	}
+	return undefined;
+}
+
+function followRequest(sent: HopRequest, target: URL): HopRequest {
+	const sameOrigin = new URL(sent.url).origin === target.origin;
+	const headers = sameOrigin ? { ...sent.headers } : withoutCredentials(sent.headers);
+	// A body only survives a 307 or 308, and a hop that would drop one was
+	// refused above, so the method and body carry over untouched.
+	return {
+		url: target.toString(),
+		method: sent.method,
+		...(sent.body === undefined ? {} : { body: sent.body }),
+		headers,
+		redirectsFollowed: sent.redirectsFollowed + 1,
+		startUrl: sent.startUrl,
+	};
+}
+
+function withoutCredentials(headers: Readonly<Record<string, string>>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).filter(([name]) => !CREDENTIAL_HEADERS.has(name.toLowerCase())),
+	);
+}
+
+function resolveLocation(location: string, base: string): URL | undefined {
+	try {
+		return new URL(location, base);
+	} catch {
+		return undefined;
+	}
+}
+
+// A protocol-relative URL is what a wiki's own configuration hands us for a
+// server address, and it means https here.
+function absolute(baseUrl: string): string {
+	return baseUrl.startsWith('//') ? `https:${baseUrl}` : baseUrl;
+}
+
+function withParams(url: string, params?: Record<string, string>): string {
+	if (params === undefined) {
+		return url;
+	}
+	const queryString = new URLSearchParams(params).toString();
+	return queryString === '' ? url : `${url}?${queryString}`;
+}

--- a/src/transport/requestChain.ts
+++ b/src/transport/requestChain.ts
@@ -1,38 +1,22 @@
 /**
- * The rules for following a redirect, as one pure decision.
+ * The Fetch standard's HTTP-redirect fetch as one pure decision, departing from
+ * the standard twice because the URLs here are a caller's to choose. It re-sends
+ * a 301, 302 or 303 as a bodyless GET; this refuses that hop, since the one
+ * caller that sends a body sends the whole request in it. It follows an `https`
+ * to `http` hop with the credentials stripped; this refuses that too.
  *
- * This module owns no sockets, no DNS and no clock: `nextHop` reads what was
- * sent and the status and Location that came back, and says whether to deliver
- * the response, send another request, or refuse. The transport drives it and
- * performs whatever the decision asks for, so each rule below is a value
- * assertion in a test rather than something only observable through a server.
- *
- * It follows the Fetch standard's HTTP-redirect fetch, with two deliberate
- * departures, both of which exist because this server fetches URLs a caller
- * chose:
- *
- * 1. A hop that would drop the request body is refused rather than performed.
- *    The standard re-sends a 301, 302 or 303 as a bodyless GET, but the one
- *    caller here that sends a body sends a SPARQL query in it, so that GET
- *    reaches the target with nothing to run and the target's answer describes a
- *    request nobody made. The published endpoint URL having moved is the fault
- *    worth reporting.
- * 2. A hop that drops from `https` to `http` is refused. The standard follows
- *    it, having only stripped the credentials.
- *
- * Credential headers are dropped across any change of origin, which is stricter
- * than node-fetch: it keeps them for a subdomain of the current host and ignores
- * the port, so a host that hands its tenants subdomains would forward one
- * tenant's credentials to another.
+ * Credentials go on any change of origin. node-fetch keeps them across a
+ * subdomain and ignores the port, which on a host that gives its tenants
+ * subdomains would hand one tenant's credentials to another.
  */
 
-/** Redirects this server follows. Every other 3xx is delivered as the status it is. */
+/** Every other 3xx is delivered as the status it is. */
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 /** The two that ask for the original method and body again. */
 const BODY_PRESERVING_STATUSES = new Set([307, 308]);
 
-/** Headers that authenticate the request they are sent on, and so belong to one origin. */
+/** Headers that authenticate a request, and so belong to one origin. */
 const CREDENTIAL_HEADERS = new Set(['authorization', 'www-authenticate', 'cookie', 'cookie2']);
 
 /** Hops followed before the chain is refused. */
@@ -40,9 +24,8 @@ export const MAX_REDIRECTS = 5;
 
 /**
  * A redirect asked for the request to be re-sent without its body. `target` is
- * the absolute URL that was not followed; it is kept off the message, because a
- * URL derived from a configured endpoint can carry that endpoint's credentials,
- * and the message reaches both the caller and the logs.
+ * kept off the message: a URL derived from a configured endpoint can carry that
+ * endpoint's credentials, and the message reaches the caller and the logs.
  */
 export class RedirectDropsBodyError extends Error {
 	public readonly status: number;
@@ -55,11 +38,7 @@ export class RedirectDropsBodyError extends Error {
 	}
 }
 
-/**
- * A redirect pointed from `https` to `http`. Following it would put the rest of
- * the exchange, including anything already sent, on the wire in clear text.
- * `target` is withheld from the message for the same reason as above.
- */
+/** A redirect pointed from `https` to `http`. `target` is withheld as above. */
 export class InsecureRedirectError extends Error {
 	public readonly status: number;
 	public readonly target: string;
@@ -98,7 +77,7 @@ export type RedirectRefusal =
 	| UnusableLocationError
 	| TooManyRedirectsError;
 
-/** What a caller asks for, before any of it reaches a socket. */
+/** What a caller asks for. */
 export interface FetchSpec {
 	params?: Record<string, string>;
 	headers?: Record<string, string>;
@@ -106,7 +85,7 @@ export interface FetchSpec {
 	body?: string;
 }
 
-/** One request in a chain: what to send, and where it sits in the chain. */
+/** One request in a chain: what to send, and where it sits. */
 export interface HopRequest {
 	/** Absolute, with `params` already applied. */
 	readonly url: string;
@@ -129,7 +108,7 @@ export type HopDecision =
 	| { readonly kind: 'follow'; readonly request: HopRequest }
 	| { readonly kind: 'refuse'; readonly error: RedirectRefusal };
 
-/** The first request of a chain, from what the caller asked for. */
+/** The first request of a chain. */
 export function firstRequest(baseUrl: string, spec?: FetchSpec): HopRequest {
 	const url = withParams(absolute(baseUrl), spec?.params);
 	return {
@@ -143,13 +122,9 @@ export function firstRequest(baseUrl: string, spec?: FetchSpec): HopRequest {
 }
 
 /**
- * What to do with the response to `sent`. Guard clauses in the order the rules
- * apply: a non-redirect is delivered, then the cap, then the Location has to
- * parse, then the two refusals, then the hop is followed.
- *
- * These rules all precede the transport's own per-hop address check, since they
- * cost nothing and it costs a DNS lookup. So a hop that is both insecure and
- * bound for a private address is reported as the insecure one; both refuse it.
+ * These rules run before the transport's per-hop address check, which costs a DNS
+ * lookup, so a hop that is both insecure and bound for a private address is
+ * reported as insecure. Both refuse it.
  */
 export function nextHop(sent: HopRequest, received: HopResponse): HopDecision {
 	if (!REDIRECT_STATUSES.has(received.status) || received.location === null) {
@@ -183,8 +158,7 @@ function refusalFor(sent: HopRequest, status: number, target: URL): RedirectRefu
 function followRequest(sent: HopRequest, target: URL): HopRequest {
 	const sameOrigin = new URL(sent.url).origin === target.origin;
 	const headers = sameOrigin ? { ...sent.headers } : withoutCredentials(sent.headers);
-	// A body only survives a 307 or 308, and a hop that would drop one was
-	// refused above, so the method and body carry over untouched.
+	// A hop that would drop the body was refused above, so both carry over.
 	return {
 		url: target.toString(),
 		method: sent.method,
@@ -209,8 +183,7 @@ function resolveLocation(location: string, base: string): URL | undefined {
 	}
 }
 
-// A protocol-relative URL is what a wiki's own configuration hands us for a
-// server address, and it means https here.
+// A wiki's own configuration hands us these for a server address.
 function absolute(baseUrl: string): string {
 	return baseUrl.startsWith('//') ? `https:${baseUrl}` : baseUrl;
 }

--- a/tests/tools/extensions/wikibase/sparql.test.ts
+++ b/tests/tools/extensions/wikibase/sparql.test.ts
@@ -12,6 +12,7 @@ import {
 	FileTooLargeError,
 	HttpStatusError,
 	postForm,
+	RedirectDropsBodyError,
 } from '../../../../src/transport/httpFetch.ts';
 import { runSparqlQuery, SparqlError } from '../../../../src/tools/extensions/wikibase/sparql.ts';
 import { withRequestFields } from '../../../../src/runtime/requestContext.ts';
@@ -267,6 +268,34 @@ describe('runSparqlQuery', () => {
 		vi.mocked(postForm).mockRejectedValue(new FileTooLargeError(20_000_000, 10_485_760));
 
 		expect((await failureOf(runSparqlQuery(ENDPOINT, CATS, MANY_ROWS))).message).toContain('10 MB');
+	});
+
+	it('says which setting to change when the query service redirects the query', async () => {
+		vi.mocked(postForm).mockRejectedValue(
+			new RedirectDropsBodyError(303, 'https://elsewhere.example.org/sparql'),
+		);
+
+		const error = await failureOf(runSparqlQuery(ENDPOINT, CATS, MANY_ROWS));
+
+		expect(error.category).toBe('upstream_failure');
+		expect(error.message).toContain('303');
+		expect(error.message).toContain('wikibase-sparql');
+	});
+
+	// A redirect target derived from the endpoint inherits its credentials, and
+	// differing in scheme it is not a substring the endpoint substitution finds.
+	// Scheme and host are what identifies the redirect and carry no token.
+	it('names the redirect target by scheme and host only, not by its path or query', async () => {
+		const secret = 'http://query.example.org/sparql?token=hunter2';
+		vi.mocked(postForm).mockRejectedValue(
+			new RedirectDropsBodyError(301, 'https://query.example.org/sparql?token=hunter2'),
+		);
+
+		const error = await failureOf(runSparqlQuery(secret, CATS, MANY_ROWS));
+
+		expect(error.message).toContain('https://query.example.org');
+		expect(error.message).not.toContain('hunter2');
+		expect(error.message).not.toContain('/sparql');
 	});
 
 	// The endpoint is the operator's to know, and it can carry a token in its path

--- a/tests/tools/extensions/wikibase/sparql.test.ts
+++ b/tests/tools/extensions/wikibase/sparql.test.ts
@@ -12,8 +12,8 @@ import {
 	FileTooLargeError,
 	HttpStatusError,
 	postForm,
-	RedirectDropsBodyError,
 } from '../../../../src/transport/httpFetch.ts';
+import { RedirectDropsBodyError } from '../../../../src/transport/requestChain.ts';
 import { runSparqlQuery, SparqlError } from '../../../../src/tools/extensions/wikibase/sparql.ts';
 import { withRequestFields } from '../../../../src/runtime/requestContext.ts';
 

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -53,8 +53,7 @@ beforeAll(async () => {
 			res.write('x'.repeat(64));
 			return;
 		}
-		// A redirect whose own body stalls the same way, for the refusal that
-		// declines to re-send a request body across it.
+		// A stalling body on a redirect that is refused.
 		if (req.url === '/redirect-and-stall') {
 			res.writeHead(301, {
 				Location: '/small',
@@ -63,8 +62,7 @@ beforeAll(async () => {
 			res.write('x');
 			return;
 		}
-		// The same stalling body on a redirect that IS followed, so the hop's own
-		// connection is observable after the chain has moved past it.
+		// The same, on a redirect that is followed.
 		if (req.url === '/followed-and-stall') {
 			res.writeHead(307, {
 				Location: '/small',
@@ -101,9 +99,8 @@ afterAll(async () => {
 });
 
 /**
- * Whether the server's end of every connection it served goes away once the
- * client is done with them. An empty list means no request reached the server, so
- * there is nothing to observe: say so, rather than pass vacuously.
+ * Whether every connection the server served goes away. An empty list means no
+ * request reached it, so there is nothing to observe: say so rather than pass.
  */
 async function connectionsClosed(sockets: Socket[], withinMs = 1000): Promise<boolean> {
 	if (sockets.length === 0) {
@@ -145,9 +142,7 @@ describe('an over-cap body refused against a real server', () => {
 		expect(await connectionsClosed(servedSockets)).toBe(true);
 	});
 
-	// The hop is followed and its own response body is never read, so nothing but
-	// the driver's disposal releases it. Two connections are served here; asserting
-	// on both is the point, since the followed hop's is the one that used to leak.
+	// The followed hop's own body is never read, so only the driver releases it.
 	it('closes the connection behind a redirect it follows', async () => {
 		const body = await postForm(`${origin}/followed-and-stall`, {
 			query: 'SELECT ?x WHERE {}',
@@ -155,10 +150,8 @@ describe('an over-cap body refused against a real server', () => {
 
 		expect(body).toBe('results');
 		expect(servedSockets).toHaveLength(2);
-		// Only the redirect hop's connection is the subject. The final response is
-		// read to completion, and this file stubs the pinned agent away, so its
-		// socket goes back to the keep-alive pool instead of closing — which is
-		// what should happen to a connection someone might reuse.
+		// The final response is read to completion and this file stubs the pinned
+		// agent away, so its socket is pooled rather than closed, by design.
 		expect(await connectionsClosed(servedSockets.slice(0, 1))).toBe(true);
 	});
 

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -21,7 +21,12 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 
 import { createServer, type Server } from 'node:http';
 import type { Socket } from 'node:net';
-import { fetchFileBytes, postForm, FileTooLargeError } from '../../src/transport/httpFetch.ts';
+import {
+	fetchFileBytes,
+	postForm,
+	FileTooLargeError,
+	RedirectDropsBodyError,
+} from '../../src/transport/httpFetch.ts';
 
 let server: Server;
 let origin: string;
@@ -50,6 +55,16 @@ beforeAll(async () => {
 		if (req.url === '/streams-too-much') {
 			res.writeHead(200, { 'Transfer-Encoding': 'chunked' });
 			res.write('x'.repeat(64));
+			return;
+		}
+		// A redirect whose own body stalls the same way, for the refusal that
+		// declines to re-send a request body across it.
+		if (req.url === '/redirect-and-stall') {
+			res.writeHead(301, {
+				Location: '/small',
+				'Content-Length': String(50 * 1024 * 1024),
+			});
+			res.write('x');
 			return;
 		}
 		// Anything else is a test asking for a route that does not exist. Refusing
@@ -117,6 +132,15 @@ describe('an over-cap body refused against a real server', () => {
 		);
 
 		expect(failure).toBeInstanceOf(FileTooLargeError);
+		expect(await connectionClosed(servingSocket)).toBe(true);
+	});
+
+	it('closes the connection behind a redirect it refuses to follow', async () => {
+		const failure = await postForm(`${origin}/redirect-and-stall`, {
+			query: 'SELECT ?x WHERE {}',
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(RedirectDropsBodyError);
 		expect(await connectionClosed(servingSocket)).toBe(true);
 	});
 

--- a/tests/transport/httpFetch.disposal.test.ts
+++ b/tests/transport/httpFetch.disposal.test.ts
@@ -21,22 +21,18 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 
 import { createServer, type Server } from 'node:http';
 import type { Socket } from 'node:net';
-import {
-	fetchFileBytes,
-	postForm,
-	FileTooLargeError,
-	RedirectDropsBodyError,
-} from '../../src/transport/httpFetch.ts';
+import { fetchFileBytes, postForm, FileTooLargeError } from '../../src/transport/httpFetch.ts';
+import { RedirectDropsBodyError } from '../../src/transport/requestChain.ts';
 
 let server: Server;
 let origin: string;
 let openSockets: Set<Socket>;
-let servingSocket: Socket | undefined;
+let servedSockets: Socket[] = [];
 
 beforeAll(async () => {
 	openSockets = new Set();
 	server = createServer((req, res) => {
-		servingSocket = req.socket;
+		servedSockets.push(req.socket);
 		if (req.url === '/small') {
 			res.writeHead(200, { 'Content-Length': '7' });
 			res.end('results');
@@ -67,6 +63,16 @@ beforeAll(async () => {
 			res.write('x');
 			return;
 		}
+		// The same stalling body on a redirect that IS followed, so the hop's own
+		// connection is observable after the chain has moved past it.
+		if (req.url === '/followed-and-stall') {
+			res.writeHead(307, {
+				Location: '/small',
+				'Content-Length': String(50 * 1024 * 1024),
+			});
+			res.write('x');
+			return;
+		}
 		// Anything else is a test asking for a route that does not exist. Refusing
 		// it keeps a mistyped path from quietly getting a different route's answer.
 		res.writeHead(404);
@@ -84,7 +90,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-	servingSocket = undefined;
+	servedSockets = [];
 });
 
 afterAll(async () => {
@@ -95,15 +101,19 @@ afterAll(async () => {
 });
 
 /**
- * Whether the server's end of the connection goes away once the client is done
- * with it. No recorded socket means the request never reached the server, so
- * there is nothing to observe: say so, rather than read a socket an earlier test
- * left behind and report its closure as this one's.
+ * Whether the server's end of every connection it served goes away once the
+ * client is done with them. An empty list means no request reached the server, so
+ * there is nothing to observe: say so, rather than pass vacuously.
  */
-async function connectionClosed(socket: Socket | undefined, withinMs = 1000): Promise<boolean> {
-	if (socket === undefined) {
+async function connectionsClosed(sockets: Socket[], withinMs = 1000): Promise<boolean> {
+	if (sockets.length === 0) {
 		throw new Error('The server served no request, so no connection was observed.');
 	}
+	const closed = await Promise.all(sockets.map((socket) => connectionClosed(socket, withinMs)));
+	return closed.every(Boolean);
+}
+
+async function connectionClosed(socket: Socket, withinMs: number): Promise<boolean> {
 	if (socket.destroyed) {
 		return true;
 	}
@@ -123,7 +133,7 @@ describe('an over-cap body refused against a real server', () => {
 		}).catch((error: unknown) => error);
 
 		expect(failure).toBeInstanceOf(FileTooLargeError);
-		expect(await connectionClosed(servingSocket)).toBe(true);
+		expect(await connectionsClosed(servedSockets)).toBe(true);
 	});
 
 	it('closes the connection when the streamed body passes the cap', async () => {
@@ -132,7 +142,24 @@ describe('an over-cap body refused against a real server', () => {
 		);
 
 		expect(failure).toBeInstanceOf(FileTooLargeError);
-		expect(await connectionClosed(servingSocket)).toBe(true);
+		expect(await connectionsClosed(servedSockets)).toBe(true);
+	});
+
+	// The hop is followed and its own response body is never read, so nothing but
+	// the driver's disposal releases it. Two connections are served here; asserting
+	// on both is the point, since the followed hop's is the one that used to leak.
+	it('closes the connection behind a redirect it follows', async () => {
+		const body = await postForm(`${origin}/followed-and-stall`, {
+			query: 'SELECT ?x WHERE {}',
+		});
+
+		expect(body).toBe('results');
+		expect(servedSockets).toHaveLength(2);
+		// Only the redirect hop's connection is the subject. The final response is
+		// read to completion, and this file stubs the pinned agent away, so its
+		// socket goes back to the keep-alive pool instead of closing — which is
+		// what should happen to a connection someone might reuse.
+		expect(await connectionsClosed(servedSockets.slice(0, 1))).toBe(true);
 	});
 
 	it('closes the connection behind a redirect it refuses to follow', async () => {
@@ -141,7 +168,7 @@ describe('an over-cap body refused against a real server', () => {
 		}).catch((error: unknown) => error);
 
 		expect(failure).toBeInstanceOf(RedirectDropsBodyError);
-		expect(await connectionClosed(servingSocket)).toBe(true);
+		expect(await connectionsClosed(servedSockets)).toBe(true);
 	});
 
 	it('closes the connection when a capped postForm refuses the body', async () => {
@@ -152,7 +179,7 @@ describe('an over-cap body refused against a real server', () => {
 		).catch((error: unknown) => error);
 
 		expect(failure).toBeInstanceOf(FileTooLargeError);
-		expect(await connectionClosed(servingSocket)).toBe(true);
+		expect(await connectionsClosed(servedSockets)).toBe(true);
 	});
 
 	it('still returns a body that fits the cap', async () => {

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+/**
+ * What a redirect target actually receives is the subject here, so this file
+ * runs the REAL node-fetch against a real loopback server that records the
+ * method, body and headers of every request it serves. Only the SSRF guard is
+ * stubbed, since a loopback destination is what a local test server is.
+ */
+vi.mock('../../src/transport/ssrfGuard.ts', async () => {
+	const actual = await vi.importActual<typeof import('../../src/transport/ssrfGuard.ts')>(
+		'../../src/transport/ssrfGuard.ts',
+	);
+	return {
+		...actual,
+		assertPublicDestination: vi.fn(async () => [{ address: '127.0.0.1', family: 4 }]),
+		buildPinnedAgent: vi.fn(() => undefined),
+	};
+});
+
+import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
+import { makeApiRequest, postForm } from '../../src/transport/httpFetch.ts';
+
+type ServedRequest = {
+	method: string;
+	url: string;
+	body: string;
+	headers: IncomingHttpHeaders;
+};
+
+const FORM = { query: 'SELECT ?x WHERE {}' };
+const ENCODED_FORM = 'query=SELECT+%3Fx+WHERE+%7B%7D';
+
+let server: Server;
+let origin: string;
+let served: ServedRequest[] = [];
+
+/**
+ * `/redirect/<status>/<rest>` answers with that status and `Location: /<rest>`,
+ * so `/redirect/302/redirect/307/sparql` is a two-hop chain. Any other path is
+ * a target and answers 200.
+ */
+beforeAll(async () => {
+	server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (chunk: Buffer) => chunks.push(chunk));
+		req.on('end', () => {
+			served.push({
+				method: req.method ?? '',
+				url: req.url ?? '',
+				body: Buffer.concat(chunks).toString('utf8'),
+				headers: req.headers,
+			});
+			const hop = /^\/redirect\/(\d{3})\/(.+)$/.exec(req.url ?? '');
+			if (hop) {
+				res.writeHead(Number(hop[1]), { Location: `/${hop[2]}` });
+				res.end('redirect notice');
+				return;
+			}
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end('{"ok":true}');
+		});
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	origin = `http://127.0.0.1:${typeof address === 'object' && address !== null ? address.port : 0}`;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+	served = [];
+});
+
+function methodsAndBodies(): { method: string; body: string }[] {
+	return served.map(({ method, body }) => ({ method, body }));
+}
+
+function target(): ServedRequest {
+	return served[served.length - 1];
+}
+
+describe('redirected requests', () => {
+	it.each([301, 302, 303])(
+		'sends a bodyless GET to the target of a %i redirect',
+		async (status) => {
+			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+
+			expect(result).toBe('{"ok":true}');
+			expect(methodsAndBodies()).toEqual([
+				{ method: 'POST', body: ENCODED_FORM },
+				{ method: 'GET', body: '' },
+			]);
+		},
+	);
+
+	it.each([307, 308])(
+		're-sends the POST and its body to the target of a %i redirect',
+		async (status) => {
+			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+
+			expect(result).toBe('{"ok":true}');
+			expect(methodsAndBodies()).toEqual([
+				{ method: 'POST', body: ENCODED_FORM },
+				{ method: 'POST', body: ENCODED_FORM },
+			]);
+		},
+	);
+
+	it('stops describing a body the downgraded request no longer carries', async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM);
+
+		expect(target().headers['content-type']).toBeUndefined();
+		expect(target().headers['content-length']).toBeUndefined();
+	});
+
+	it('keeps the form content type on a hop that still sends the body', async () => {
+		await postForm(`${origin}/redirect/307/sparql`, FORM);
+
+		expect(target().headers['content-type']).toBe('application/x-www-form-urlencoded');
+	});
+
+	it('keeps a caller header unrelated to the body across a downgrade', async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+			headers: { Accept: 'application/sparql-results+json' },
+		});
+
+		expect(target().headers.accept).toBe('application/sparql-results+json');
+	});
+
+	it('does not resurrect the body when a later hop preserves the method', async () => {
+		await postForm(`${origin}/redirect/302/redirect/307/sparql`, FORM);
+
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
+	});
+
+	it('downgrades a preserved POST at the hop that asks for it', async () => {
+		await postForm(`${origin}/redirect/307/redirect/302/sparql`, FORM);
+
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'GET', body: '' },
+		]);
+	});
+
+	it('leaves a redirected GET a GET, query string and all', async () => {
+		const result = await makeApiRequest<{ ok: boolean }>(`${origin}/redirect/301/w/api.php`, {
+			action: 'query',
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
+		expect(target().url).toBe('/w/api.php?action=query');
+	});
+});

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -115,6 +115,20 @@ describe('redirected requests', () => {
 		expect(target().headers['content-length']).toBeUndefined();
 	});
 
+	it("drops the caller's other body-describing headers across a downgrade", async () => {
+		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+			headers: {
+				'Content-Encoding': 'identity',
+				'Content-Language': 'en',
+				'Content-Location': '/sparql',
+			},
+		});
+
+		expect(target().headers['content-encoding']).toBeUndefined();
+		expect(target().headers['content-language']).toBeUndefined();
+		expect(target().headers['content-location']).toBeUndefined();
+	});
+
 	it('keeps the form content type on a hop that still sends the body', async () => {
 		await postForm(`${origin}/redirect/307/sparql`, FORM);
 

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -18,12 +18,8 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 });
 
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
-import {
-	makeApiRequest,
-	postForm,
-	HttpStatusError,
-	RedirectDropsBodyError,
-} from '../../src/transport/httpFetch.ts';
+import { makeApiRequest, postForm, HttpStatusError } from '../../src/transport/httpFetch.ts';
+import { RedirectDropsBodyError } from '../../src/transport/requestChain.ts';
 
 type ServedRequest = {
 	method: string;

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -120,12 +120,17 @@ describe('redirected requests', () => {
 			headers: {
 				'Content-Encoding': 'identity',
 				'Content-Language': 'en',
+				// node-fetch recomputes Content-Length only for a request that has
+				// a body, so a caller's value reaches the downgraded GET unless the
+				// downgrade removes it.
+				'Content-Length': '25',
 				'Content-Location': '/sparql',
 			},
 		});
 
 		expect(target().headers['content-encoding']).toBeUndefined();
 		expect(target().headers['content-language']).toBeUndefined();
+		expect(target().headers['content-length']).toBeUndefined();
 		expect(target().headers['content-location']).toBeUndefined();
 	});
 

--- a/tests/transport/httpFetch.redirect.test.ts
+++ b/tests/transport/httpFetch.redirect.test.ts
@@ -18,7 +18,12 @@ vi.mock('../../src/transport/ssrfGuard.ts', async () => {
 });
 
 import { createServer, type IncomingHttpHeaders, type Server } from 'node:http';
-import { makeApiRequest, postForm } from '../../src/transport/httpFetch.ts';
+import {
+	makeApiRequest,
+	postForm,
+	HttpStatusError,
+	RedirectDropsBodyError,
+} from '../../src/transport/httpFetch.ts';
 
 type ServedRequest = {
 	method: string;
@@ -50,6 +55,19 @@ beforeAll(async () => {
 				body: Buffer.concat(chunks).toString('utf8'),
 				headers: req.headers,
 			});
+			// A 3xx with no Location at all, which is not a redirect to follow.
+			if (req.url === '/locationless') {
+				res.writeHead(302);
+				res.end('going nowhere');
+				return;
+			}
+			// A target carrying a credential, which a query-service URL can do and
+			// the refusal must keep out of its message.
+			if (req.url === '/redirect-to-token') {
+				res.writeHead(301, { Location: '/sparql?token=hunter2' });
+				res.end('redirect notice');
+				return;
+			}
 			const hop = /^\/redirect\/(\d{3})\/(.+)$/.exec(req.url ?? '');
 			if (hop) {
 				res.writeHead(Number(hop[1]), { Location: `/${hop[2]}` });
@@ -81,19 +99,47 @@ function target(): ServedRequest {
 	return served[served.length - 1];
 }
 
+async function refusalFrom(url: string): Promise<RedirectDropsBodyError> {
+	const error = await postForm(url, FORM).catch((err: unknown) => err);
+	expect(error).toBeInstanceOf(RedirectDropsBodyError);
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pinned by the assertion above
+	return error as RedirectDropsBodyError;
+}
+
 describe('redirected requests', () => {
 	it.each([301, 302, 303])(
-		'sends a bodyless GET to the target of a %i redirect',
+		'refuses a %i redirect of a request that carries a body',
 		async (status) => {
-			const result = await postForm(`${origin}/redirect/${status}/sparql`, FORM);
+			const error = await refusalFrom(`${origin}/redirect/${status}/sparql`);
 
-			expect(result).toBe('{"ok":true}');
-			expect(methodsAndBodies()).toEqual([
-				{ method: 'POST', body: ENCODED_FORM },
-				{ method: 'GET', body: '' },
-			]);
+			expect(error.status).toBe(status);
+			// The first hop went out whole; the target was never contacted, so the
+			// refusal is not a request that quietly lost what it was carrying.
+			expect(methodsAndBodies()).toEqual([{ method: 'POST', body: ENCODED_FORM }]);
 		},
 	);
+
+	it('names the redirect target it refused to follow, resolved absolutely', async () => {
+		const error = await refusalFrom(`${origin}/redirect/301/sparql`);
+
+		expect(error.target).toBe(`${origin}/sparql`);
+	});
+
+	it('keeps the refused target out of the message, which reaches the caller and the logs', async () => {
+		const error = await refusalFrom(`${origin}/redirect-to-token`);
+
+		expect(error.target).toBe(`${origin}/sparql?token=hunter2`);
+		expect(error.message).not.toContain('hunter2');
+		expect(error.message).not.toContain(origin);
+		expect(error.message).toContain('301');
+	});
+
+	it('reports a 3xx carrying no Location as the status it is, not as a refusal', async () => {
+		const error = await postForm(`${origin}/locationless`, FORM).catch((err: unknown) => err);
+
+		expect(error).toBeInstanceOf(HttpStatusError);
+		expect(error).not.toBeInstanceOf(RedirectDropsBodyError);
+	});
 
 	it.each([307, 308])(
 		're-sends the POST and its body to the target of a %i redirect',
@@ -108,30 +154,26 @@ describe('redirected requests', () => {
 		},
 	);
 
-	it('stops describing a body the downgraded request no longer carries', async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM);
+	it('re-sends the body across a chain of preserving hops', async () => {
+		const result = await postForm(`${origin}/redirect/307/redirect/308/sparql`, FORM);
 
-		expect(target().headers['content-type']).toBeUndefined();
-		expect(target().headers['content-length']).toBeUndefined();
+		expect(result).toBe('{"ok":true}');
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+		]);
 	});
 
-	it("drops the caller's other body-describing headers across a downgrade", async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM, {
-			headers: {
-				'Content-Encoding': 'identity',
-				'Content-Language': 'en',
-				// node-fetch recomputes Content-Length only for a request that has
-				// a body, so a caller's value reaches the downgraded GET unless the
-				// downgrade removes it.
-				'Content-Length': '25',
-				'Content-Location': '/sparql',
-			},
-		});
+	it('refuses at the hop that would drop the body, after the earlier hops were re-sent', async () => {
+		const error = await refusalFrom(`${origin}/redirect/307/redirect/302/sparql`);
 
-		expect(target().headers['content-encoding']).toBeUndefined();
-		expect(target().headers['content-language']).toBeUndefined();
-		expect(target().headers['content-length']).toBeUndefined();
-		expect(target().headers['content-location']).toBeUndefined();
+		expect(error.status).toBe(302);
+		expect(error.target).toBe(`${origin}/sparql`);
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'POST', body: ENCODED_FORM },
+			{ method: 'POST', body: ENCODED_FORM },
+		]);
 	});
 
 	it('keeps the form content type on a hop that still sends the body', async () => {
@@ -140,32 +182,12 @@ describe('redirected requests', () => {
 		expect(target().headers['content-type']).toBe('application/x-www-form-urlencoded');
 	});
 
-	it('keeps a caller header unrelated to the body across a downgrade', async () => {
-		await postForm(`${origin}/redirect/303/sparql`, FORM, {
+	it('keeps a caller header on a hop that re-sends the body', async () => {
+		await postForm(`${origin}/redirect/307/sparql`, FORM, {
 			headers: { Accept: 'application/sparql-results+json' },
 		});
 
 		expect(target().headers.accept).toBe('application/sparql-results+json');
-	});
-
-	it('does not resurrect the body when a later hop preserves the method', async () => {
-		await postForm(`${origin}/redirect/302/redirect/307/sparql`, FORM);
-
-		expect(methodsAndBodies()).toEqual([
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'GET', body: '' },
-			{ method: 'GET', body: '' },
-		]);
-	});
-
-	it('downgrades a preserved POST at the hop that asks for it', async () => {
-		await postForm(`${origin}/redirect/307/redirect/302/sparql`, FORM);
-
-		expect(methodsAndBodies()).toEqual([
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'POST', body: ENCODED_FORM },
-			{ method: 'GET', body: '' },
-		]);
 	});
 
 	it('leaves a redirected GET a GET, query string and all', async () => {
@@ -179,5 +201,19 @@ describe('redirected requests', () => {
 			{ method: 'GET', body: '' },
 		]);
 		expect(target().url).toBe('/w/api.php?action=query');
+	});
+
+	it('follows a multi-hop redirect of a bodyless request to the target', async () => {
+		const result = await makeApiRequest<{ ok: boolean }>(
+			`${origin}/redirect/301/redirect/303/w/api.php`,
+			{ action: 'query' },
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(methodsAndBodies()).toEqual([
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+			{ method: 'GET', body: '' },
+		]);
 	});
 });

--- a/tests/transport/httpFetch.test.ts
+++ b/tests/transport/httpFetch.test.ts
@@ -146,14 +146,14 @@ describe('utils.fetchCore (via makeApiRequest / fetchPageHtml)', () => {
 		vi.mocked(fetch).mockResolvedValueOnce(
 			new Response(null, {
 				status: 302,
-				headers: { Location: 'http://169.254.169.254/latest/meta-data/' },
+				headers: { Location: 'https://169.254.169.254/latest/meta-data/' },
 			}),
 		);
 		vi.mocked(assertPublicDestination)
 			.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
 			.mockRejectedValueOnce(
 				new Error(
-					'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): http://169.254.169.254/latest/meta-data/',
+					'Refusing to fetch URL resolving to non-public address 169.254.169.254 (linkLocal): https://169.254.169.254/latest/meta-data/',
 				),
 			);
 

--- a/tests/transport/requestChain.test.ts
+++ b/tests/transport/requestChain.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest';
+import {
+	firstRequest,
+	nextHop,
+	InsecureRedirectError,
+	MAX_REDIRECTS,
+	RedirectDropsBodyError,
+	TooManyRedirectsError,
+	UnusableLocationError,
+	type HopRequest,
+} from '../../src/transport/requestChain.ts';
+
+/**
+ * The redirect rules are a pure function of what was sent and what came back, so
+ * every case here is a value assertion. No server, no socket, no mock.
+ */
+
+const START = 'https://wiki.example/w/api.php';
+
+function sent(overrides: Partial<HopRequest> = {}): HopRequest {
+	return { ...firstRequest(START), ...overrides };
+}
+
+function got(
+	status: number,
+	location: string | null = '/moved',
+): { status: number; location: string | null } {
+	return { status, location };
+}
+
+describe('firstRequest', () => {
+	it('derives GET from the absence of a body', () => {
+		expect(firstRequest(START).method).toBe('GET');
+	});
+
+	it('derives POST from the presence of a body', () => {
+		const request = firstRequest(START, { body: 'query=x' });
+
+		expect(request.method).toBe('POST');
+		expect(request.body).toBe('query=x');
+	});
+
+	it('treats an empty body as a body, so it travels as a POST', () => {
+		expect(firstRequest(START, { body: '' }).method).toBe('POST');
+	});
+
+	it('reads a protocol-relative URL as https', () => {
+		expect(firstRequest('//wiki.example/w/api.php').url).toBe(START);
+	});
+
+	it('applies the params to the url before anything is sent', () => {
+		expect(firstRequest(START, { params: { action: 'query' } }).url).toBe(`${START}?action=query`);
+	});
+
+	it('starts the chain at the url it was given', () => {
+		const request = firstRequest(START, { params: { action: 'query' } });
+
+		expect(request.redirectsFollowed).toBe(0);
+		expect(request.startUrl).toBe(request.url);
+	});
+});
+
+describe('which statuses are a redirect', () => {
+	it.each([301, 302, 303, 307, 308])('follows a %i that carries a Location', (status) => {
+		expect(nextHop(sent(), got(status)).kind).toBe('follow');
+	});
+
+	// 300 offers a choice, 305 names a proxy, 304 and 306 are not redirects at
+	// all: following any of them as though it were a destination is wrong.
+	it.each([300, 304, 305, 306, 309])('delivers a %i even when it carries a Location', (status) => {
+		expect(nextHop(sent(), got(status)).kind).toBe('deliver');
+	});
+
+	it('delivers a redirect status that carries no Location', () => {
+		expect(nextHop(sent(), got(302, null)).kind).toBe('deliver');
+	});
+
+	it('delivers a 2xx', () => {
+		expect(nextHop(sent(), got(200, null)).kind).toBe('deliver');
+	});
+});
+
+describe('the request the next hop sends', () => {
+	it('resolves a path-only Location against the hop that sent it', () => {
+		const decision = nextHop(sent(), got(302, '/elsewhere/api.php'));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { url: 'https://wiki.example/elsewhere/api.php' },
+		});
+	});
+
+	it('resolves a protocol-relative Location against the scheme in use', () => {
+		const decision = nextHop(sent(), got(302, '//other.example/api.php'));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { url: 'https://other.example/api.php' },
+		});
+	});
+
+	// Later in a chain the current hop and the start are different URLs, and a
+	// relative Location belongs to the hop that sent it.
+	it('resolves a path-only Location against the current hop, not the start of the chain', () => {
+		const secondHop = sent({
+			url: 'https://moved.example/a/b',
+			redirectsFollowed: 1,
+		});
+
+		const decision = nextHop(secondHop, got(302, '/c'));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { url: 'https://moved.example/c' },
+		});
+	});
+
+	it('counts the hop, so a chain can be capped', () => {
+		const decision = nextHop(sent({ redirectsFollowed: 2 }), got(302));
+
+		expect(decision).toMatchObject({ kind: 'follow', request: { redirectsFollowed: 3 } });
+	});
+
+	it('keeps the start url across the chain, so the cap can name where it began', () => {
+		const decision = nextHop(sent({ redirectsFollowed: 2 }), got(302));
+
+		expect(decision).toMatchObject({ kind: 'follow', request: { startUrl: START } });
+	});
+
+	it('re-sends the method and body across a 307', () => {
+		const decision = nextHop(sent({ ...firstRequest(START, { body: 'query=x' }) }), got(307));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { method: 'POST', body: 'query=x' },
+		});
+	});
+});
+
+describe('credential headers across a hop', () => {
+	const withCredentials = () =>
+		sent({
+			headers: {
+				Authorization: 'Bearer secret',
+				Cookie: 'session=secret',
+				'WWW-Authenticate': 'Basic',
+				Accept: 'application/json',
+			},
+		});
+
+	it('keeps them on a hop that stays on the same origin', () => {
+		const decision = nextHop(withCredentials(), got(302, '/elsewhere'));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { headers: { Authorization: 'Bearer secret', Cookie: 'session=secret' } },
+		});
+	});
+
+	it('drops them on a hop to another host', () => {
+		const decision = nextHop(withCredentials(), got(302, 'https://other.example/x'));
+
+		expect(decision).toMatchObject({ kind: 'follow' });
+		const headers = (decision as { request: HopRequest }).request.headers;
+		expect(headers).not.toHaveProperty('Authorization');
+		expect(headers).not.toHaveProperty('Cookie');
+		expect(headers).not.toHaveProperty('WWW-Authenticate');
+	});
+
+	// A tenant of a host that hands out subdomains is a different tenant, and
+	// node-fetch's own rule would forward the credentials to it.
+	it('drops them on a hop to a subdomain of the same host', () => {
+		const decision = nextHop(withCredentials(), got(302, 'https://tenant.wiki.example/x'));
+
+		expect((decision as { request: HopRequest }).request.headers).not.toHaveProperty(
+			'Authorization',
+		);
+	});
+
+	it('drops them on a hop that only changes the port', () => {
+		const decision = nextHop(withCredentials(), got(302, 'https://wiki.example:8443/x'));
+
+		expect((decision as { request: HopRequest }).request.headers).not.toHaveProperty(
+			'Authorization',
+		);
+	});
+
+	it('keeps a header that is not a credential across a change of host', () => {
+		const decision = nextHop(withCredentials(), got(302, 'https://other.example/x'));
+
+		expect(decision).toMatchObject({
+			kind: 'follow',
+			request: { headers: { Accept: 'application/json' } },
+		});
+	});
+});
+
+describe('the hops it refuses', () => {
+	it('refuses to drop a body a 301, 302 or 303 would discard', () => {
+		const withBody = sent(firstRequest(START, { body: 'query=x' }));
+
+		for (const status of [301, 302, 303]) {
+			const decision = nextHop(withBody, got(status, '/moved'));
+
+			expect(decision).toMatchObject({ kind: 'refuse' });
+			const error = (decision as { error: Error }).error;
+			expect(error).toBeInstanceOf(RedirectDropsBodyError);
+			expect((error as RedirectDropsBodyError).status).toBe(status);
+			expect((error as RedirectDropsBodyError).target).toBe('https://wiki.example/moved');
+		}
+	});
+
+	it('refuses a hop from https to http, body or no body', () => {
+		const decision = nextHop(sent(), got(302, 'http://wiki.example/x'));
+
+		expect(decision).toMatchObject({ kind: 'refuse' });
+		const error = (decision as { error: Error }).error;
+		expect(error).toBeInstanceOf(InsecureRedirectError);
+		expect((error as InsecureRedirectError).target).toBe('http://wiki.example/x');
+	});
+
+	it('allows a hop from http to https, which loses nothing', () => {
+		const fromHttp = sent(firstRequest('http://wiki.example/w/api.php'));
+
+		expect(nextHop(fromHttp, got(302, 'https://wiki.example/x')).kind).toBe('follow');
+	});
+
+	it('reports an insecure hop as insecure even when it also drops a body', () => {
+		const withBody = sent(firstRequest(START, { body: 'query=x' }));
+
+		expect(
+			(nextHop(withBody, got(303, 'http://wiki.example/x')) as { error: Error }).error,
+		).toBeInstanceOf(InsecureRedirectError);
+	});
+
+	it('refuses a Location that is not a URL', () => {
+		const decision = nextHop(sent(), got(302, 'http://['));
+
+		expect(decision).toMatchObject({ kind: 'refuse' });
+		expect((decision as { error: Error }).error).toBeInstanceOf(UnusableLocationError);
+	});
+
+	it('refuses the hop after the last one it will follow, naming where the chain began', () => {
+		const decision = nextHop(sent({ redirectsFollowed: MAX_REDIRECTS }), got(302));
+
+		expect(decision).toMatchObject({ kind: 'refuse' });
+		const error = (decision as { error: Error }).error;
+		expect(error).toBeInstanceOf(TooManyRedirectsError);
+		expect((error as TooManyRedirectsError).startUrl).toBe(START);
+	});
+
+	it('follows the last hop within the cap', () => {
+		expect(nextHop(sent({ redirectsFollowed: MAX_REDIRECTS - 1 }), got(302)).kind).toBe('follow');
+	});
+
+	// The cap is reached before anything about the target is read, so a chain that
+	// runs long is reported as long rather than as whatever its next hop would be.
+	it('reports the cap ahead of a body-dropping hop', () => {
+		const withBody = sent({
+			...firstRequest(START, { body: 'query=x' }),
+			redirectsFollowed: MAX_REDIRECTS,
+		});
+
+		expect((nextHop(withBody, got(303)) as { error: Error }).error).toBeInstanceOf(
+			TooManyRedirectsError,
+		);
+	});
+});
+
+describe('what a refusal keeps out of its message', () => {
+	// Any of these URLs can carry a credential in its path or query, and a message
+	// reaches both the caller and the logs.
+	it.each([
+		new RedirectDropsBodyError(303, 'https://q.example/sparql?token=hunter2'),
+		new InsecureRedirectError(302, 'http://q.example/sparql?token=hunter2'),
+	])('keeps the target out of $name', (error) => {
+		expect(error.message).not.toContain('hunter2');
+		expect(error.message).not.toContain('q.example');
+		expect(error.target).toContain('hunter2');
+	});
+});

--- a/tests/transport/requestChain.test.ts
+++ b/tests/transport/requestChain.test.ts
@@ -10,11 +10,6 @@ import {
 	type HopRequest,
 } from '../../src/transport/requestChain.ts';
 
-/**
- * The redirect rules are a pure function of what was sent and what came back, so
- * every case here is a value assertion. No server, no socket, no mock.
- */
-
 const START = 'https://wiki.example/w/api.php';
 
 function sent(overrides: Partial<HopRequest> = {}): HopRequest {
@@ -65,8 +60,7 @@ describe('which statuses are a redirect', () => {
 		expect(nextHop(sent(), got(status)).kind).toBe('follow');
 	});
 
-	// 300 offers a choice, 305 names a proxy, 304 and 306 are not redirects at
-	// all: following any of them as though it were a destination is wrong.
+	// 300 offers a choice and 305 names a proxy: neither is a destination.
 	it.each([300, 304, 305, 306, 309])('delivers a %i even when it carries a Location', (status) => {
 		expect(nextHop(sent(), got(status)).kind).toBe('deliver');
 	});
@@ -99,8 +93,7 @@ describe('the request the next hop sends', () => {
 		});
 	});
 
-	// Later in a chain the current hop and the start are different URLs, and a
-	// relative Location belongs to the hop that sent it.
+	// A relative Location belongs to the hop that sent it, not to the start.
 	it('resolves a path-only Location against the current hop, not the start of the chain', () => {
 		const secondHop = sent({
 			url: 'https://moved.example/a/b',
@@ -167,8 +160,7 @@ describe('credential headers across a hop', () => {
 		expect(headers).not.toHaveProperty('WWW-Authenticate');
 	});
 
-	// A tenant of a host that hands out subdomains is a different tenant, and
-	// node-fetch's own rule would forward the credentials to it.
+	// node-fetch's own rule would forward the credentials to a subdomain.
 	it('drops them on a hop to a subdomain of the same host', () => {
 		const decision = nextHop(withCredentials(), got(302, 'https://tenant.wiki.example/x'));
 
@@ -253,8 +245,7 @@ describe('the hops it refuses', () => {
 		expect(nextHop(sent({ redirectsFollowed: MAX_REDIRECTS - 1 }), got(302)).kind).toBe('follow');
 	});
 
-	// The cap is reached before anything about the target is read, so a chain that
-	// runs long is reported as long rather than as whatever its next hop would be.
+	// The cap is read before the target, so a long chain is reported as long.
 	it('reports the cap ahead of a body-dropping hop', () => {
 		const withBody = sent({
 			...firstRequest(START, { body: 'query=x' }),
@@ -268,8 +259,7 @@ describe('the hops it refuses', () => {
 });
 
 describe('what a refusal keeps out of its message', () => {
-	// Any of these URLs can carry a credential in its path or query, and a message
-	// reaches both the caller and the logs.
+	// These URLs can carry a credential, and a message reaches the caller and the logs.
 	it.each([
 		new RedirectDropsBodyError(303, 'https://q.example/sparql?token=hunter2'),
 		new InsecureRedirectError(302, 'http://q.example/sparql?token=hunter2'),


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/549
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/555
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/556
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/559

Supersedes #551, and is built on its branch so its verified work is carried rather than re-derived.

`fetchCore` hand-rolled the Fetch standard's redirect algorithm and implemented part of it. Each rule it got wrong was a separate open issue in the same fifteen lines, and none could be tested without standing up a server — which is why three of the four went unnoticed until a socket count was taken.

The rules now live in `src/transport/requestChain.ts` as one pure decision. `nextHop` reads what was sent and the status and Location that came back, and answers deliver, follow or refuse; `fetchCore` performs the I/O each answer asks for. Because a refusal is a returned value rather than a throw, every response that is not delivered leaves through one place — which is what disposes of the abandoned bodies, instead of a call at each exit that a later edit can forget.

## What the rules now say

| Rule | Issue |
|---|---|
| Follow only 301, 302, 303, 307 and 308 — a `300` offers a choice and a `305` names a proxy, so neither is an address | #559 |
| Refuse a hop that would drop the request body | #549 |
| Refuse a hop from `https` to `http` | #556 |
| Drop credential headers across any change of origin | #556 |
| Dispose of every abandoned body, on the followed hop as well as at each refusal | #555 |
| Read a failing source's diagnostics up to 8 KB rather than whole | #559 |

Two of these are deliberate departures from the standard, both because this server fetches URLs a caller chose: the standard re-sends a 301/302/303 as a bodyless GET, and it follows an `https` → `http` hop once it has stripped the credentials.

Credentials go on a change of **origin**, not of host. That is stricter than node-fetch, whose rule keeps them for a subdomain of the current host and ignores the port — on a host that gives its tenants subdomains, that would hand one tenant's credentials to another.

The method is now derived from the presence of a body, so `fetchCore` has no `method` option and a bodyless POST is not representable. That retires the question #551 left open — whether the refusal should key on the body or the method — by making the two the same thing.

## What this costs, measured

Unchanged from #551, and still the thing to weigh: **a wiki publishing a 301/302/303-redirecting query-service URL loses queries that worked before.** Verified live:

| Published endpoint | Answers a form POST with | Target answers the same POST |
|---|---|---|
| `http://database.factgrid.de/sparql` | `301` → `https://database.factgrid.de/sparql` | `200` |
| `http://dbpedia.org/sparql` | `303` → `https://dbpedia.org/sparql` | `200` |

Both are plaintext endpoints upgrading to TLS, so the first request already went out in the clear. Refusing surfaces that; following it hides it. Endpoints answering `307`/`308` are unaffected.

## For the reviewer

- **Extracting the decision, rather than finishing the loop in place.** Three independent designs were compared and judges split 2–1 for extraction, so this is a close call worth your own view. What tipped it: two rules in this exact loop were found unpinned by any test during the work on #551 — one header set three-quarters unexercised, one disposal call with no test at all — so "each rule is a millisecond value assertion" is not hypothetical here. The counter-argument is that 55 lines with one caller does not need a module.
- **`requestChain.ts` imports nothing.** No node-fetch, no DNS, no clock. That is what makes the rules testable, and it is also what would let an eventual move to undici keep this file and delete only the parts that duplicate the standard.
- **An insecure hop is reported ahead of a private-address one.** The pure rules run before the transport's DNS check, since they cost nothing and it costs a lookup, so `https` → `http://169.254.169.254` is reported as insecure rather than as private. Both refuse it. One existing SSRF test's fixture was an `https` → `http` redirect and so was testing two rules at once; it now uses an `https` target, which is what it meant to test.

## Verification

`tests/transport/requestChain.test.ts` — 39 cases, no mocks, no sockets, no `Response` objects. **14 mutations applied one at a time, all 14 caught.** The one that initially survived was a real gap: resolving a relative `Location` against the start of the chain rather than the current hop passed everything, because every relative-Location case was on the first hop where the two URLs are equal. There is now a second-hop case.

`tests/transport/httpFetch.disposal.test.ts` gained the test #555 needed and had no way to express: a **followed** hop whose body is never read. It fails when disposal is moved back to the refusal path only. Its harness now records every socket the server served, because the second hop used to overwrite the first and hide exactly the leak being measured.

Gates individually, all exit 0: `npm run lint`, `npm run typecheck`, `npm run fmt:check`, `npm test` (151 files, 2122 tests).

## Not in this change

`#561` (a token in a redirect target escaping the endpoint redaction) is in the Wikibase layer, not here. The uncapped **success** body — `fetchPageHtml` reads an unbounded `text()` on the discovery and probe paths — is a different resource on a different path. Duplicate `Location` headers join to a bogus URL that this still follows; it needs its own decision about which to honour.

> <sub>AI-authored — Claude Code, `Opus 5 (xhigh)`; the maintainer asked for one holistic fix after a review found four issues sharing a root cause, and chose to fold #551 in rather than merge it first; diff not yet human-reviewed; 14 mutations verified caught, the disposal test verified to fail without the fix, the two live endpoint measurements reproduced with curl, gates green locally.</sub>
