### PR TITLE
Offer the Docker image as an OCI package in server.json

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,9 +1,12 @@
 name: Publish Image
 
+# The tagged build is not triggered here: the release workflow calls this one so
+# that publishing to the MCP registry, which validates the image the `oci`
+# package in server.json names, cannot run before the image exists.
 on:
   push:
-    tags: ['v*']
     branches: [master]
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,16 @@ on:
       - 'v*'
 
 jobs:
+  image:
+    uses: ./.github/workflows/publish-image.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
   build-and-publish:
+    needs: image
     runs-on: ubuntu-latest
     permissions:
       contents: write # For creating release
@@ -37,6 +46,9 @@ jobs:
 
       - name: Update server.json (npm)
         run: node scripts/update-server-json-npm.cjs
+
+      - name: Update server.json (image)
+        run: node scripts/update-server-json-oci.cjs
 
       - name: Commit and push server.json
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- The MCP registry entry now offers the published Docker image as a package, which is what gets a server into Docker's MCP catalog and from there into Docker Desktop's MCP Toolkit. The catalog runs the image on stdio, as a local server for one client; `docker run` keeps its HTTP default for deployments.
+
 ## [0.17.0] - 2026-08-13
 
 ### Breaking changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ LABEL org.opencontainers.image.title="MediaWiki MCP Server" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.revision="${GIT_SHA}"
 
+# Ownership proof for the MCP registry: publishing the `oci` package in
+# server.json fails unless the image carries this label and it matches the
+# server name there.
+LABEL io.modelcontextprotocol.server.name="io.github.ProfessionalWiki/mediawiki-mcp-server"
+
 WORKDIR /app
 
 # Copy built artifacts

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -15,6 +15,8 @@ For contributors adding an install channel, editing a plugin manifest, or testin
 
 Every plugin manifest is a wrapper that launches the published npm package with `npx`. The `.mcpb` bundle and the Docker image each ship their own build instead.
 
+The Docker image doubles as the registry entry's `oci` package, which is how the server reaches Docker's MCP catalog — that catalog takes OCI packages and skips npm ones. The registry proves ownership of the image through the `io.modelcontextprotocol.server.name` label in the `Dockerfile`: it must match the server name in `server.json`, and publishing fails without it. The package pins the image by tag rather than declaring a `version`, which the registry rejects on an OCI package.
+
 Commit a manifest for a client only when that client installs plugins from a repository. For any other client, add it to the README install section and commit no file.
 
 ## Plugin layout
