### PR TITLE
Bound how long a tool call waits for a wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- A wiki that stops answering no longer hangs a tool call for minutes on end. A call that reaches a wiki now gives up within a fixed time and returns an error naming the limit it hit, instead of retrying out of sight. This also covers the first call to a wiki, where connecting and signing in were previously unbounded and slowest of all. A timed-out write reports that the change may or may not have been applied, since the server cannot tell. `add-wiki` is not yet covered: it reaches an unconfigured host over its own path.
+
 ## [0.17.0] - 2026-08-13
 
 ### Breaking changes

--- a/src/errors/classifyError.ts
+++ b/src/errors/classifyError.ts
@@ -1,4 +1,5 @@
 import { CredentialResolutionError } from './credentialResolutionError.ts';
+import { WikiTimeoutError } from './wikiTimeoutError.ts';
 
 export type ErrorCategory =
 	| 'not_found'
@@ -70,6 +71,9 @@ const MW_CODE_TO_CATEGORY: Record<string, ErrorCategory> = {
 	ratelimited: 'rate_limited',
 	// upstream_failure (explicit; unknown codes also fall through here)
 	readonly: 'upstream_failure',
+	// The one code this server issues rather than the wiki; listed so the
+	// pack-collision check covers it too.
+	'request-timeout': 'upstream_failure',
 };
 
 // Code families the wiki numbers per case, matched by prefix rather than by
