### PR TITLE
Document the two response channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 
 ### Tools
 
-Every tool that operates on a wiki accepts an optional `wiki` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI. Omit it to use the configured default wiki (see [Configuration](#configuration)). Each tool response reports the wiki the call ran against. Results carry a prose rendering in `content` and the same payload as JSON in `structuredContent`; see [response channels](docs/tool-conventions.md#response-channels).
+Every tool that operates on a wiki accepts an optional `wiki` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI. Omit it to use the configured default wiki (see [Configuration](#configuration)). Each tool response reports the wiki the call ran against. Each successful response carries its payload as prose in `content` and as JSON in `structuredContent`; see [response channels](docs/tool-conventions.md#response-channels).
 
 #### Page reads
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An MCP (Model Context Protocol) server that enables Large Language Model (LLM) c
 
 ### Tools
 
-Every tool that operates on a wiki accepts an optional `wiki` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI. Omit it to use the configured default wiki (see [Configuration](#configuration)). Each tool response reports the wiki the call ran against.
+Every tool that operates on a wiki accepts an optional `wiki` argument naming the wiki to act on (the wiki-management and OAuth tools do not) — pass a wiki key (e.g. `en.wikipedia.org`) or the full `mcp://wikis/{wikiKey}` URI. Omit it to use the configured default wiki (see [Configuration](#configuration)). Each tool response reports the wiki the call ran against. Results carry a prose rendering in `content` and the same payload as JSON in `structuredContent`; see [response channels](docs/tool-conventions.md#response-channels).
 
 #### Page reads
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -151,7 +151,7 @@ There is no MCP-spec-level budget for tool output. Cap sizes are chosen to stay 
 
 #### Response channels
 
-A successful result carries the payload twice: a prose rendering in `content[0]` and the same payload as JSON in `structuredContent`. Which one a model reads depends on the client: one that understands `structuredContent` shows the JSON and ignores the prose; one that reads only `content` shows the prose. No tool declares an `outputSchema`, and none should without a client that needs the contract: the declaration is served in `tools/list` to every client on every session.
+A successful result carries its payload twice: as prose in `content[0]` and as JSON in `structuredContent`. Which channel the model sees depends on the client, and it may be only one of them, so both carry the complete payload. No tool declares an `outputSchema`, and none should until a client needs the contract: the declaration reaches every client through `tools/list`, whether or not it uses it.
 
 #### Default-value omission in list responses
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -149,6 +149,10 @@ This convention doesn't apply to tools that reject oversize input (e.g. `get-pag
 
 There is no MCP-spec-level budget for tool output. Cap sizes are chosen to stay well under Anthropic's 25,000-token Claude Code default ([Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)) and revisited when [MCP discussion #2211](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2211) ratifies a standard.
 
+#### Response channels
+
+A successful result carries the payload twice: a prose rendering in `content[0]` and the same payload as JSON in `structuredContent`. Which one a model reads depends on the client: one that understands `structuredContent` shows the JSON and ignores the prose; one that reads only `content` shows the prose. No tool declares an `outputSchema`, and none should without a client that needs the contract: the declaration is served in `tools/list` to every client on every session.
+
 #### Default-value omission in list responses
 
 List tools omit fields whose value is the type default rather than serialising them: a boolean flag is present only when `true` (absent means `false`), empty strings and empty arrays are dropped, and a value equal to a documented common default is omitted (e.g. a category member's `type` is absent for an ordinary page). Every non-default value is preserved; field names are unchanged. State the convention in each affected tool's description so callers know absence means the default.


### PR DESCRIPTION
A successful result carries its payload as prose in `content[0]` and as JSON in `structuredContent`; which one a model reads depends on the client. That shape was recorded only in a code comment and a test helper, and the commit that dropped `outputSchema` (e985cf0) still reads as the last word. This states it in the tool conventions, records the decision not to declare `outputSchema`, and links it from the README.

**To decide:** whether "none should until a client needs the contract" is the rule you want written down. The stated reason is the `tools/list` cost; a declaration also makes the payload a validated contract, so drift becomes a client-side failure.

No behaviour changes, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QZefTKJor8VJKSJ9A4Fgi
