### PR TITLE
Bound wiki discovery so add-wiki cannot hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Fixed
 
-- A wiki that stops answering no longer hangs a tool call for minutes on end. A call that reaches a wiki now gives up within a fixed time and returns an error naming the limit it hit, instead of retrying out of sight. This also covers the first call to a wiki, where connecting and signing in were previously unbounded and slowest of all. A timed-out write reports that the change may or may not have been applied, since the server cannot tell. `add-wiki` is not yet covered: it reaches an unconfigured host over its own path.
+- A wiki that stops answering no longer hangs a tool call for minutes. This covers the first call to a wiki, where connecting and signing in were previously unbounded. A timed-out write reports that the change may or may not have been applied, since the server cannot tell.
+- `add-wiki` no longer hangs on a URL whose host accepts the connection and then goes quiet. It now gives up after 30 seconds and reports a timeout, instead of suggesting the URL may be wrong.
 
 ## [0.17.0] - 2026-08-13
 

--- a/src/tools/add-wiki.ts
+++ b/src/tools/add-wiki.ts
@@ -3,6 +3,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { Tool } from '../runtime/tool.ts';
 import type { ManagementContext } from '../runtime/context.ts';
 import { discoverWiki } from '../wikis/wikiDiscovery.ts';
+import { callDeadline, WIKI_CONNECT_TIMEOUT_MS } from '../runtime/callDeadline.ts';
 import { SsrfValidationError } from '../transport/ssrfGuard.ts';
 import { DuplicateWikiKeyError } from '../wikis/wikiRegistry.ts';
 
