### PR TITLE
Document how mode combines with section in update-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- `update-page` now documents that `mode` can be scoped with `section`: `mode='append'` writes at the end of the named section, and `mode='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
+
 ### Fixed
 
 - A wiki that stops answering no longer hangs a tool call for minutes. This covers the first call to a wiki, where connecting and signing in were previously unbounded. A timed-out write reports that the change may or may not have been applied, since the server cannot tell.

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -52,7 +52,9 @@ const inputSchema = {
 		.enum(['append', 'prepend'])
 		.optional()
 		.describe(
-			"Adds source to the existing content instead of replacing it: 'append' to the end, 'prepend' to the start.",
+			"Adds source to the existing content instead of replacing it: 'append' to the end, 'prepend' to the start. " +
+				"With section=N, 'append' writes at the end of that section and 'prepend' immediately above that section's " +
+				'heading, which inserts a new section before an existing one.',
 		),
 	bot: z
 		.boolean()
@@ -137,7 +139,7 @@ async function subsectionRemovalError(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next. Resending a mode='append' or 'prepend' call whose result never arrived adds the delta a second time.",
+		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section at the end of the page means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next. Resending a mode='append' or 'prepend' call whose result never arrived adds the delta a second time.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/534

`update-page` accepts `mode` and `section` together, and MediaWiki does something useful with the combination that no description mentions: `ApiEditPage` extracts the named section, concatenates the delta, and writes that section back. So `mode='append'` with `section=N` lands at the end of section N, and `mode='prepend'` immediately above section N's heading, which inserts a new section before an existing one without sending the whole page. The second is not derivable, since "prepend to section 3" reads as "at the top of section 3's body".

`mode` gains one sentence saying so; the existing sentence is untouched. The top-level description's "adding a new section means appending" becomes "adding a new section at the end of the page means appending", so it reads as one route rather than the only one. Behaviour is unchanged.

This does not change where a plain append lands, which is what #534 reports. That placement is MediaWiki's: `Parser::extractSections` runs the last top-level section to EOF, so the trailing block sits inside it, and `section=<last>` with `mode='append'` produces a page byte-identical to a plain append. Verified on MediaWiki 1.43.9. #534 is closed with the full reasoning.

## Considered, omitted

- **A sentence stating that an appended delta lands below the closing categories.** True, and near-certainly inert: append means the end, and #538 measured a description-wording arm at zero movement. It also carries a cost, since a caller told about the limitation is being invited onto `get-page section=N` plus `update-page section=N`, which truncates above 50000 bytes with a dead-end remedy hint while #536 is open, and which gives up the one `update-page` path that cannot lose a concurrent update.
- **A `sectionsnotsupported` note on `section`.** `section` is a hard API error on content models without sections, where a plain append succeeds. That is an error-classification gap, not a `mode` fact.

## Verified

`lint`, `fmt:check`, `typecheck`, `build`, `check:mcp` and the 35 `update-page` tests all exit 0. No test asserts a description, and the README tool table row is unaffected.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; open question from @alistair3149, redirected once to cut a sentence documenting the limitation as expected behaviour; diff not yet human-reviewed; checks as above, plus API semantics verified against MediaWiki core source and empirically against a live 1.43.9 wiki.</sub>