@@ -62,7 +64,7 @@ Do not hand-edit a field in that table, because the next release overwrites it. 
 npm run sync-manifests
 ```
 
-Everything else in these files is hand-maintained, including each catalog's top-level `description` and `interface`. In `server.json` the script sets only the top-level pair; the `packages[]` entries are written during the release workflow by `scripts/update-server-json-npm.cjs` and `scripts/update-server-json-mcpb.cjs`.
+Everything else in these files is hand-maintained, including each catalog's top-level `description` and `interface`. In `server.json` the script sets only the top-level pair; the `packages[]` entries are written during the release workflow by `scripts/update-server-json-npm.cjs`, `scripts/update-server-json-mcpb.cjs`, and `scripts/update-server-json-oci.cjs`.
 
 Adding a manifest to the sync takes three edits:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,6 +40,7 @@ git push origin master --follow-tags
 
 The `release` GitHub workflow triggers automatically on the tag and:
 
+- Builds and pushes the [Docker image](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pkgs/container/mediawiki-mcp-server), by calling the `publish-image` workflow. The rest of the release waits for it, because the registry resolves the image the `oci` package names while publishing.
 - Builds the `.mcpb` bundle and attaches it to a new [GitHub Release](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases), using the new `CHANGELOG.md` section as the release body.
 - Publishes the package to [NPM](https://www.npmjs.com/package/@professional-wiki/mediawiki-mcp-server).
 - Publishes to the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.professionalwiki/mediawiki-mcp-server).

--- a/scripts/update-server-json-oci.cjs
+++ b/scripts/update-server-json-oci.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const { PACKAGE_JSON_PATH, SERVER_JSON_PATH } = require('./constants.cjs');
+
+const IMAGE = 'ghcr.io/professionalwiki/mediawiki-mcp-server';
+
+/**
+ * Points the OCI package at the image published for this release. The registry
+ * rejects a `version` field on an OCI package, so the tag in `identifier` is
+ * the only place the version can go. Unlike its npm and mcpb siblings this
+ * fails on a missing package rather than skipping: a silent skip would publish
+ * a registry entry pointing at the previous release's image.
+ */
+function setImageTag(serverJson, version) {
+	const ociPackage = serverJson.packages?.find((p) => p.registryType === 'oci');
+	if (!ociPackage) {
+		throw new Error('server.json has no oci package to point at the released image');
+	}
+	ociPackage.identifier = `${IMAGE}:${version}`;
+}
+
+function main() {
+	console.log('Updating server.json with image tag...');
+
+	const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
+	const serverJson = JSON.parse(fs.readFileSync(SERVER_JSON_PATH, 'utf8'));
+
+	setImageTag(serverJson, packageJson.version);
+	console.log(`Image: ${IMAGE}:${packageJson.version}`);
+
+	fs.writeFileSync(SERVER_JSON_PATH, JSON.stringify(serverJson, null, 2) + '\n');
+	console.log('✓ Updated server.json with image tag successfully');
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = { setImageTag };

--- a/server.json
+++ b/server.json
@@ -229,6 +229,48 @@
           "default": "3000"
         }
       ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/professionalwiki/mediawiki-mcp-server:0.17.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Fixed to stdio for this package: the image defaults to the HTTP transport, which serves a deployment rather than one local client.",
+          "value": "stdio"
+        },
+        {
+          "name": "MCP_CONTENT_MAX_BYTES",
+          "description": "Byte cap for the content bodies and result blocks tools return (wikitext, rendered HTML, diffs, statement and row listings). An oversized response is truncated with a trailing marker describing what was left out.",
+          "format": "number",
+          "default": "50000"
+        },
+        {
+          "name": "MCP_FILE_DATA_MAX_BYTES",
+          "description": "Hard cap on the base64-encoded size of a get-file-data response. A transport/safety backstop; callers tune actual size with the tool's width parameter. Over-cap responses error rather than truncate.",
+          "format": "number",
+          "default": "1000000"
+        },
+        {
+          "name": "MCP_LOG_LEVEL",
+          "description": "Minimum severity for logger output (stderr telemetry and sendLoggingMessage broadcast). Invalid values fail loudly on first log call.",
+          "choices": [
+            "debug",
+            "info",
+            "notice",
+            "warning",
+            "error",
+            "critical",
+            "alert",
+            "emergency",
+            "silent"
+          ],
+          "default": "debug"
+        }
+      ]
     }
   ]
 }

--- a/tests/scripts/update-server-json-oci.test.ts
+++ b/tests/scripts/update-server-json-oci.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+type Package = { registryType: string; identifier: string };
+
+const { setImageTag } = createRequire(import.meta.url)(
+	'../../scripts/update-server-json-oci.cjs',
+) as {
+	setImageTag: (serverJson: { packages: Package[] }, version: string) => void;
+};
+
+// The oci package sits between the other two so a lookup that takes the first
+// or the last package fails here.
+function serverJson(): { packages: Package[] } {
+	return {
+		packages: [
+			{ registryType: 'mcpb', identifier: 'https://example.com/v0.1.0/Server.mcpb' },
+			{ registryType: 'oci', identifier: 'ghcr.io/professionalwiki/mediawiki-mcp-server:0.1.0' },
+			{ registryType: 'npm', identifier: '@professional-wiki/mediawiki-mcp-server' },
+		],
+	};
+}
+
+function packageOfType(json: { packages: Package[] }, registryType: string): Package {
+	return json.packages.find((p) => p.registryType === registryType)!;
+}
+
+describe('setImageTag', () => {
+	it('points the oci package at the released version of the image', () => {
+		const json = serverJson();
+
+		setImageTag(json, '0.2.0');
+
+		expect(packageOfType(json, 'oci').identifier).toBe(
+			'ghcr.io/professionalwiki/mediawiki-mcp-server:0.2.0',
+		);
+	});
+
+	it('leaves the other packages untouched', () => {
+		const json = serverJson();
+
+		setImageTag(json, '0.2.0');
+
+		expect(packageOfType(json, 'mcpb').identifier).toBe('https://example.com/v0.1.0/Server.mcpb');
+		expect(packageOfType(json, 'npm').identifier).toBe('@professional-wiki/mediawiki-mcp-server');
+	});
+
+	it('refuses a server.json that has no oci package', () => {
+		const json = { packages: [{ registryType: 'npm', identifier: 'mediawiki-mcp-server' }] };
+
+		expect(() => setImageTag(json, '0.2.0')).toThrow('no oci package');
+	});
+});


### PR DESCRIPTION
Docker builds the MCP catalog that Docker Desktop imports from the MCP
registry, taking `oci` packages with a stdio transport and skipping npm
ones. Our entry had only npm and mcpb packages, so the server was absent
from that catalog.

The image defaults to the HTTP transport, which serves a deployment
rather than one local client, and the deployment docs rely on that
default; the package entry pins `MCP_TRANSPORT=stdio` instead of
changing the image. It declares only the environment variables that
change behaviour on stdio, leaving out the HTTP and OAuth-proxy ones.

Three constraints come with the entry:

- Ownership of an OCI package is proven by resolving the image and
  reading an `io.modelcontextprotocol.server.name` label, so the
  Dockerfile now carries one.
- The registry rejects a `version` field on an OCI package, so the
  released version lives in the image tag, which
  `scripts/update-server-json-oci.cjs` rewrites like its npm and mcpb
  siblings do for their identifiers.
- Publishing resolves that image, so it has to exist first. The release
  workflow now calls `publish-image` and waits for it; on v0.17.0 the
  image landed 105 seconds after the release job had finished, so
  publishing an OCI package would have failed. The image's cosign
  identity is unchanged, because a certificate issued to a called
  workflow carries that workflow's ref, which is what
  `docs/deployment.md` verifies against.

Verified against docker/mcp-gateway's `TransformToDocker`, which rejects
the current entry as `incompatible server: no compatible packages` and
accepts this one. The published image speaks MCP over stdio with the
override: `initialize`, 29 tools, and a `get-page` call against English
Wikipedia.

Considered, omitted: a bind mount for `config.json`. The server has no
environment variable for naming a wiki, so a catalog user gets English
Wikipedia plus whatever `add-wiki` registers at runtime. A `--mount`
runtime argument would express the mount, but the gateway resolves an
unset config variable to the empty string, leaving `:/app/config.json`
and a container that refuses to start for everyone who wants the
default.

> <sub>AI-authored — Claude Code, `Opus 5 (max)`; detailed spec from @JeroenDeDauw, executed by a subagent, no redirections; diff not yet human-reviewed; new tests written and seen failing without the change, full suite + lint + typecheck + server.json schema validation green locally, catalog transform and published image exercised locally, CI not yet run.</sub>