@@ -32,7 +33,7 @@ export const addWiki: Tool<typeof inputSchema, ManagementContext> = {
 	async handle({ wikiUrl }, ctx: ManagementContext): Promise<CallToolResult> {
 		let wikiInfo;
 		try {
-			wikiInfo = await discoverWiki(wikiUrl);
+			wikiInfo = await discoverWiki(wikiUrl, callDeadline(WIKI_CONNECT_TIMEOUT_MS, 'connecting'));
 		} catch (error) {
 			if (error instanceof SsrfValidationError) {
 				return ctx.format.invalidInput(`Failed to add wiki: ${error.message}`);

--- a/src/transport/httpFetch.ts
+++ b/src/transport/httpFetch.ts
@@ -255,9 +255,12 @@ function destroyBody(response: Response): void {
 	}
 }
 
-export async function fetchPageHtml(url: string): Promise<string | null> {
+export async function fetchPageHtml(
+	url: string,
+	options?: { signal?: AbortSignal },
+): Promise<string | null> {
 	try {
-		const response = await fetchCore(url);
+		const response = await fetchCore(url, { signal: options?.signal });
 		return await response.text();
 	} catch {
 		return null;

--- a/src/wikis/wikiDiscovery.ts
+++ b/src/wikis/wikiDiscovery.ts
@@ -1,10 +1,17 @@
 import { errorMessage } from '../errors/isErrnoException.ts';
+import { WikiTimeoutError } from '../errors/wikiTimeoutError.ts';
+import type { CallDeadline } from '../runtime/callDeadline.ts';
 import { makeApiRequest, fetchPageHtml } from '../transport/httpFetch.ts';
 import { assertPublicDestination } from '../transport/ssrfGuard.ts';
 import { logger } from '../runtime/logger.ts';
 import { normalizeServer } from './normalizeServer.ts';
 
 const COMMON_SCRIPT_PATHS = ['/w', ''];
+
+/** Whether a rejection is the budget expiring rather than the host answering. */
+function isAborted(error: unknown): boolean {
+	return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+}
 
 interface MediaWikiActionApiSiteInfoGeneral {
 	sitename: string;
@@ -33,6 +40,7 @@ export interface WikiInfo {
 async function fetchWikiInfoFromApi(
 	wikiServer: string,
 	scriptPath: string,
+	deadline: CallDeadline,
 ): Promise<WikiInfo | null> {
 	const baseUrl = `${wikiServer}${scriptPath}/api.php`;
 	const params = {
@@ -45,8 +53,16 @@ async function fetchWikiInfoFromApi(
 
 	let data: MediaWikiActionApiResponse | null = null;
 	try {
-		data = await makeApiRequest<MediaWikiActionApiResponse>(baseUrl, params);
+		data = await makeApiRequest<MediaWikiActionApiResponse>(baseUrl, params, {
+			signal: deadline.signal,
+		});
 	} catch (error) {
+		// A path that is simply wrong answers 404, and discovery moves on to the
+		// next candidate. Running out of time is not a wrong path, and reporting
+		// it as one sends the caller after a URL typo that is not there.
+		if (isAborted(error)) {
+			throw new WikiTimeoutError(deadline.timeoutMs, deadline.phase);
+		}
 		logger.error('Error fetching wiki info', {
 			baseUrl,
 			error: errorMessage(error),
@@ -73,9 +89,12 @@ async function fetchWikiInfoFromApi(
 	};
 }
 
-async function fetchUsingCommonScriptPaths(wikiServer: string): Promise<WikiInfo | null> {
+async function fetchUsingCommonScriptPaths(
+	wikiServer: string,
+	deadline: CallDeadline,
+): Promise<WikiInfo | null> {
 	for (const candidatePath of COMMON_SCRIPT_PATHS) {
-		const apiResult = await fetchWikiInfoFromApi(wikiServer, candidatePath);
+		const apiResult = await fetchWikiInfoFromApi(wikiServer, candidatePath, deadline);
 		if (apiResult) {
 			return apiResult;
 		}
@@ -123,14 +142,21 @@ function extractScriptPathsFromHtml(htmlContent: string | null, wikiServer: stri
 async function fetchUsingScriptPathsFromHtml(
 	wikiServer: string,
 	originalWikiUrl: string,
+	deadline: CallDeadline,
 ): Promise<WikiInfo | null> {
-	const htmlContent = await fetchPageHtml(originalWikiUrl);
+	const htmlContent = await fetchPageHtml(originalWikiUrl, { signal: deadline.signal });
+	// `fetchPageHtml` reports every failure as no content, an abort included, so
+	// the budget is checked here rather than left to resurface on the next
+	// request — which it would not do if that request failed for its own reason.
+	if (deadline.signal.aborted) {
+		throw new WikiTimeoutError(deadline.timeoutMs, deadline.phase);
+	}
 	const htmlScriptPathCandidates = extractScriptPathsFromHtml(htmlContent, wikiServer);
 	const pathsToTry =
 		htmlScriptPathCandidates.length > 0 ? htmlScriptPathCandidates : COMMON_SCRIPT_PATHS;
 
 	for (const candidatePath of pathsToTry) {
-		const apiResult = await fetchWikiInfoFromApi(wikiServer, candidatePath);
+		const apiResult = await fetchWikiInfoFromApi(wikiServer, candidatePath, deadline);
 		if (apiResult) {
 			return apiResult;
 		}
@@ -139,10 +165,14 @@ async function fetchUsingScriptPathsFromHtml(
 	return null;
 }
 
-async function getWikiInfo(wikiServer: string, originalWikiUrl: string): Promise<WikiInfo | null> {
+async function getWikiInfo(
+	wikiServer: string,
+	originalWikiUrl: string,
+	deadline: CallDeadline,
+): Promise<WikiInfo | null> {
 	return (
-		(await fetchUsingCommonScriptPaths(wikiServer)) ??
-		(await fetchUsingScriptPathsFromHtml(wikiServer, originalWikiUrl))
+		(await fetchUsingCommonScriptPaths(wikiServer, deadline)) ??
+		(await fetchUsingScriptPathsFromHtml(wikiServer, originalWikiUrl, deadline))
 	);
 }
 
@@ -151,10 +181,21 @@ function parseWikiUrl(wikiUrl: string): string {
 	return `${url.protocol}//${url.host}`;
 }
 
-export async function discoverWiki(wikiUrl: string): Promise<WikiInfo | null> {
+/**
+ * `deadline` covers all of discovery rather than one request, which would
+ * multiply across the five it can make. `fetchCore` applies no timeout of its
+ * own and the URL comes from the caller, so without one a host that accepts the
+ * connection and then goes quiet holds the call open until the OS gives up. The
+ * DNS lookups inside `assertPublicDestination` take no signal, so they run down
+ * the budget without being cancelled by it.
+ */
+export async function discoverWiki(
+	wikiUrl: string,
+	deadline: CallDeadline,
+): Promise<WikiInfo | null> {
 	await assertPublicDestination(wikiUrl);
 	const wikiServer = parseWikiUrl(wikiUrl);
-	const info = await getWikiInfo(wikiServer, wikiUrl);
+	const info = await getWikiInfo(wikiServer, wikiUrl, deadline);
 	if (info !== null) {
 		await assertPublicDestination(info.server);
 	}

--- a/tests/tools/add-wiki.test.ts
+++ b/tests/tools/add-wiki.test.ts
@@ -6,6 +6,8 @@ vi.mock('../../src/wikis/wikiDiscovery.ts', () => ({
 
 import type { RegisteredTool } from '@modelcontextprotocol/server';
 import { discoverWiki } from '../../src/wikis/wikiDiscovery.ts';
+import { WikiTimeoutError } from '../../src/errors/wikiTimeoutError.ts';
+import { WIKI_CONNECT_TIMEOUT_MS } from '../../src/runtime/callDeadline.ts';
 import { SsrfValidationError } from '../../src/transport/ssrfGuard.ts';
 import { DuplicateWikiKeyError, WikiRegistryImpl } from '../../src/wikis/wikiRegistry.ts';
 import type { WikiConfig } from '../../src/config/loadConfig.ts';
@@ -208,6 +210,39 @@ describe('add-wiki', () => {
 
 		const envelope = assertStructuredError(result, 'upstream_failure');
 		expect(envelope.message).toMatch(/Failed to add wiki: Connection refused/);
+		expect(reconcile).not.toHaveBeenCalled();
+	});
+
+	it('gives discovery the budget for reaching a wiki the first time', async () => {
+		vi.mocked(discoverWiki).mockResolvedValue(null);
+
+		await dispatch(
+			addWiki,
+			fakeManagementContext({ reconcile: vi.fn() }),
+		)({
+			wikiUrl: 'https://example.org/',
+		});
+
+		// The phase is what keeps the dispatcher's "your change may have been
+		// applied" caveat off this tool, which declares readOnlyHint: false.
+		expect(vi.mocked(discoverWiki).mock.calls[0]?.[1]).toMatchObject({
+			timeoutMs: WIKI_CONNECT_TIMEOUT_MS,
+			phase: 'connecting',
+		});
+	});
+
+	it('names a discovery timeout rather than blaming the URL', async () => {
+		vi.mocked(discoverWiki).mockRejectedValue(new WikiTimeoutError(15_000, 'connecting'));
+
+		const reconcile = vi.fn();
+		const ctx = fakeManagementContext({ reconcile });
+		const result = await dispatch(addWiki, ctx)({ wikiUrl: 'https://example.org/' });
+
+		const envelope = assertStructuredError(result, 'upstream_failure', 'request-timeout');
+		expect(envelope.message).toMatch(/Gave up trying to reach the wiki/);
+		// This tool declares readOnlyHint: false, so the write caveat is gated on
+		// the phase alone — and discovery never reaches a wiki, let alone writes.
+		expect(envelope.message).not.toMatch(/may or may not have been applied/);
 		expect(reconcile).not.toHaveBeenCalled();
 	});
 

--- a/tests/wikis/wikiDiscovery.test.ts
+++ b/tests/wikis/wikiDiscovery.test.ts
@@ -10,13 +10,18 @@ vi.mock('../../src/transport/ssrfGuard.ts', () => ({
 	assertPublicDestination: vi.fn(),
 }));
 
-import { makeApiRequest } from '../../src/transport/httpFetch.ts';
+import { makeApiRequest, fetchPageHtml } from '../../src/transport/httpFetch.ts';
 import { assertPublicDestination } from '../../src/transport/ssrfGuard.ts';
 import { discoverWiki } from '../../src/wikis/wikiDiscovery.ts';
+import { WikiTimeoutError } from '../../src/errors/wikiTimeoutError.ts';
+import { callDeadline, WIKI_CONNECT_TIMEOUT_MS } from '../../src/runtime/callDeadline.ts';
+import { rejectionOf } from '../helpers/rejectionOf.ts';
 
 // assertPublicDestination resolves the addresses it validated, so a stubbed
 // approval has to hand back a resolved public address, not nothing.
 const publicAddresses: LookupAddress[] = [{ address: '93.184.216.34', family: 4 }];
+
+const budget = () => callDeadline(WIKI_CONNECT_TIMEOUT_MS, 'connecting');
 
 describe('discoverWiki', () => {
 	beforeEach(() => {
@@ -31,7 +36,7 @@ describe('discoverWiki', () => {
 			),
 		);
 
-		await expect(discoverWiki('http://10.0.0.1/')).rejects.toThrow(/non-public/);
+		await expect(discoverWiki('http://10.0.0.1/', budget())).rejects.toThrow(/non-public/);
 		expect(makeApiRequest).not.toHaveBeenCalled();
 	});
 
@@ -55,7 +60,7 @@ describe('discoverWiki', () => {
 				),
 			);
 
-		await expect(discoverWiki('https://public.example/')).rejects.toThrow(/10\.0\.0\.42/);
+		await expect(discoverWiki('https://public.example/', budget())).rejects.toThrow(/10\.0\.0\.42/);
 	});
 
 	it('returns the WikiInfo when both the input URL and the discovered server are public', async () => {
@@ -71,7 +76,7 @@ describe('discoverWiki', () => {
 			},
 		});
 
-		const info = await discoverWiki('https://public.example/wiki/Main_Page');
+		const info = await discoverWiki('https://public.example/wiki/Main_Page', budget());
 
 		expect(info).toEqual({
 			sitename: 'Public Wiki',
@@ -95,7 +100,7 @@ describe('discoverWiki', () => {
 			},
 		});
 
-		const info = await discoverWiki('https://www.mediawiki.org/wiki/Main_Page');
+		const info = await discoverWiki('https://www.mediawiki.org/wiki/Main_Page', budget());
 
 		expect(info).toEqual({
 			sitename: 'MediaWiki',
@@ -104,5 +109,115 @@ describe('discoverWiki', () => {
 			server: 'https://www.mediawiki.org',
 			servername: 'www.mediawiki.org',
 		});
+	});
+
+	it('bounds every request it makes, on one budget for the whole discovery', async () => {
+		vi.mocked(makeApiRequest).mockResolvedValue({ query: {} });
+		vi.mocked(fetchPageHtml).mockResolvedValue(null);
+
+		await discoverWiki('https://public.example/wiki/Main_Page', budget());
+
+		// `fetchCore` applies no timeout of its own, so a host that accepts the
+		// connection and then goes quiet held add-wiki open until the OS gave up.
+		const signals = vi
+			.mocked(makeApiRequest)
+			.mock.calls.map((call) => call[2]?.signal)
+			.concat(vi.mocked(fetchPageHtml).mock.calls.map((call) => call[1]?.signal));
+		expect(signals.length).toBeGreaterThan(1);
+		expect(signals.every((signal) => signal !== undefined)).toBe(true);
+		// One budget, not one per attempt: discovery tries up to five paths in
+		// sequence, so a fresh budget each time would multiply the bound.
+		expect(new Set(signals).size).toBe(1);
+	});
+
+	it('reports running out of time as a timeout, not as a URL that is not a wiki', async () => {
+		// What an expired budget actually produces: `AbortSignal.timeout`'s reason
+		// is a TimeoutError, and node-fetch raises AbortError. Driven directly so
+		// the test does not wait out the real budget.
+		vi.mocked(makeApiRequest).mockRejectedValue(
+			new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
+		);
+		vi.mocked(fetchPageHtml).mockResolvedValue(null);
+
+		const err = await discoverWiki('https://public.example/wiki/Main_Page', budget()).then(
+			() => undefined,
+			(e: unknown) => e,
+		);
+
+		// Returning null here would reach the caller as "ensure the URL is correct
+		// and the wiki is accessible", sending them after a typo that is not there.
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+		expect((err as WikiTimeoutError).phase).toBe('connecting');
+	});
+
+	it('still reports a host that answers but is not a wiki as not a wiki', async () => {
+		vi.mocked(makeApiRequest).mockResolvedValue({ query: {} });
+		vi.mocked(fetchPageHtml).mockResolvedValue(null);
+
+		await expect(
+			discoverWiki('https://public.example/wiki/Main_Page', budget()),
+		).resolves.toBeNull();
+	});
+	it('falls through a wrong script path to the next candidate', async () => {
+		vi.mocked(makeApiRequest)
+			.mockRejectedValueOnce(new Error('HTTP error! status: 404 for URL: /w/api.php'))
+			.mockResolvedValueOnce({
+				query: {
+					general: {
+						sitename: 'Public Wiki',
+						scriptpath: '',
+						articlepath: '/wiki/$1',
+						server: 'https://public.example',
+						servername: 'public.example',
+					},
+				},
+			});
+
+		// Only running out of time ends discovery. Treating every failure as one
+		// would turn each 404 — the normal answer from a path this wiki does not
+		// use — into a bogus timeout.
+		await expect(
+			discoverWiki('https://public.example/wiki/Main_Page', budget()),
+		).resolves.toMatchObject({ servername: 'public.example', scriptpath: '' });
+	});
+
+	it('gives up on a host that accepts the connection and then goes quiet', async () => {
+		vi.mocked(makeApiRequest).mockImplementation(
+			async (_url, _params, options) =>
+				new Promise((_resolve, reject) => {
+					options?.signal?.addEventListener('abort', () => {
+						reject(options.signal?.reason);
+					});
+				}),
+		);
+		vi.mocked(fetchPageHtml).mockResolvedValue(null);
+
+		// The budget is the caller's, so this observes it actually firing rather
+		// than only that a signal was threaded through. `AbortSignal.timeout` is
+		// not advanceable by vitest's fake clock, so the budget is small and real.
+		const err = await rejectionOf(
+			discoverWiki('https://public.example/wiki/Main_Page', callDeadline(20, 'connecting')),
+		);
+
+		expect(err).toBeInstanceOf(WikiTimeoutError);
+	});
+	it('reports a budget spent on the page fetch, even when the retry fails for its own reason', async () => {
+		// `fetchPageHtml` reports every failure as no content, an abort included.
+		vi.mocked(fetchPageHtml).mockImplementation(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 40));
+			return null;
+		});
+		// The retry that follows fails for a reason of its own — a DNS lookup that
+		// stops resolving, say — so it does not re-raise the abort on discovery's
+		// behalf, and without the check the timeout is simply lost.
+		vi.mocked(makeApiRequest).mockRejectedValue(
+			Object.assign(new Error('getaddrinfo ENOTFOUND public.example'), { code: 'ENOTFOUND' }),
+		);
+
+		const err = await rejectionOf(
+			discoverWiki('https://public.example/wiki/Main_Page', callDeadline(20, 'connecting')),
+		);
+
+		expect(err).toBeInstanceOf(WikiTimeoutError);
 	});
 });


### PR DESCRIPTION
`add-wiki` takes an arbitrary caller-supplied URL and reaches it through
`fetchCore`, which applies no timeout of its own. Against a host that
completes the TCP handshake and then goes quiet, discovery ran until the
operating system gave up -- the last outbound path in the server with no
bound at all, and the one an untrusted URL reaches.

`discoverWiki` now takes a `CallDeadline` covering all of it. One budget
rather than one per request: it makes up to five in sequence -- two common
script paths, the page itself, then up to two paths parsed out of that
HTML -- so a budget each would multiply. The caller supplies it, so the
budget is armed before the first DNS lookup rather than after, and
`add-wiki` gives it the one for reaching a wiki the first time.

Running out of time is now reported as running out of time. Every fetch
failure previously collapsed to `null`, which `add-wiki` renders as "ensure
the URL is correct and the wiki is accessible" -- advice that sends the
caller after a typo that is not there. A wrong script path still answers
404 and discovery still moves on to the next candidate; only an abort ends
it, as a timeout carrying the `request-timeout` code. It is raised in the
connecting phase, so the write caveat this tool would otherwise attract
from its `readOnlyHint: false` is correctly withheld -- discovery never
reaches a wiki, let alone writes to one.

`fetchPageHtml` reports every failure as no content, an abort included, so
the budget is checked on return rather than left to resurface on the next
request -- which it would not do if that request then failed for its own
reason, such as a DNS lookup that stops resolving. It also gains the
`signal` option the rest of that module already takes.

## Verified

Against a black-holed address (10.255.255.1, permitted for the test via
MCP_TRUSTED_HOSTS) using the built `dist`: discovery now fails at 30.0s
with "Gave up trying to reach the wiki after 30 seconds". The same script
on master was still running when I stopped it at roughly sixteen minutes.

Full suite 2183 passing, typecheck, lint and format checks clean. Each
guard is mutation-tested: treating every failure as a timeout, a budget
that never fires, the wrong phase, and dropping the check after the page
fetch each turn a specific test red.

It also tightens the `[Unreleased]` entry that came in with #585, since both entries live in the same block.

## Considered, omitted

Defaulting `fetchCore`'s signal to the ambient request deadline. A reviewer confirmed deferring is right: there is no remaining unbounded caller, so it would guard only against callers that do not exist yet, and a per-request default could not have produced what this needed — one budget spanning five sequential requests.

Making `fetchPageHtml`'s signal required rather than optional. It has one caller and omitting it is the bug being fixed, but optional matches `makeApiRequest` and `postForm` in the same module.

**Follow-up worth filing, pre-existing:** when the page HTML yields no script-path candidates, discovery falls back to `COMMON_SCRIPT_PATHS` and re-issues the two requests it has already made and already seen fail. Two of the five the budget must cover are duplicates of known failures, which now costs a shared budget rather than only latency.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context) (xhigh)`; follow-up @alistair3149 asked for after #585, then a review pass; diff not yet human-reviewed; TDD with every guard mutation-tested, reviewed by a fresh-context subagent whose four findings are all addressed, full suite + typecheck + lint + format clean locally and in CI, and the before/after measured against a black-holed address using the built `dist`.</sub>
