### PR TITLE
Tolerate the conformance checks mcpjam 5 cannot run here

### DIFF
--- a/scripts/mcp-checks.cjs
+++ b/scripts/mcp-checks.cjs
@@ -20,17 +20,24 @@ const PORT = Number(process.env.PORT) || 3117;
 const SERVER_URL = `http://127.0.0.1:${PORT}/mcp`;
 const STARTUP_TIMEOUT_MS = 15000;
 
-// Neither check can run against this server, and neither is a gap to close.
-// modern-undeclared-capability-error needs a tool that asks the caller for
-// input, so that it can prove the server rejects a client which never
+// None of these checks can run against this server, and none is a gap to
+// close. modern-undeclared-capability-error needs a tool that asks the caller
+// for input, so that it can prove the server rejects a client which never
 // declared that capability; this server has no such tool, and the check
 // bails before it contacts the server at all. modern-subscription-graceful-close
 // waits for the completion result a server sends when it tears a subscription
 // down, which this server does send on shutdown, but the check only aborts
 // its own end of the stream and so can never observe one.
+// modern-tool-output-schema-conformant validates structuredContent against a
+// tool's declared outputSchema, and no tool declares one.
+// modern-logs-require-log-level needs a tool known to emit log notifications,
+// so that silence proves the opt-in gate; this server sends none and does not
+// advertise the logging capability.
 const TOLERATED_UNRUN_CHECKS = [
 	'modern-undeclared-capability-error',
 	'modern-subscription-graceful-close',
+	'modern-tool-output-schema-conformant',
+	'modern-logs-require-log-level',
 ];
 
 // A run that selected next to nothing establishes nothing, and the suite
@@ -235,8 +242,12 @@ function judgeConformanceReport(report) {
 		}
 	}
 
+	// A check the profile itself leaves unscored cannot withhold the verdict.
+	const unscored = Array.isArray(report?.profile?.pendingCheckIds)
+		? report.profile.pendingCheckIds
+		: [];
 	for (const id of unrunCheckIds(report)) {
-		if (!TOLERATED_UNRUN_CHECKS.includes(id)) {
+		if (!TOLERATED_UNRUN_CHECKS.includes(id) && !unscored.includes(id)) {
 			problems.push(`${id} could not run, so conformance is unproven`);
 		}
 	}

--- a/tests/scripts/mcp-checks.test.ts
+++ b/tests/scripts/mcp-checks.test.ts
@@ -12,6 +12,7 @@ type ConformanceReport = {
 	passed?: boolean;
 	outcome?: string;
 	checks?: unknown;
+	profile?: { pendingCheckIds: string[] };
 };
 
 const { judgeConformanceReport } = createRequire(import.meta.url)(
@@ -73,6 +74,44 @@ describe('judgeConformanceReport', () => {
 		});
 
 		expect(judgeConformanceReport(report)).toEqual([]);
+	});
+
+	it('accepts the checks a 5.x suite cannot run without probes this server cannot offer', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'incomplete',
+			checks: [
+				...passingChecks(34),
+				unrunCheck('modern-tool-output-schema-conformant'),
+				unrunCheck('modern-logs-require-log-level'),
+			],
+		});
+
+		expect(judgeConformanceReport(report)).toEqual([]);
+	});
+
+	it('accepts an unrunnable check the profile leaves unscored', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'incomplete',
+			checks: [...passingChecks(35), unrunCheck('modern-some-future-obligation')],
+			profile: { pendingCheckIds: ['modern-some-future-obligation'] },
+		});
+
+		expect(judgeConformanceReport(report)).toEqual([]);
+	});
+
+	it('rejects an unrunnable check the profile scores', () => {
+		const report = modernReport({
+			passed: false,
+			outcome: 'incomplete',
+			checks: [...passingChecks(35), unrunCheck('modern-some-future-obligation')],
+			profile: { pendingCheckIds: ['modern-some-other-check'] },
+		});
+
+		expect(judgeConformanceReport(report)).toEqual([
+			expect.stringContaining('modern-some-future-obligation'),
+		]);
 	});
 
 	it('rejects an unrunnable check that is not tolerated', () => {


### PR DESCRIPTION
Bumping `@mcpjam/cli` to 5.x brings a conformance checker that reports two checks as `could-not-run` where 3.x passed them vacuously: `modern-tool-output-schema-conformant` needs `fixtures.toolCalls` and no tool declares an `outputSchema`; `modern-logs-require-log-level` needs a `logProbe` and the server sends no log notifications. `check:mcp` fails a run on any unrunnable check outside its allowlist, so the bump goes red with zero failed checks.

Adds both to `TOLERATED_UNRUN_CHECKS`, and tolerates any unrunnable check the report's own profile lists under `pendingCheckIds`, since the profile does not score those either. Unblocks https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/597.

**To decide:** whether the `pendingCheckIds` rule is wanted. Without it, the next checker release that adds an unscored, unrunnable check needs another allowlist entry; with it, an unscored check can never withhold the verdict, which is what the profile already says of it.

**Verified:** tests for `judgeConformanceReport` written first (two failing, then passing; twelve in the file). The 5.6.0 CLI run locally against the built server produced a report with 0 failed and 4 unrunnable checks; the judge on master rejects it with exactly the two messages CI shows, this one accepts it. `npm test` (2186), lint, typecheck and format check clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QZefTKJor8VJKSJ9A4Fgi