@@ -106,6 +110,11 @@ export function classifyError(
 ): { category: ErrorCategory; code?: string } {
 	if (err instanceof CredentialResolutionError) {
 		return { category: 'authentication' };
+	}
+	// Carries no `code` of its own, so it would otherwise reach the caller as a
+	// bare upstream_failure.
+	if (err instanceof WikiTimeoutError) {
+		return { category: 'upstream_failure', code: 'request-timeout' };
 	}
 	if (err !== null && typeof err === 'object') {
 		const code = (err as { code?: unknown }).code;

--- a/src/errors/wikiTimeoutError.ts
+++ b/src/errors/wikiTimeoutError.ts
@@ -1,0 +1,24 @@
+/** How far a call got before its budget ran out. */
+export type WikiTimeoutPhase = 'connecting' | 'calling';
+
+/**
+ * Thrown when a wiki request is abandoned for exhausting its time budget rather
+ * than for the caller cancelling. `disableRetry` stops mwn's ladder sleeping
+ * `retryPause` and re-issuing against a signal that has already fired.
+ */
+export class WikiTimeoutError extends Error {
+	public readonly disableRetry = true;
+
+	public constructor(
+		timeoutMs: number,
+		public readonly phase: WikiTimeoutPhase,
+	) {
+		const seconds = Math.round(timeoutMs / 1000);
+		super(
+			phase === 'connecting'
+				? `Gave up trying to reach the wiki after ${seconds} seconds`
+				: `Gave up waiting for the wiki after ${seconds} seconds`,
+		);
+		this.name = 'WikiTimeoutError';
+	}
+}

--- a/src/runtime/callDeadline.ts
+++ b/src/runtime/callDeadline.ts
@@ -1,0 +1,33 @@
+import type { WikiTimeoutPhase } from '../errors/wikiTimeoutError.ts';
+
+/**
+ * The budget one tool call gets for all of its wiki traffic, retries included.
+ * Sized against the longest legitimate call, a cold-wiki `upload-file-from-url`:
+ * WIKI_CONNECT_TIMEOUT_MS signing in, FETCH_TIMEOUT_MS fetching the source, then
+ * the upload POST under mwn's own 60s cap — the first two on their own timers,
+ * only sharing this clock. An {exec:…} credential can spend 30s ahead of them.
+ */
+export const WIKI_CALL_TIMEOUT_MS = 150_000;
+
+/**
+ * The budget for reaching a wiki the first time; mwn's login is three
+ * sub-second round-trips. Independent of the call's budget rather than nested
+ * inside it, because the connection is shared work — see `withSharedWorkScope`.
+ */
+export const WIKI_CONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * `AbortSignal.timeout` carries neither its duration nor its meaning, so both
+ * travel beside it. `phase` is fixed where the budget is armed rather than
+ * where it expires, so a connect budget cannot forget to say that nothing the
+ * caller asked for was sent.
+ */
+export interface CallDeadline {
+	readonly signal: AbortSignal;
+	readonly timeoutMs: number;
+	readonly phase: WikiTimeoutPhase;
+}
+
+export function callDeadline(timeoutMs: number, phase: WikiTimeoutPhase): CallDeadline {
+	return { signal: AbortSignal.timeout(timeoutMs), timeoutMs, phase };
+}

--- a/src/runtime/createContext.ts
+++ b/src/runtime/createContext.ts
@@ -9,8 +9,9 @@ import { RevisionNormalizerImpl } from '../services/revisionNormalize.ts';
 import { ResponseFormatterImpl } from '../results/response.ts';
 import { ErrorClassifierImpl } from '../errors/classifyError.ts';
 import { extensionErrorVocabulary, extensionPacks } from '../tools/extensions/index.ts';
-import { withAbortSignal } from '../wikis/abortableMwn.ts';
-import { getRequestSignal } from './requestContext.ts';
+import { withCallBounds } from '../wikis/abortableMwn.ts';
+import { getRequestDeadline, getRequestSignal } from './requestContext.ts';
+import { callDeadline, WIKI_CALL_TIMEOUT_MS } from './callDeadline.ts';
 
 export function createToolContext(deps: {
 	logger: Logger;
@@ -20,13 +21,13 @@ export function createToolContext(deps: {
 }): ToolContext {
 	const { logger, state, transport, getProxyConfig } = deps;
 	return {
-		// The cached instance is shared across requests, so the caller's
-		// cancellation signal is applied as a per-request view over it rather
-		// than being set on the instance itself.
+		// The cached instance is shared, so bounds go on a per-request view rather
+		// than on the instance. Taking the deadline from the request scope is what
+		// makes a tool that acquires the wiki twice spend one budget, not two.
 		mwn: async (wikiKey?: string) => {
 			const bot = await state.mwnProvider.get(wikiKey);
-			const signal = getRequestSignal();
-			return signal === undefined ? bot : withAbortSignal(bot, signal);
+			const deadline = getRequestDeadline() ?? callDeadline(WIKI_CALL_TIMEOUT_MS, 'calling');
+			return withCallBounds(bot, deadline, getRequestSignal());
 		},
 		wikis: state.wikiRegistry,
 		activeWiki: state.activeWiki,

--- a/src/runtime/dispatcher.ts
+++ b/src/runtime/dispatcher.ts
@@ -5,6 +5,8 @@ import type { ToolContext } from './context.ts';
 import { applySpecialCase } from '../errors/specialCases.ts';
 import { errorMessage } from '../errors/isErrnoException.ts';
 import { getRequestSignal, getRuntimeToken, withRequestFields } from './requestContext.ts';
+import { callDeadline, WIKI_CALL_TIMEOUT_MS } from './callDeadline.ts';
+import { WikiTimeoutError } from '../errors/wikiTimeoutError.ts';
 import { isWikiScoped, normalizeWikiArg } from './wikiArg.ts';
 import {
 	emitToolCall,
@@ -29,6 +31,12 @@ const TOOLS_BYPASSING_ACTIVE_WIKI_AUTH: ReadonlySet<string> = new Set([
 	'oauth-status',
 	'oauth-logout',
 ]);
+
+// The budget can expire before a write is submitted or after it is in flight,
+// and the server cannot tell which. A caller that replays an append assuming it
+// never landed would add the content twice.
+const WRITE_TIMEOUT_CAVEAT =
+	'. The change may or may not have been applied — check the wiki before retrying';
 
 export function dispatch<TSchema extends ZodRawShape, TCtx extends ToolContext = ToolContext>(
 	tool: Tool<TSchema, TCtx>,
@@ -108,7 +116,12 @@ async function runDispatchInner<TSchema extends ZodRawShape, TCtx extends ToolCo
 	let result: CallToolResult;
 
 	try {
-		result = await tool.handle(args, ctx);
+		// Armed here rather than around the whole of dispatch() so an interactive
+		// OAuth login does not spend the budget before the tool runs.
+		result = await withRequestFields(
+			{ deadline: callDeadline(WIKI_CALL_TIMEOUT_MS, 'calling') },
+			() => tool.handle(args, ctx),
+		);
 		if (result.isError) {
 			const first = result.content[0];
 			const text =
@@ -138,7 +151,14 @@ async function runDispatchInner<TSchema extends ZodRawShape, TCtx extends ToolCo
 		const rawMessage = errorMessage(err);
 		const tailored = overridden.message !== rawMessage;
 		const verb = tool.failureVerb ?? tool.name;
-		const finalMessage = tailored ? overridden.message : `Failed to ${verb}: ${overridden.message}`;
+		let finalMessage = tailored ? overridden.message : `Failed to ${verb}: ${overridden.message}`;
+		if (
+			err instanceof WikiTimeoutError &&
+			err.phase === 'calling' &&
+			tool.annotations.readOnlyHint === false
+		) {
+			finalMessage += WRITE_TIMEOUT_CAVEAT;
+		}
 		errorText = finalMessage;
 
 		// A cancelled call fails on the way down — mwn surfaces the torn-down

--- a/src/runtime/requestContext.ts
+++ b/src/runtime/requestContext.ts
@@ -1,9 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { CallDeadline } from './callDeadline.ts';
 
 interface RequestContext {
 	runtimeToken?: string;
 	wikiKey?: string;
 	signal?: AbortSignal;
+	deadline?: CallDeadline;
 }
 
 export const runtimeTokenStore = new AsyncLocalStorage<RequestContext>();
@@ -16,6 +18,14 @@ export function getRuntimeToken(): string | undefined {
 // request or the connection drops. Undefined outside a request scope.
 export function getRequestSignal(): AbortSignal | undefined {
 	return runtimeTokenStore.getStore()?.signal;
+}
+
+/**
+ * The call's time budget. Kept apart from `signal` so code asking whether the
+ * CALLER walked away cannot read a budget expiry as one.
+ */
+export function getRequestDeadline(): CallDeadline | undefined {
+	return runtimeTokenStore.getStore()?.deadline;
 }
 
 export function getRequestWiki(): string | undefined {
@@ -40,14 +50,13 @@ export function withRequestFields<T>(
 }
 
 /**
- * Runs `fn` with the cancellation signal detached, keeping the rest of the
- * scope (notably the runtime token, which the call still needs to authenticate).
+ * Runs `fn` detached from the caller that happened to trigger it, on `deadline`
+ * rather than that caller's cancellation and remaining time.
  *
- * For work that outlives the request that happened to trigger it: a result
- * shared between concurrent callers must not be torn down because the first
- * caller to arrive walked away, which would hand every other waiter the
- * failure path.
+ * For work shared between concurrent callers: the first caller's cancellation
+ * would fail every other waiter, and its leftover budget is just as arbitrary —
+ * a joiner would inherit it, making its answer depend on an unrelated clock.
  */
-export function withoutRequestSignal<T>(fn: () => Promise<T>): Promise<T> {
-	return withRequestFields({ signal: undefined }, fn);
+export function withSharedWorkScope<T>(deadline: CallDeadline, fn: () => Promise<T>): Promise<T> {
+	return withRequestFields({ signal: undefined, deadline }, fn);
 }

--- a/src/tools/extensions/neowiki/neowikiRequest.ts
+++ b/src/tools/extensions/neowiki/neowikiRequest.ts
@@ -2,6 +2,7 @@ import type { Mwn } from 'mwn';
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ErrorCategory } from '../../../errors/classifyError.ts';
 import type { ToolContext } from '../../../runtime/context.ts';
+import { WikiTimeoutError } from '../../../errors/wikiTimeoutError.ts';
 
 /** A NeoWiki REST failure already classified into an MCP error category. */
 export class NeoWikiApiError extends Error {
@@ -108,6 +109,11 @@ export async function neowikiRequest(mwn: Mwn, spec: NeoWikiRequestSpec): Promis
 		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- axios response body at this boundary
 		return (response as { data: unknown }).data;
 	} catch (err: unknown) {
+		// The server's own verdict, not the wiki's: relabelling it as a pack error
+		// would lose the code and, on writes, the dispatcher's caveat.
+		if (err instanceof WikiTimeoutError) {
+			throw err;
+		}
 		throw classifyNeoWikiError(err);
 	}
 }

--- a/src/transport/ready.ts
+++ b/src/transport/ready.ts
@@ -3,6 +3,8 @@ import { recordReadyFailure } from '../runtime/metrics.ts';
 import { monotonicNow } from '../runtime/clock.ts';
 import type { MwnProvider } from '../wikis/mwnProvider.ts';
 import type { ActiveWiki } from '../wikis/activeWiki.ts';
+import { withCallBounds } from '../wikis/abortableMwn.ts';
+import { callDeadline } from '../runtime/callDeadline.ts';
 
 interface ReadyCacheEntry {
 	expiresAt: number;
@@ -28,7 +30,10 @@ export function __resetReadyCacheForTesting(): void {
 // resolving the provider can log in, which alone can outlast the budget.
 async function probeSiteInfo(mwnProvider: MwnProvider): Promise<void> {
 	const mwn = await mwnProvider.get();
-	await mwn.request({
+	// The race below stops the caller waiting; this stops the probe, which would
+	// otherwise keep retrying long after /ready replied and accumulate under
+	// polling.
+	await withCallBounds(mwn, callDeadline(READY_PROBE_TIMEOUT_MS, 'calling')).request({
 		action: 'query',
 		meta: 'siteinfo',
 		format: 'json',

--- a/src/wikis/abortableMwn.ts
+++ b/src/wikis/abortableMwn.ts
@@ -1,4 +1,6 @@
 import type { Mwn, RawRequestParams } from 'mwn';
+import type { CallDeadline } from '../runtime/callDeadline.ts';
+import { WikiTimeoutError } from '../errors/wikiTimeoutError.ts';
 
 /**
  * Marks an error so mwn's retry ladder leaves it alone. `handleRequestFailure`
@@ -9,8 +11,13 @@ interface RetryableError {
 }
 
 /**
- * Returns a view of `bot` whose MediaWiki API calls carry `signal`, so an
- * abandoned request stops hitting the wiki instead of running to completion.
+ * Returns a view of `bot` whose MediaWiki API calls stop when `deadline`
+ * expires, and when the caller walks away if a `cancellation` signal is given.
+ *
+ * One deadline armed outside the view and shared by every request it makes is
+ * what bounds the retry LADDER rather than one attempt: mwn's own 60s cap is
+ * per attempt, and two of its retry branches nest requests that each get a
+ * fresh budget.
  *
  * Every API call mwn makes funnels through `rawRequest` — `request()` calls it
  * directly and `query()` goes through `request()` — so intercepting that one
@@ -25,23 +32,44 @@ interface RetryableError {
  *
  * That last property is why anything wrapped *inside* this view must preserve
  * the receiver: a layer that rebinds `this` to the bare instance cuts this
- * Proxy out of every internal hop and the signal silently stops applying. See
+ * Proxy out of every internal hop and the bound silently stops applying. See
  * the note in `mwnErrorSanitizer.ts`, which sits inside this one.
  *
  * Not covered: the `Page`/`File`/`Category`/`User`/`Wikitext` helper classes mwn
  * builds in its constructor close over the bare instance, so calls made through
  * them never re-enter this Proxy. Nothing in `src/` uses them; a tool that
- * reached for `bot.page(...)` would quietly lose cancellation.
+ * reached for `bot.page(...)` would quietly lose both bounds.
  *
- * The abort also has to be marked `disableRetry`. mwn treats a rejection that
- * carries no HTTP response as transient and retries it, and an aborted request
- * has no response — so an untreated abort sleeps through the whole retry ladder
- * (3 retries, 5s apart by default) before giving up, making cancellation slower
- * than letting the request finish.
+ * An abandoned request also has to be marked `disableRetry`. mwn treats a
+ * rejection that carries no HTTP response as transient and retries it, and an
+ * aborted request has none — so an untreated abort sleeps through the whole
+ * retry ladder before giving up, making the bound slower than letting the
+ * request finish. An expired deadline carries the flag on `WikiTimeoutError`.
  */
-export function withAbortSignal(bot: Mwn, signal: AbortSignal): Mwn {
+export function withCallBounds(bot: Mwn, deadline: CallDeadline, cancellation?: AbortSignal): Mwn {
+	const signal =
+		cancellation === undefined ? deadline.signal : AbortSignal.any([deadline.signal, cancellation]);
 	return new Proxy(bot, {
 		get(target, prop, receiver): unknown {
+			if (prop === 'massQuery') {
+				// `massQuery` puts per-batch errors IN its result array instead of
+				// rejecting, so a stopped batch arrives as data: `get-pages` skips an
+				// entry with no `query` and reports every page as missing, and
+				// `mwn.read` dereferences it into a TypeError. Ordinary per-batch
+				// failures are left alone, as mwn intends.
+				return async (...args: Parameters<Mwn['massQuery']>): Promise<unknown> => {
+					// Applied to the receiver so the internal `this.request` hop stays
+					// bounded.
+					const responses = await bot.massQuery.apply(receiver, args);
+					if (signal.aborted) {
+						const failure = responses.find((response) => response instanceof Error);
+						if (failure) {
+							throw failure;
+						}
+					}
+					return responses;
+				};
+			}
 			if (prop !== 'rawRequest') {
 				return Reflect.get(target, prop, receiver);
 			}
@@ -49,10 +77,15 @@ export function withAbortSignal(bot: Mwn, signal: AbortSignal): Mwn {
 				try {
 					return await target.rawRequest({ ...requestOptions, signal });
 				} catch (err: unknown) {
-					if (signal.aborted && typeof err === 'object' && err !== null) {
+					if (signal.aborted) {
+						// `AbortSignal.any` forwards the winning signal's own reason
+						// object, so identity says which of the two fired first.
+						if (deadline.signal.aborted && signal.reason === deadline.signal.reason) {
+							throw new WikiTimeoutError(deadline.timeoutMs, deadline.phase);
+						}
 						// Best-effort: a frozen error would throw on assignment in strict
 						// mode and replace the real failure with a TypeError.
-						if (Object.isExtensible(err)) {
+						if (typeof err === 'object' && err !== null && Object.isExtensible(err)) {
 							(err as RetryableError).disableRetry = true;
 						}
 					}

--- a/src/wikis/mwnProvider.ts
+++ b/src/wikis/mwnProvider.ts
@@ -1,5 +1,7 @@
 import { Mwn, type MwnOptions } from 'mwn';
 import { USER_AGENT } from '../runtime/constants.ts';
+import { callDeadline, WIKI_CONNECT_TIMEOUT_MS } from '../runtime/callDeadline.ts';
+import { withCallBounds } from './abortableMwn.ts';
 import type { ExecSecret, WikiConfig } from '../config/loadConfig.ts';
 import { runExecSecret } from './execSecret.ts';
 import { redactAuthorizationHeader, wrapMwnErrors } from './mwnErrorSanitizer.ts';
@@ -118,24 +120,38 @@ export class MwnProviderImpl implements MwnProvider {
 			apiUrl: `${server}${scriptpath}/api.php`,
 			userAgent: USER_AGENT,
 		};
+		if (effectiveToken) {
+			options.OAuth2AccessToken = effectiveToken;
+		} else if (username && password) {
+			options.username = username;
+			options.password = password;
+			// Force `assert=user` so MediaWiki returns `assertuserfailed` (instead of
+			// silently downgrading to anonymous) once the BotPassword session expires.
+			// mwn already auto-relogs in and retries on that code; without `assert`,
+			// writes would fail with `permissiondenied` and no recovery would occur.
+			options.defaultParams = { ...options.defaultParams, assert: 'user' };
+		}
 
-		let instance: Mwn;
+		const instance = new Mwn(options);
 		try {
+			// `Mwn.init` constructs and signs in in one step, leaving nowhere to
+			// bound three round-trips that each fund a fresh retry ladder. The
+			// branch is ours to make because the provider only ever sets an OAuth 2
+			// token or a bot-password pair. No cancellation: `getInstance` hands
+			// this promise to every concurrent caller — shared work, see
+			// `withSharedWorkScope`.
+			const connecting = withCallBounds(
+				instance,
+				callDeadline(WIKI_CONNECT_TIMEOUT_MS, 'connecting'),
+			);
 			if (effectiveToken) {
-				options.OAuth2AccessToken = effectiveToken;
-				instance = await Mwn.init(options);
+				// Makes no request, so it has no reason to go through the view.
+				instance.initOAuth();
+				await connecting.getTokensAndSiteInfo();
 			} else if (username && password) {
-				options.username = username;
-				options.password = password;
-				// Force `assert=user` so MediaWiki returns `assertuserfailed` (instead of
-				// silently downgrading to anonymous) once the BotPassword session expires.
-				// mwn already auto-relogs in and retries on that code; without `assert`,
-				// writes would fail with `permissiondenied` and no recovery would occur.
-				options.defaultParams = { ...options.defaultParams, assert: 'user' };
-				instance = await Mwn.init(options);
+				await connecting.login();
 			} else {
-				instance = new Mwn(options);
-				await instance.getSiteInfo();
+				await connecting.getSiteInfo();
 			}
 		} catch (error: unknown) {
 			redactAuthorizationHeader(error, effectiveToken);

--- a/src/wikis/siteInfo.ts
+++ b/src/wikis/siteInfo.ts
@@ -1,7 +1,8 @@
 import type { ToolContext } from '../runtime/context.ts';
 import type { SiteInfo, LicenseInfo, SiteInfoCache } from './siteInfoCache.ts';
 import { normalizeServer } from './normalizeServer.ts';
-import { withoutRequestSignal } from '../runtime/requestContext.ts';
+import { withSharedWorkScope } from '../runtime/requestContext.ts';
+import { callDeadline, WIKI_CONNECT_TIMEOUT_MS } from '../runtime/callDeadline.ts';
 
 interface SiteInfoApiResponse {
 	query?: {
@@ -94,12 +95,12 @@ export async function resolveSiteInfo(ctx: ToolContext, wikiKey: string): Promis
 		return existing;
 	}
 
-	// Detached from the calling request's cancellation: this promise is handed
-	// to every concurrent caller, so honouring the first caller's cancellation
-	// would drop all the others onto the fallback and silently degrade their
-	// page URLs. The extra siteinfo request an abandoned caller leaves behind is
-	// one cheap call, and it populates the cache for everyone.
-	const promise = withoutRequestSignal(() => fetchSiteInfo(ctx, wikiKey)).finally(() => {
+	// Handed to every concurrent caller, so it runs detached from the one that
+	// triggered it and on its own budget — see `withSharedWorkScope`. The extra
+	// request an abandoned caller leaves behind populates the cache anyway.
+	const promise = withSharedWorkScope(callDeadline(WIKI_CONNECT_TIMEOUT_MS, 'connecting'), () =>
+		fetchSiteInfo(ctx, wikiKey),
+	).finally(() => {
 		inflight.delete(wikiKey);
 	});
 	inflight.set(wikiKey, promise);

--- a/tests/errors/classifyError.test.ts
+++ b/tests/errors/classifyError.test.ts
@@ -5,8 +5,16 @@ import { errorResult } from '../../src/results/response.ts';
 import { createMockMwnError } from '../helpers/mock-mwn-error.ts';
 import { assertStructuredError } from '../helpers/structuredResult.ts';
 import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.ts';
+import { WikiTimeoutError } from '../../src/errors/wikiTimeoutError.ts';
 
 describe('classifyError', () => {
+	it('classifies an expired call budget as an upstream failure with a stable code', () => {
+		expect(classifyError(new WikiTimeoutError(150_000, 'calling'))).toEqual({
+			category: 'upstream_failure',
+			code: 'request-timeout',
+		});
+	});
+
 	describe('maps MW .code to category', () => {
 		const cases: Array<[string, ErrorCategory]> = [
 			['missingtitle', 'not_found'],

--- a/tests/helpers/fakeContext.ts
+++ b/tests/helpers/fakeContext.ts
@@ -117,3 +117,27 @@ export function withoutEditAttribution(ctx: ToolContext): ToolContext {
 		},
 	};
 }
+
+// A ctx whose registry and activeWiki agree on one wiki — the dispatcher
+// resolves and validates it before applying the OAuth gate, so a ctx whose two
+// halves disagree passes only by accident.
+export function ctxForWiki(
+	config: Record<string, unknown>,
+	transport: ToolContext['transport'],
+): ToolContext {
+	const registry: Record<string, unknown> = { 'wiki-key': config };
+	return fakeContext({
+		transport,
+		wikis: {
+			getAll: () => registry as never,
+			get: ((key: string) => registry[key]) as never,
+			add: () => {},
+			remove: () => {},
+			isManagementAllowed: () => true,
+		},
+		activeWiki: {
+			get: () => ({ key: getRequestWiki() ?? 'wiki-key', config: config as never }),
+			getDefaultKey: () => 'wiki-key',
+		},
+	});
+}

--- a/tests/helpers/rejectionOf.ts
+++ b/tests/helpers/rejectionOf.ts
@@ -1,0 +1,11 @@
+/**
+ * The error a promise rejects with, as a value. Tests that assert several
+ * things about one rejection cannot use `expect(...).rejects`, which takes a
+ * single matcher.
+ */
+export async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+	return promise.then(
+		() => undefined,
+		(err: unknown) => err,
+	);
+}

--- a/tests/runtime/createContext.test.ts
+++ b/tests/runtime/createContext.test.ts
@@ -3,6 +3,7 @@ import { createToolContext } from '../../src/runtime/createContext.ts';
 import { createAppState, type AppState } from '../../src/wikis/state.ts';
 import { logger } from '../../src/runtime/logger.ts';
 import { withRequestFields } from '../../src/runtime/requestContext.ts';
+import { callDeadline } from '../../src/runtime/callDeadline.ts';
 import type { Config } from '../../src/config/loadConfig.ts';
 
 const testConfig: Config = {
@@ -20,6 +21,25 @@ const testConfig: Config = {
 	},
 	uploadDirs: [],
 };
+
+function contextOverStubbedBot(): {
+	ctx: ReturnType<typeof createToolContext>;
+	calls: { signal?: AbortSignal }[];
+} {
+	const calls: { signal?: AbortSignal }[] = [];
+	const bot = {
+		async rawRequest(options: { signal?: AbortSignal }): Promise<unknown> {
+			calls.push(options);
+			return {};
+		},
+	};
+	const state = {
+		...createAppState(testConfig),
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering only the surface under test
+		mwnProvider: { get: async (): Promise<unknown> => bot } as unknown as AppState['mwnProvider'],
+	};
+	return { ctx: createToolContext({ logger, state, transport: 'stdio' }), calls };
+}
 
 describe('createToolContext', () => {
 	it('populates all ToolContext fields', () => {
@@ -43,19 +63,7 @@ describe('createToolContext', () => {
 	});
 
 	it('applies the request cancellation signal to the mwn instance it hands out', async () => {
-		const calls: { signal?: AbortSignal }[] = [];
-		const bot = {
-			async rawRequest(options: { signal?: AbortSignal }): Promise<unknown> {
-				calls.push(options);
-				return {};
-			},
-		};
-		const state = {
-			...createAppState(testConfig),
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering only the surface under test
-			mwnProvider: { get: async (): Promise<unknown> => bot } as unknown as AppState['mwnProvider'],
-		};
-		const ctx = createToolContext({ logger, state, transport: 'stdio' });
+		const { ctx, calls } = contextOverStubbedBot();
 		const controller = new AbortController();
 
 		await withRequestFields({ signal: controller.signal }, async () => {
@@ -63,22 +71,33 @@ describe('createToolContext', () => {
 			await scoped.rawRequest({ url: 'https://test.wiki/w/api.php' });
 		});
 
-		expect(calls[0]?.signal).toBe(controller.signal);
+		expect(calls[0]?.signal?.aborted).toBe(false);
+		controller.abort();
+		expect(calls[0]?.signal?.aborted).toBe(true);
 	});
 
-	it('hands out the bare instance when no request scope is active', async () => {
-		const bot = {
-			async rawRequest(): Promise<unknown> {
-				return {};
-			},
-		};
-		const state = {
-			...createAppState(testConfig),
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering only the surface under test
-			mwnProvider: { get: async (): Promise<unknown> => bot } as unknown as AppState['mwnProvider'],
-		};
-		const ctx = createToolContext({ logger, state, transport: 'stdio' });
+	it('spends one budget across every acquisition in the same call', async () => {
+		const { ctx, calls } = contextOverStubbedBot();
 
-		expect(await ctx.mwn()).toBe(bot);
+		await withRequestFields({ deadline: callDeadline(20, 'calling') }, async () => {
+			await (await ctx.mwn()).rawRequest({ url: 'https://test.wiki/w/api.php' });
+			await new Promise((resolve) => setTimeout(resolve, 40));
+			await (await ctx.mwn()).rawRequest({ url: 'https://test.wiki/w/api.php' });
+		});
+
+		// Eleven tools acquire the bot twice — once for the work, once to build a
+		// page URL — so a budget armed per acquisition would multiply.
+		expect(calls[0]?.signal?.aborted).toBe(true);
+		expect(calls[1]?.signal?.aborted).toBe(true);
+	});
+
+	it('bounds calls made outside any request scope', async () => {
+		const { ctx, calls } = contextOverStubbedBot();
+
+		await (await ctx.mwn()).rawRequest({ url: 'https://test.wiki/w/api.php' });
+
+		// Startup reconciliation, the wiki resources and the readiness probe reach
+		// the wiki with no MCP request around them.
+		expect(calls[0]?.signal).toBeDefined();
 	});
 });

--- a/tests/runtime/dispatch.oauth.test.ts
+++ b/tests/runtime/dispatch.oauth.test.ts
@@ -1,11 +1,9 @@
 // tests/runtime/dispatch.oauth.test.ts
 import type { CallToolResult } from '@modelcontextprotocol/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { WikiConfig } from '../../src/config/loadConfig.ts';
-import type { ToolContext } from '../../src/runtime/context.ts';
 import { dispatch } from '../../src/runtime/dispatcher.ts';
 import type { Tool } from '../../src/runtime/tool.ts';
-import { fakeContext } from '../helpers/fakeContext.ts';
+import { fakeContext, ctxForWiki } from '../helpers/fakeContext.ts';
 import { startFakeAs, type FakeAsHandle } from '../helpers/fakeAuthorizationServer.ts';
 import { fakeBrowserDriver } from '../helpers/fakeBrowserDriver.ts';
 import { useTempTokenStore } from '../helpers/tempTokenStore.ts';
@@ -28,27 +26,6 @@ afterEach(async () => {
 	_resetRefreshDedupForTesting();
 	vi.clearAllMocks();
 });
-
-// Builds a ctx whose single wiki (keyed `wiki-key`) carries the given config,
-// with a registry + activeWiki that agree on it — the dispatcher resolves and
-// validates the wiki before applying the OAuth gate.
-function ctxForWiki(config: WikiConfig, transport: ToolContext['transport']): ToolContext {
-	const registry: Record<string, WikiConfig> = { 'wiki-key': config };
-	return fakeContext({
-		transport,
-		wikis: {
-			getAll: () => registry,
-			get: (key: string) => registry[key],
-			add: () => {},
-			remove: () => {},
-			isManagementAllowed: () => true,
-		},
-		activeWiki: {
-			get: () => ({ key: getRequestWiki() ?? 'wiki-key', config }),
-			getDefaultKey: () => 'wiki-key',
-		},
-	});
-}
 
 /** A dummy tool that returns whatever getRuntimeToken() sees at invocation time. */
 const tokenCaptureTool: Tool<Record<string, never>> = {

--- a/tests/runtime/dispatcher.test.ts
+++ b/tests/runtime/dispatcher.test.ts
@@ -1,15 +1,21 @@
 import { type StderrWriteSpy } from '../helpers/stderrSpy.ts';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockAcquireToken } = vi.hoisted(() => ({ mockAcquireToken: vi.fn() }));
+vi.mock('../../src/auth/acquireToken.ts', () => ({ acquireToken: mockAcquireToken }));
 import { z } from 'zod';
 import { dispatch } from '../../src/runtime/dispatcher.ts';
 import type { Tool } from '../../src/runtime/tool.ts';
-import { fakeContext } from '../helpers/fakeContext.ts';
+import { fakeContext, ctxForWiki } from '../helpers/fakeContext.ts';
 import { fakeLogger } from '../helpers/fakeLogger.ts';
 import { createMockMwnError } from '../helpers/mock-mwn-error.ts';
 import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.ts';
-import { withRequestFields } from '../../src/runtime/requestContext.ts';
+import { withRequestFields, getRequestDeadline } from '../../src/runtime/requestContext.ts';
+import { WIKI_CALL_TIMEOUT_MS } from '../../src/runtime/callDeadline.ts';
+import { WikiTimeoutError } from '../../src/errors/wikiTimeoutError.ts';
 import { getPage } from '../../src/tools/get-page.ts';
 import { ContentFormat } from '../../src/results/contentFormat.ts';
+import { assertStructuredError } from '../helpers/structuredResult.ts';
 
 const noopTool = (handle: Tool<{ x: z.ZodString }>['handle']): Tool<{ x: z.ZodString }> => ({
 	name: 'get-page',
@@ -93,6 +99,107 @@ describe('dispatcher', () => {
 		const result = await dispatch(tool, ctx)({ x: 'y' });
 		const envelope = JSON.parse((result.content[0] as { text: string }).text);
 		expect(envelope.message).toBe('Failed to update page: boom');
+	});
+
+	it('starts the budget after an interactive sign-in, not before it', async () => {
+		let duringSignIn: unknown = 'unset';
+		mockAcquireToken.mockReset().mockImplementation(async () => {
+			duringSignIn = getRequestDeadline();
+			return 'token';
+		});
+		const ctx = ctxForWiki(
+			{
+				sitename: 'Test',
+				server: 'https://test.wiki',
+				articlepath: '/wiki',
+				scriptpath: '/w',
+				oauth2ClientId: 'client',
+			},
+			'stdio',
+		);
+		let seen: { timeoutMs: number } | undefined;
+		const tool = noopTool(async () => {
+			seen = getRequestDeadline();
+			return ctx.format.ok({ ok: true });
+		});
+
+		await dispatch(tool, ctx)({ x: 'y' });
+
+		// A browser sign-in is minutes of human reaction time.
+		expect(mockAcquireToken).toHaveBeenCalledOnce();
+		expect(duringSignIn).toBeUndefined();
+		expect(seen?.timeoutMs).toBe(WIKI_CALL_TIMEOUT_MS);
+	});
+
+	it('gives the handler a time budget for its wiki calls', async () => {
+		const ctx = fakeContext();
+		let seen: { timeoutMs: number } | undefined;
+		const tool = noopTool(async () => {
+			seen = getRequestDeadline();
+			return ctx.format.ok({ ok: true });
+		});
+
+		await dispatch(tool, ctx)({ x: 'y' });
+
+		expect(seen?.timeoutMs).toBe(WIKI_CALL_TIMEOUT_MS);
+	});
+
+	it('reports an exhausted budget as an upstream failure with a stable code', async () => {
+		const ctx = fakeContext();
+		const tool = noopTool(async () => {
+			throw new WikiTimeoutError(WIKI_CALL_TIMEOUT_MS, 'calling');
+		});
+
+		const result = await dispatch(tool, ctx)({ x: 'y' });
+
+		const envelope = assertStructuredError(result, 'upstream_failure', 'request-timeout');
+		expect(envelope.message).toContain('150 seconds');
+	});
+
+	it('warns that a timed-out write may still have been applied', async () => {
+		const ctx = fakeContext();
+		const tool = {
+			...noopTool(async () => {
+				throw new WikiTimeoutError(WIKI_CALL_TIMEOUT_MS, 'calling');
+			}),
+			annotations: { title: 't', readOnlyHint: false, destructiveHint: false },
+		};
+
+		const result = await dispatch(tool, ctx)({ x: 'y' });
+
+		const envelope = JSON.parse((result.content[0] as { text: string }).text);
+		expect(envelope.message).toContain('may or may not have been applied');
+	});
+
+	it('adds no such warning when the call never got past connecting', async () => {
+		const ctx = fakeContext();
+		const tool = {
+			...noopTool(async () => {
+				throw new WikiTimeoutError(30_000, 'connecting');
+			}),
+			annotations: { title: 't', readOnlyHint: false, destructiveHint: false },
+		};
+
+		const result = await dispatch(tool, ctx)({ x: 'y' });
+
+		// The budget that expired covers only signing in, so the write provably
+		// never left the process.
+		const envelope = JSON.parse((result.content[0] as { text: string }).text);
+		expect(envelope.message).toContain('Gave up trying to reach the wiki');
+		expect(envelope.message).not.toContain('may or may not have been applied');
+	});
+
+	it('adds no such warning to a timed-out read', async () => {
+		const ctx = fakeContext();
+		const tool = noopTool(async () => {
+			throw new WikiTimeoutError(WIKI_CALL_TIMEOUT_MS, 'calling');
+		});
+
+		const result = await dispatch(tool, ctx)({ x: 'y' });
+
+		const envelope = JSON.parse((result.content[0] as { text: string }).text);
+		expect(envelope.message).toContain('Gave up waiting for the wiki');
+		expect(envelope.message).not.toContain('may or may not have been applied');
 	});
 
 	it('surfaces a CredentialResolutionError from the mwn provider as authentication category', async () => {
@@ -180,6 +287,20 @@ describe('dispatcher emits tool_call telemetry', () => {
 		expect(line).toBeDefined();
 		expect(line!.outcome).toBe('cancelled');
 		expect(line!.level).toBe('info');
+	});
+
+	it('reports an exhausted budget as an upstream failure, not as a cancellation', async () => {
+		const ctx = fakeContext({ logger: fakeLogger() });
+		const tool = noopTool(async () => {
+			throw new WikiTimeoutError(WIKI_CALL_TIMEOUT_MS, 'calling');
+		});
+
+		// A live caller: the budget expired, the client did not walk away.
+		await withRequestFields({ signal: new AbortController().signal }, () =>
+			dispatch(tool, ctx)({ x: 'y' }),
+		);
+
+		expect(captureToolCallLine(stderrSpy)?.outcome).toBe('upstream_failure');
 	});
 
 	it('still reports a genuine failure as an upstream failure when nothing was cancelled', async () => {

--- a/tests/runtime/requestContext.test.ts
+++ b/tests/runtime/requestContext.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
 	runtimeTokenStore,
+	getRequestDeadline,
+	getRequestSignal,
 	getRequestWiki,
 	getRuntimeToken,
+	withSharedWorkScope,
 	withRequestContext,
 	withRequestFields,
 } from '../../src/runtime/requestContext.ts';
+import { callDeadline } from '../../src/runtime/callDeadline.ts';
 
 describe('requestContext', () => {
 	it('returns undefined outside a run', () => {
@@ -80,5 +84,25 @@ describe('request context wiki', () => {
 				expect(getRuntimeToken()).toBe('bearer-xyz');
 			});
 		});
+	});
+});
+
+describe('scoping work shared between callers', () => {
+	it('takes neither the caller cancellation nor the caller budget', async () => {
+		// The assertions live inside the callback, which might never be invoked.
+		expect.assertions(3);
+		const callerDeadline = callDeadline(60_000, 'calling');
+		const sharedDeadline = callDeadline(60_000, 'calling');
+
+		await withRequestFields(
+			{ signal: new AbortController().signal, deadline: callerDeadline },
+			async () => {
+				await withSharedWorkScope(sharedDeadline, async () => {
+					expect(getRequestSignal()).toBeUndefined();
+					expect(getRequestDeadline()).toBe(sharedDeadline);
+					expect(getRequestDeadline()).not.toBe(callerDeadline);
+				});
+			},
+		);
 	});
 });

--- a/tests/tools/extensions/neowiki/neowikiRequest.test.ts
+++ b/tests/tools/extensions/neowiki/neowikiRequest.test.ts
@@ -6,6 +6,8 @@ import {
 	neowikiErrorResult,
 	NeoWikiApiError,
 } from '../../../../src/tools/extensions/neowiki/neowikiRequest.ts';
+import { WikiTimeoutError } from '../../../../src/errors/wikiTimeoutError.ts';
+import { rejectionOf } from '../../../helpers/rejectionOf.ts';
 
 // Builds an axios-style rejection: a thrown error carrying `.response`.
 function httpError(status: number, data: unknown): Error & { response: unknown } {
@@ -27,6 +29,21 @@ describe('neowikiRequest', () => {
 		const call = mock.rawRequest.mock.calls[0][0] as Record<string, unknown>;
 		expect(call.url).toBe('https://test.wiki/w/rest.php/neowiki/v0/schemas?limit=500&offset=0');
 		expect(call.method).toBe('GET');
+	});
+
+	it('lets an expired call budget through instead of relabelling it', async () => {
+		const mock = createMockMwn({
+			rawRequest: vi.fn().mockRejectedValue(new WikiTimeoutError(150_000, 'calling')),
+		});
+
+		const err = await rejectionOf(
+			neowikiRequest(mock as never, { method: 'GET', path: '/schemas' }),
+		);
+
+		// Converted, the tool returns it as a RESULT the dispatcher never sees,
+		// losing the code and the write caveat.
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+		expect(err).not.toBeInstanceOf(NeoWikiApiError);
 	});
 
 	it('JSON-encodes a POST body and sets Content-Type', async () => {

--- a/tests/transport/ready.test.ts
+++ b/tests/transport/ready.test.ts
@@ -70,6 +70,42 @@ describe('/ready', () => {
 		vi.useRealTimers();
 	});
 
+	it('stops the probe request itself, not just the wait for it', async () => {
+		const calls: { signal?: AbortSignal }[] = [];
+		interface ProbeBot {
+			rawRequest(options: { url?: string; data?: unknown; signal?: AbortSignal }): Promise<unknown>;
+			request(params: unknown): Promise<unknown>;
+		}
+		const bot: ProbeBot = {
+			async rawRequest(options: { signal?: AbortSignal }): Promise<unknown> {
+				calls.push(options);
+				return { query: { general: { sitename: 'X' } } };
+			},
+
+			async request(this: ProbeBot, params: unknown): Promise<unknown> {
+				return this.rawRequest({ url: 'https://example.org/w/api.php', data: params });
+			},
+		};
+		const app = express();
+		mountReadyEndpoint(app, {
+			activeWiki: mockActiveWiki,
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Mwn has 100+ methods; this probe uses request() and rawRequest().
+			mwnProvider: { get: async () => bot as never, invalidate: () => {} },
+		});
+
+		await request(app).get('/ready');
+
+		// Giving up on the answer is not the same as stopping the request.
+		const probeSignal = calls[0]?.signal;
+		expect(probeSignal).toBeDefined();
+		// And it must be the PROBE's budget: bounded at the per-call one instead,
+		// a probe outlives the race that abandoned it by two orders of magnitude
+		// and a polled endpoint piles them up.
+		expect(probeSignal?.aborted).toBe(false);
+		await new Promise((resolve) => setTimeout(resolve, READY_PROBE_TIMEOUT_MS + 250));
+		expect(probeSignal?.aborted).toBe(true);
+	});
+
 	it('returns 200 ready when the probe succeeds', async () => {
 		mockRequest.mockResolvedValue({ query: { general: { sitename: 'X' } } });
 		const res = await request(makeApp()).get('/ready');

--- a/tests/wikis/abortableMwn.test.ts
+++ b/tests/wikis/abortableMwn.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { Mwn, RawRequestParams } from 'mwn';
-import { withAbortSignal } from '../../src/wikis/abortableMwn.ts';
+import { withCallBounds } from '../../src/wikis/abortableMwn.ts';
+import { callDeadline } from '../../src/runtime/callDeadline.ts';
+import { WikiTimeoutError } from '../../src/errors/wikiTimeoutError.ts';
 import { wrapMwnErrors } from '../../src/wikis/mwnErrorSanitizer.ts';
+import { rejectionOf } from '../helpers/rejectionOf.ts';
 
 /**
  * A stand-in shaped like the parts of mwn this wrapper leans on: `rawRequest`
@@ -28,23 +31,52 @@ function createFakeBot(
 	return bot as unknown as Mwn & { csrfToken: string; calls: RawRequestParams[] };
 }
 
-describe('withAbortSignal', () => {
-	it('attaches the signal to the request options', async () => {
+describe('withCallBounds', () => {
+	it('tears a request down when the caller cancels', async () => {
 		const controller = new AbortController();
 		const bot = createFakeBot(async () => ({ ok: true }));
 
-		await withAbortSignal(bot, controller.signal).rawRequest({
+		await withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).rawRequest({
 			url: 'https://wiki.example/api.php',
 		});
 
-		expect(bot.calls[0]?.signal).toBe(controller.signal);
+		// Behavioural, not by identity: the attached signal is composed from both.
+		const attached = bot.calls[0]?.signal;
+		expect(attached?.aborted).toBe(false);
+		controller.abort();
+		expect(attached?.aborted).toBe(true);
+	});
+
+	it('tears a request down when the call runs out of budget', async () => {
+		const bot = createFakeBot(async () => ({ ok: true }));
+
+		await withCallBounds(bot, callDeadline(5, 'calling'), new AbortController().signal).rawRequest({
+			url: 'https://wiki.example/api.php',
+		});
+
+		const attached = bot.calls[0]?.signal;
+		expect(attached?.aborted).toBe(false);
+		// `AbortSignal.timeout` is unref'd and is not advanced by vitest's fake
+		// timers, so a deadline test has to wait on the real clock.
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(attached?.aborted).toBe(true);
+	});
+
+	it('bounds the call even when the caller supplies no cancellation', async () => {
+		const bot = createFakeBot(async () => ({ ok: true }));
+		const deadline = callDeadline(60_000, 'calling');
+
+		await withCallBounds(bot, deadline).rawRequest({ url: 'https://wiki.example/api.php' });
+
+		// With nothing to compose, the deadline's own signal travels unwrapped.
+		expect(bot.calls[0]?.signal).toBe(deadline.signal);
 	});
 
 	it('keeps the caller-supplied request options', async () => {
 		const controller = new AbortController();
 		const bot = createFakeBot(async () => ({ ok: true }));
 
-		await withAbortSignal(bot, controller.signal).rawRequest({
+		await withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).rawRequest({
 			url: 'https://wiki.example/api.php',
 			method: 'post',
 		});
@@ -57,13 +89,17 @@ describe('withAbortSignal', () => {
 		const controller = new AbortController();
 		const bot = createFakeBot(async () => ({ ok: true }));
 
-		await withAbortSignal(bot, controller.signal).request({ action: 'query' });
+		await withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).request({
+			action: 'query',
+		});
 
 		// The Proxy returns methods unbound, so `this` inside `request` is the
 		// Proxy and its internal hop is intercepted. Binding to the target here
 		// would silently drop the signal from every internally-issued call.
 		expect(bot.calls).toHaveLength(1);
-		expect(bot.calls[0]?.signal).toBe(controller.signal);
+		expect(bot.calls[0]?.signal?.aborted).toBe(false);
+		controller.abort();
+		expect(bot.calls[0]?.signal?.aborted).toBe(true);
 	});
 
 	it('marks an aborted failure so mwn does not retry it', async () => {
@@ -73,12 +109,11 @@ describe('withAbortSignal', () => {
 			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
 		});
 
-		const err = await withAbortSignal(bot, controller.signal)
-			.rawRequest({ url: 'https://wiki.example/api.php' })
-			.then(
-				() => undefined,
-				(e: unknown) => e,
-			);
+		const err = await rejectionOf(
+			withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
 
 		// mwn's handleRequestFailure retries any rejection carrying no HTTP
 		// response, and an aborted request has none — without this flag a
@@ -92,12 +127,11 @@ describe('withAbortSignal', () => {
 			throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
 		});
 
-		const err = await withAbortSignal(bot, controller.signal)
-			.rawRequest({ url: 'https://wiki.example/api.php' })
-			.then(
-				() => undefined,
-				(e: unknown) => e,
-			);
+		const err = await rejectionOf(
+			withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
 
 		expect((err as { disableRetry?: boolean }).disableRetry).toBeUndefined();
 	});
@@ -110,20 +144,195 @@ describe('withAbortSignal', () => {
 		// error-sanitised instance, and the abort view goes on the outside. A
 		// wrapper that rebinds `this` to the raw object breaks the outer proxy's
 		// interception of mwn's internal hops, so the signal silently vanishes.
-		await withAbortSignal(wrapMwnErrors(bot), controller.signal).request({ action: 'query' });
+		await withCallBounds(
+			wrapMwnErrors(bot),
+			callDeadline(60_000, 'calling'),
+			controller.signal,
+		).request({
+			action: 'query',
+		});
 
-		expect(bot.calls[0]?.signal).toBe(controller.signal);
+		expect(bot.calls[0]?.signal?.aborted).toBe(false);
+		controller.abort();
+		expect(bot.calls[0]?.signal?.aborted).toBe(true);
 	});
 
 	it('writes through to the shared instance so cached state is not shadowed', () => {
 		const controller = new AbortController();
 		const bot = createFakeBot(async () => ({ ok: true }));
 
-		const scoped = withAbortSignal(bot, controller.signal) as unknown as { csrfToken: string };
+		const scoped = withCallBounds(
+			bot,
+			callDeadline(60_000, 'calling'),
+			controller.signal,
+		) as unknown as {
+			csrfToken: string;
+		};
 		scoped.csrfToken = 'fresh-token';
 
 		// A per-request clone would strand this write on a throwaway object and
 		// make every request re-fetch the token from the wiki.
 		expect(bot.csrfToken).toBe('fresh-token');
+	});
+	it('reports an expired deadline as a timeout naming the budget', async () => {
+		const bot = createFakeBot(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		// Armed in 5ms so the test does not wait, but reporting the production
+		// budget, so the assertion is made on the subject rather than on an error
+		// the test built itself.
+		const err = await rejectionOf(
+			withCallBounds(bot, {
+				signal: AbortSignal.timeout(5),
+				timeoutMs: 150_000,
+				phase: 'calling',
+			}).rawRequest({ url: 'https://wiki.example/api.php' }),
+		);
+
+		// Without the replacement the caller reads "canceled": axios reports an
+		// abort with a `code`, and classifyError skips its message fallbacks
+		// whenever a code is present, so nothing downstream can improve it.
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+		expect((err as { disableRetry?: boolean }).disableRetry).toBe(true);
+		// The budget is named so a caller can tell how long it actually waited.
+		expect((err as Error).message).toContain('150 seconds');
+	});
+
+	it('reports a cancellation as a cancellation, not as a timeout', async () => {
+		const controller = new AbortController();
+		const bot = createFakeBot(async () => {
+			controller.abort();
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		const err = await rejectionOf(
+			withCallBounds(bot, callDeadline(60_000, 'calling'), controller.signal).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
+
+		// The dispatcher tells the two apart to decide whether a failed call was
+		// the caller walking away or the wiki running out of time; replacing a
+		// cancellation with a timeout would report every cancelled call as an
+		// upstream fault.
+		expect(err).not.toBeInstanceOf(WikiTimeoutError);
+		expect((err as { disableRetry?: boolean }).disableRetry).toBe(true);
+	});
+	it('reports an expired deadline as a timeout with a live cancellation composed in', async () => {
+		// The shape production always has: the SDK supplies a cancellation signal
+		// on every request, so the deadline never travels alone. Without this the
+		// reason-identity check that tells the two apart is never exercised, and
+		// deleting it would go unnoticed.
+		const bot = createFakeBot(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		const err = await rejectionOf(
+			withCallBounds(bot, callDeadline(5, 'calling'), new AbortController().signal).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
+
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+	});
+
+	it('surfaces a batch that ran out of budget instead of returning it as data', async () => {
+		const bot = createFakeBot(async () => ({ ok: true }));
+		// mwn resolves massQuery with per-batch errors placed in the array rather
+		// than rejecting it.
+		Object.assign(bot, {
+			async massQuery(): Promise<unknown[]> {
+				return [{ query: { pages: [] } }, new WikiTimeoutError(150_000, 'calling')];
+			},
+		});
+
+		const expired = callDeadline(5, 'calling');
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const err = await rejectionOf(
+			withCallBounds(bot, expired).massQuery({ action: 'query', titles: ['A'] }, 'titles'),
+		);
+
+		// Left as data, this reaches get-pages as a batch with no `query` and is
+		// skipped — reporting a timeout as every requested page being missing.
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+	});
+
+	it('leaves an ordinary per-batch failure in place', async () => {
+		const bot = createFakeBot(async () => ({ ok: true }));
+		const batchFailure = Object.assign(new Error('server error'), { code: 'internal_api_error' });
+		Object.assign(bot, {
+			async massQuery(): Promise<unknown[]> {
+				return [{ query: { pages: [] } }, batchFailure];
+			},
+		});
+
+		const responses = await withCallBounds(bot, callDeadline(60_000, 'calling')).massQuery(
+			{ action: 'query', titles: ['A'] },
+			'titles',
+		);
+
+		// mwn collects these deliberately so one bad batch does not lose the rest.
+		expect(responses[1]).toBe(batchFailure);
+	});
+	it('keeps reporting a cancellation as one even after the budget also expires', async () => {
+		const controller = new AbortController();
+		// Aborted before the request is issued, so which signal fired first is
+		// fixed rather than raced. The request then outlives the budget, so by the
+		// time the failure surfaces BOTH have fired and only the order tells them
+		// apart.
+		controller.abort();
+		const bot = createFakeBot(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		const deadline = callDeadline(20, 'calling');
+		const err = await rejectionOf(
+			withCallBounds(bot, deadline, controller.signal).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
+
+		// Asserted, not assumed: both assertions below also hold if the deadline
+		// never fires, so lengthening it would disarm the test silently.
+		expect(deadline.signal.aborted).toBe(true);
+		expect(err).not.toBeInstanceOf(WikiTimeoutError);
+		expect((err as { disableRetry?: boolean }).disableRetry).toBe(true);
+	});
+	it('keeps the bound on the requests massQuery issues internally', async () => {
+		const bot = createFakeBot(async () => ({ query: { pages: [] } }));
+		// mwn's massQuery reaches the network through `this.request`, so the double
+		// must too: a stub that ignores `this` cannot observe the receiver, and
+		// rebinding it cuts this Proxy out of the hop.
+		Object.assign(bot, {
+			async massQuery(this: Mwn, query: unknown): Promise<unknown[]> {
+				return [await this.request(query as never)];
+			},
+		});
+
+		await withCallBounds(bot, callDeadline(60_000, 'calling')).massQuery(
+			{ action: 'query', titles: ['A'] },
+			'titles',
+		);
+
+		expect(bot.calls[0]?.signal).toBeDefined();
+	});
+	it('reports the phase of the budget that expired', async () => {
+		const bot = createFakeBot(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			throw Object.assign(new Error('canceled'), { code: 'ERR_CANCELED' });
+		});
+
+		const err = await rejectionOf(
+			withCallBounds(bot, callDeadline(5, 'connecting')).rawRequest({
+				url: 'https://wiki.example/api.php',
+			}),
+		);
+
+		expect((err as WikiTimeoutError).phase).toBe('connecting');
+		expect((err as Error).message).toContain('Gave up trying to reach the wiki');
 	});
 });

--- a/tests/wikis/mwnProvider.test.ts
+++ b/tests/wikis/mwnProvider.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockConstructor, mockGetSiteInfo, mockInit } = vi.hoisted(() => ({
+const {
+	mockConstructor,
+	mockGetSiteInfo,
+	mockInitOAuth,
+	mockLogin,
+	mockGetTokensAndSiteInfo,
+	mockRawRequest,
+} = vi.hoisted(() => ({
 	mockConstructor: vi.fn(),
 	mockGetSiteInfo: vi.fn(),
-	mockInit: vi.fn(),
+	mockInitOAuth: vi.fn(),
+	mockLogin: vi.fn(),
+	mockGetTokensAndSiteInfo: vi.fn(),
+	mockRawRequest: vi.fn(),
 }));
 
 vi.mock('mwn', () => ({
@@ -12,7 +22,10 @@ vi.mock('mwn', () => ({
 			mockConstructor(options);
 		}
 		public getSiteInfo = mockGetSiteInfo;
-		public static init = mockInit;
+		public initOAuth = mockInitOAuth;
+		public login = mockLogin;
+		public getTokensAndSiteInfo = mockGetTokensAndSiteInfo;
+		public rawRequest = mockRawRequest;
 	},
 }));
 
@@ -30,6 +43,7 @@ import { WikiRegistryImpl } from '../../src/wikis/wikiRegistry.ts';
 import { ActiveWikiImpl } from '../../src/wikis/activeWiki.ts';
 import type { WikiConfig } from '../../src/config/loadConfig.ts';
 import { CredentialResolutionError } from '../../src/errors/credentialResolutionError.ts';
+import { withRequestFields } from '../../src/runtime/requestContext.ts';
 
 const sample = (name: string): WikiConfig => ({
 	sitename: name,
@@ -39,11 +53,19 @@ const sample = (name: string): WikiConfig => ({
 });
 
 describe('MwnProviderImpl', () => {
+	// The bounded view intercepts `rawRequest`, so the doubles must route through
+	// it for a test to observe whether the sign-in was bounded.
+	async function signIn(this: { rawRequest: (options: unknown) => Promise<unknown> }) {
+		await this.rawRequest({ url: 'https://a.example.com/w/api.php' });
+	}
+
 	beforeEach(() => {
 		mockConstructor.mockReset();
-		mockGetSiteInfo.mockReset();
-		mockInit.mockReset();
-		mockGetSiteInfo.mockResolvedValue(undefined);
+		mockRawRequest.mockReset().mockResolvedValue({});
+		mockInitOAuth.mockReset();
+		mockGetSiteInfo.mockReset().mockImplementation(signIn);
+		mockLogin.mockReset().mockImplementation(signIn);
+		mockGetTokensAndSiteInfo.mockReset().mockImplementation(signIn);
 		mockRunExecSecret.mockReset();
 	});
 
@@ -69,12 +91,11 @@ describe('MwnProviderImpl', () => {
 	it('creates fresh mwn per call when runtime token is set', async () => {
 		const reg = new WikiRegistryImpl({ a: sample('a') }, true);
 		const sel = new ActiveWikiImpl('a', reg);
-		mockInit.mockImplementation(async (options: unknown) => ({ id: 'oauth', options }));
 		const provider = new MwnProviderImpl(reg, sel, () => 'TOKEN');
 		const m1 = await provider.get();
 		const m2 = await provider.get();
 		expect(m1).not.toBe(m2);
-		expect(mockInit).toHaveBeenCalledTimes(2);
+		expect(mockConstructor).toHaveBeenCalledTimes(2);
 	});
 
 	it('invalidate clears the cache for one key', async () => {
@@ -111,7 +132,7 @@ describe('MwnProviderImpl', () => {
 		expect(mockConstructor).toHaveBeenCalledTimes(2);
 	});
 
-	it('uses Mwn.init with OAuth2 token when config has token', async () => {
+	it('passes the OAuth2 token from config to mwn', async () => {
 		const reg = new WikiRegistryImpl(
 			{
 				a: { ...sample('a'), token: 'config-token' },
@@ -119,10 +140,9 @@ describe('MwnProviderImpl', () => {
 			true,
 		);
 		const sel = new ActiveWikiImpl('a', reg);
-		mockInit.mockResolvedValue({ id: 'oauth' });
 		const provider = new MwnProviderImpl(reg, sel, () => undefined);
 		await provider.get();
-		expect(mockInit).toHaveBeenCalledWith(
+		expect(mockConstructor).toHaveBeenCalledWith(
 			expect.objectContaining({
 				OAuth2AccessToken: 'config-token',
 			}),
@@ -137,10 +157,9 @@ describe('MwnProviderImpl', () => {
 			true,
 		);
 		const sel = new ActiveWikiImpl('a', reg);
-		mockInit.mockResolvedValue({ id: 'oauth' });
 		const provider = new MwnProviderImpl(reg, sel, () => 'runtime-token');
 		await provider.get();
-		expect(mockInit).toHaveBeenCalledWith(
+		expect(mockConstructor).toHaveBeenCalledWith(
 			expect.objectContaining({
 				OAuth2AccessToken: 'runtime-token',
 			}),
@@ -155,10 +174,9 @@ describe('MwnProviderImpl', () => {
 			true,
 		);
 		const sel = new ActiveWikiImpl('a', reg);
-		mockInit.mockResolvedValue({ id: 'bot' });
 		const provider = new MwnProviderImpl(reg, sel, () => undefined);
 		await provider.get();
-		expect(mockInit).toHaveBeenCalledWith(
+		expect(mockConstructor).toHaveBeenCalledWith(
 			expect.objectContaining({
 				username: 'Bot@MCP',
 				password: 'secret',
@@ -175,10 +193,9 @@ describe('MwnProviderImpl', () => {
 			true,
 		);
 		const sel = new ActiveWikiImpl('a', reg);
-		mockInit.mockResolvedValue({ id: 'oauth' });
 		const provider = new MwnProviderImpl(reg, sel, () => undefined);
 		await provider.get();
-		const options = mockInit.mock.calls[0]?.[0] as { defaultParams?: { assert?: unknown } };
+		const options = mockConstructor.mock.calls[0]?.[0] as { defaultParams?: { assert?: unknown } };
 		expect(options.defaultParams?.assert).toBeUndefined();
 	});
 
@@ -191,6 +208,75 @@ describe('MwnProviderImpl', () => {
 		expect(options.defaultParams?.assert).toBeUndefined();
 	});
 
+	// The provider drives sign-in itself, so the branch mwn used to pick is ours.
+	it('signs in with the OAuth 2 handshake when a token is configured', async () => {
+		const reg = new WikiRegistryImpl({ a: { ...sample('a'), token: 'config-token' } }, true);
+		const provider = new MwnProviderImpl(reg, new ActiveWikiImpl('a', reg), () => undefined);
+
+		await provider.get();
+
+		expect(mockInitOAuth).toHaveBeenCalledOnce();
+		expect(mockGetTokensAndSiteInfo).toHaveBeenCalledOnce();
+		expect(mockLogin).not.toHaveBeenCalled();
+		// initOAuth() sets the flag that makes mwn attach the bearer, so a
+		// handshake issued before it would go out unauthenticated.
+		expect(mockInitOAuth.mock.invocationCallOrder[0]).toBeLessThan(
+			mockGetTokensAndSiteInfo.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it('logs in when a bot password is configured', async () => {
+		const reg = new WikiRegistryImpl(
+			{ a: { ...sample('a'), username: 'Bot@MCP', password: 'secret' } },
+			true,
+		);
+		const provider = new MwnProviderImpl(reg, new ActiveWikiImpl('a', reg), () => undefined);
+
+		await provider.get();
+
+		expect(mockLogin).toHaveBeenCalledOnce();
+		expect(mockInitOAuth).not.toHaveBeenCalled();
+		expect(mockGetTokensAndSiteInfo).not.toHaveBeenCalled();
+	});
+
+	it('only reads site info when the wiki has no credentials', async () => {
+		const reg = new WikiRegistryImpl({ a: sample('a') }, true);
+		const provider = new MwnProviderImpl(reg, new ActiveWikiImpl('a', reg), () => undefined);
+
+		await provider.get();
+
+		expect(mockGetSiteInfo).toHaveBeenCalledOnce();
+		expect(mockLogin).not.toHaveBeenCalled();
+		expect(mockInitOAuth).not.toHaveBeenCalled();
+	});
+
+	it('bounds the sign-in that reaching a wiki for the first time performs', async () => {
+		const reg = new WikiRegistryImpl(
+			{ a: { ...sample('a'), username: 'Bot@MCP', password: 'secret' } },
+			true,
+		);
+		const provider = new MwnProviderImpl(reg, new ActiveWikiImpl('a', reg), () => undefined);
+
+		await provider.get();
+
+		// Three round-trips that each fund a fresh retry ladder, which `Mwn.init`
+		// left carrying no signal at all.
+		expect(mockRawRequest.mock.calls[0]?.[0]?.signal).toBeDefined();
+	});
+
+	it('keeps a shared sign-in alive when the caller that triggered it cancels', async () => {
+		const reg = new WikiRegistryImpl({ a: sample('a') }, true);
+		const provider = new MwnProviderImpl(reg, new ActiveWikiImpl('a', reg), () => undefined);
+		const controller = new AbortController();
+
+		await withRequestFields({ signal: controller.signal }, () => provider.get());
+		controller.abort();
+
+		// Cached and handed to every concurrent caller, so tying it to the first
+		// arrival's cancellation would fail the rest.
+		expect(mockRawRequest.mock.calls[0]?.[0]?.signal.aborted).toBe(false);
+	});
+
 	describe('lazy exec-backed credentials', () => {
 		const execWiki = (name: string): WikiConfig => ({
 			...sample(name),
@@ -199,7 +285,6 @@ describe('MwnProviderImpl', () => {
 
 		it('runs the exec command once on first use and reuses the cached value', async () => {
 			mockRunExecSecret.mockResolvedValue('exec-token');
-			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
 			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
 			const sel = new ActiveWikiImpl('a', reg);
 			const provider = new MwnProviderImpl(reg, sel, () => undefined);
@@ -208,7 +293,7 @@ describe('MwnProviderImpl', () => {
 			await provider.get('a');
 
 			expect(mockRunExecSecret).toHaveBeenCalledOnce();
-			expect(mockInit).toHaveBeenCalledWith(
+			expect(mockConstructor).toHaveBeenCalledWith(
 				expect.objectContaining({ OAuth2AccessToken: 'exec-token' }),
 			);
 		});
@@ -236,7 +321,6 @@ describe('MwnProviderImpl', () => {
 		});
 
 		it('does not resolve config secrets when a runtime token is present', async () => {
-			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
 			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
 			const sel = new ActiveWikiImpl('a', reg);
 			const provider = new MwnProviderImpl(reg, sel, () => 'runtime-token');
@@ -250,7 +334,6 @@ describe('MwnProviderImpl', () => {
 			mockRunExecSecret
 				.mockRejectedValueOnce(new CredentialResolutionError('transient'))
 				.mockResolvedValueOnce('exec-token');
-			mockInit.mockResolvedValue({ getSiteInfo: mockGetSiteInfo });
 			const reg = new WikiRegistryImpl({ a: execWiki('a') }, true);
 			const sel = new ActiveWikiImpl('a', reg);
 			const provider = new MwnProviderImpl(reg, sel, () => undefined);

--- a/tests/wikis/siteInfo.test.ts
+++ b/tests/wikis/siteInfo.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { resolveSiteInfo } from '../../src/wikis/siteInfo.ts';
 import { createMockMwn } from '../helpers/mock-mwn.ts';
 import { fakeContext } from '../helpers/fakeContext.ts';
+import { withRequestFields, getRequestDeadline } from '../../src/runtime/requestContext.ts';
+import { callDeadline } from '../../src/runtime/callDeadline.ts';
 import type { SiteInfo } from '../../src/wikis/siteInfoCache.ts';
 
 // A fresh Map-backed cache (the fakeContext default is seeded; tests of the
@@ -20,6 +22,31 @@ function emptyCache() {
 }
 
 describe('resolveSiteInfo', () => {
+	it('gives the shared fetch its own budget, not the starting caller remainder', async () => {
+		const spentBudget = callDeadline(1, 'calling');
+		let budgetDuringFetch: unknown = 'never ran';
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: { general: { server: 'https://public.example', articlepath: '/wiki/$1' } },
+			}),
+		});
+		const ctx = fakeContext({
+			// Where the real createContext reads the budget it applies.
+			mwn: async () => {
+				budgetDuringFetch = getRequestDeadline();
+				return mock as never;
+			},
+			siteInfoCache: emptyCache() as never,
+		});
+
+		await withRequestFields({ deadline: spentBudget }, () => resolveSiteInfo(ctx, 'test-wiki'));
+
+		// Handed to every concurrent caller, so a joiner with a full budget must
+		// not be dropped onto the fallback by whatever was left of the starter's.
+		expect(budgetDuringFetch).toBeDefined();
+		expect(budgetDuringFetch).not.toBe(spentBudget);
+	});
+
 	it('fetches and caches server + articlepath + license from siteinfo', async () => {
 		const mock = createMockMwn({
 			request: vi.fn().mockResolvedValue({


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/570

A network fault could leave a call retrying at the wiki for 255 seconds,
and considerably longer on paths the report does not reach. Every wiki
call now runs under a time budget.

## Corrections to the report

- 255s is the network branch alone. mwn funds every retry branch from one
  shared counter, so they interleave rather than compound -- but badtoken
  and assertuserfailed recovery issue nested requests that each get a
  fresh budget. The relogin nest reaches roughly 42 minutes, and this
  server arms it deliberately by setting `assert=user`.
- Reaching a wiki for the first time was worse than any tool call.
  `Mwn.init` signs in with three sequential round-trips that each fund a
  full ladder, and the provider caches the promise, so one stalled
  connection blocked every concurrent caller for that wiki.
- The suggested per-wiki `timeout` cannot work: `timeout` is not a member
  of `MwnOptions`. Only `maxRetries` and `retryPause` travel that route,
  and they are the wrong knob -- the same counter funds CSRF-token
  recovery, maxlag, readonly and relogin. Both are left at mwn's defaults.
- maxlag, flagged in the report as unverified, needs no work. MediaWiki
  answers with `Retry-After: max((int)$maxlag, 5)` and mwn always sends
  `maxlag=5`, so it adds at most 15s and draws from the shared counter.

## The change

One budget per tool call, armed by the dispatcher, held in the request
scope and applied at `rawRequest` -- the single seam every mwn call
funnels through. Sharing one budget across the call is load-bearing:
eleven tools acquire the wiki twice, once for the work and once to build
a page URL, so a budget armed per acquisition multiplies. It is armed
around the handler alone, so an interactive OAuth login -- minutes of
human reaction time -- cannot spend it before the tool runs.

`create()` no longer calls `Mwn.init`. It constructs, then drives sign-in
through a view bounded at 30s. That budget and the shared siteinfo fetch
both run detached from the caller that triggered them, on their own clock:
those promises are handed to every concurrent caller, so neither one
caller's cancellation nor whatever is left of its budget may decide the
outcome for the rest.

The budget is a separate request-scope field from the client's
cancellation signal, so cancellation stays distinguishable from expiry: a
timeout is reported as `upstream_failure` with code `request-timeout`
rather than as a cancelled call. The error carries how far the call got,
fixed where the budget is armed, so a write that timed out while still
connecting is not told its change may have landed when nothing was sent.

`massQuery` collects per-batch errors into its result array instead of
rejecting. Left alone, a stopped batch reached `get-pages` as an entry
with no `query` and was skipped, reporting a timeout as every requested
page being missing; `mwn.read` dereferenced it and failed with a
TypeError naming neither the wiki nor the budget. The bounded view now
rethrows when its own signal fired, which covers cancellation too, and
leaves ordinary per-batch failures in place as mwn intends.

## For the reviewer

- 150s and 30s. The longest legitimate call is a cold-wiki
  `upload-file-from-url`: 30s connecting, 30s fetching the source, a 60s
  upload POST. A wiki whose credential comes from an `{exec:…}` command
  can spend another 30s ahead of all of it, which is the case with the
  least headroom. 30s to connect is also shorter than mwn's own 60s
  per-request cap, so a sign-in that legitimately takes 35-60s now fails.
- `src/transport/ready.ts` is the one severable piece. The probe already
  bounded the caller's wait but not the request, so an abandoned probe
  kept retrying and a readiness endpoint polled every few seconds
  accumulated them. Say if you would rather split it.
- No config knob, which is the half of the report this refuses. Every
  operator knob here is a server-wide env var and every per-wiki field is
  identity or policy; the only timing env var this project had was
  removed in 0.15.0, and #387 declined one for a timeout on the reasoning
  that adding one later is backward compatible.

## Known limits

The reporter's connection-reset case is untouched: that ladder completes
in about 15s and never reaches any deadline. The bound can overshoot by
one unabortable mwn sleep, since a `sleep(retryPause)` between attempts
is a bare timer no signal interrupts, and on the maxlag branch that sleep
is whatever the responder puts in `Retry-After`. `add-wiki` is not
covered: it reaches an unconfigured host through `fetchCore`, which
applies no default timeout. mwn's own `login()` swallows a failing
post-login siteinfo fetch, which predates this change.

## Verified

Same host, same script, against a black-holed address (10.255.255.1)
using the built `dist`: first connection to a stalled wiki took 255.0s
and 255.1s on master across two runs, and 30.0s on this branch.

Full suite 2175 passing, typecheck, lint and format checks clean. Each
guard is mutation-tested: reverting the provider decomposition, the
massQuery rethrow and its receiver binding, the deadline-vs-cancellation
identity check, the sign-in branch selection, the phase gate, the ready
probe budget and the shared-work budget each turn a specific test red.


> <sub>AI-authored — Claude Code, `Opus 5 (1M context) (xhigh)`; one-line ask from @alistair3149 to look into the issue, then two directions (review it, trim the comments); diff not yet human-reviewed; TDD throughout with every guard mutation-tested, full suite + typecheck + lint + format clean locally and in CI, and the before/after timing measured against a black-holed address using the built `dist`.</sub>

<details><summary>Production notes</summary>

Investigated, then reviewed end to end, by parallel subagents on the same model; every load-bearing claim above was checked directly against `node_modules/mwn` or by running code. That review found two regressions in the first draft of this branch and one defect worse than the bug being fixed: `massQuery` returns per-batch errors as data, so a timed-out `get-pages` had been reporting "these pages do not exist".

</details>
