### PR TITLE
Normalize protocol-relative MediaWiki server in wiki discovery

### DIFF
--- a/src/wikis/wikiDiscovery.ts
+++ b/src/wikis/wikiDiscovery.ts
@@ -2,6 +2,7 @@ import { errorMessage } from '../errors/isErrnoException.ts';
 import { makeApiRequest, fetchPageHtml } from '../transport/httpFetch.ts';
 import { assertPublicDestination } from '../transport/ssrfGuard.ts';
 import { logger } from '../runtime/logger.ts';
+import { normalizeServer } from './normalizeServer.ts';
 
 const COMMON_SCRIPT_PATHS = ['/w', ''];
 
@@ -67,7 +68,7 @@ async function fetchWikiInfoFromApi(
 		sitename: general.sitename,
 		scriptpath: general.scriptpath,
 		articlepath: general.articlepath.replace('/$1', ''),
-		server: general.server,
+		server: normalizeServer(general.server),
 		servername: general.servername,
 	};
 }

--- a/tests/wikis/wikiDiscovery.test.ts
+++ b/tests/wikis/wikiDiscovery.test.ts
@@ -81,4 +81,28 @@ describe('discoverWiki', () => {
 			servername: 'public.example',
 		});
 	});
+
+	it('normalizes a protocol-relative MediaWiki server to https', async () => {
+		vi.mocked(makeApiRequest).mockResolvedValue({
+			query: {
+				general: {
+					sitename: 'MediaWiki',
+					scriptpath: '/w',
+					articlepath: '/wiki/$1',
+					server: '//www.mediawiki.org',
+					servername: 'www.mediawiki.org',
+				},
+			},
+		});
+
+		const info = await discoverWiki('https://www.mediawiki.org/wiki/Main_Page');
+
+		expect(info).toEqual({
+			sitename: 'MediaWiki',
+			scriptpath: '/w',
+			articlepath: '/wiki',
+			server: 'https://www.mediawiki.org',
+			servername: 'www.mediawiki.org',
+		});
+	});
 });


### PR DESCRIPTION
`discoverWiki` / `add-wiki` stored MediaWiki siteinfo `general.server` as returned by the API. Wikimedia wikis (and many others) publish a protocol-relative value like `//www.mediawiki.org`, which later tools turn into an `Invalid URL` when building `${server}${scriptpath}/api.php`.

`normalizeServer` already exists for this (`https:` + `//host`) and is used by `wikiProbe` and `siteInfo`. This applies the same helper in `wikiDiscovery` so registered wikis get an absolute `https://…` server.

Fixes #573

Thanks @JeroenDeDauw for reporting and reproducing.