### PR TITLE
Let search-page target specific namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from. A call that omits `namespaces` searches the main namespace, which was always the case but went unstated; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.
+
 ### Changed
 
 - `update-page` now documents that `mode` can be scoped with `section`: `mode='append'` writes at the end of the named section, and `mode='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
 
 ### Fixed
 
+- Passing more namespace IDs than the wiki accepts (50, unless the account holds `apihighlimits`) is now reported as invalid input rather than as an upstream failure. This affects `get-category-members`, `get-links-here`, `get-recent-changes` and `search-page`.
 - A wiki that stops answering no longer hangs a tool call for minutes. This covers the first call to a wiki, where connecting and signing in were previously unbounded. A timed-out write reports that the change may or may not have been applied, since the server cannot tell.
 - `add-wiki` no longer hangs on a URL whose host accepts the connection and then goes quiet. It now gives up after 30 seconds and reports a timeout, instead of suggesting the URL may be wrong.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-site-info` | Get a wiki's key settings: MediaWiki version, content language, title-case rules, namespaces, installed extensions, license, and (optionally) statistics. |
 | `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. Disabled when fewer than two wikis are configured. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
-| `search-page` | Search wiki page titles and contents. |
+| `search-page` | Search wiki page titles and contents (full-text). Searches the main namespace unless given other namespace IDs. |
 | `search-page-by-prefix` | Search page titles by prefix. |
 | `whoami` | Report the identity the current session is authenticated as on the targeted wiki — username, whether it is anonymous, and group memberships (optionally user rights). |
 

--- a/src/errors/classifyError.ts
+++ b/src/errors/classifyError.ts
@@ -51,6 +51,7 @@ const MW_CODE_TO_CATEGORY: Record<string, ErrorCategory> = {
 	immobilenamespace: 'invalid_input',
 	nonfilenamespace: 'invalid_input',
 	filetypemismatch: 'invalid_input',
+	toomanyvalues: 'invalid_input',
 	// conflict
 	editconflict: 'conflict',
 	articleexists: 'conflict',

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/server';
-import type { ApiSearchResult } from 'mwn';
+import type { ApiResponse, ApiSearchResult } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
@@ -15,12 +15,17 @@ const inputSchema = {
 		.max(100)
 		.optional()
 		.describe('Maximum number of search results to return'),
+	namespaces: z
+		.array(z.number().int().nonnegative())
+		.nonempty()
+		.optional()
+		.describe('Namespace IDs to search — e.g. [0, 12] for main and help'),
 } as const;
 
 export const searchPage: Tool<typeof inputSchema> = {
 	name: 'search-page',
 	description:
-		'Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, and timestamp. Accepts up to 100 matches per call (default 10); additional matches beyond the cap are flagged in the response — narrow the query to surface more. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.',
+		"Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, timestamp, and the namespace the match came from. Covers the main namespace unless namespaces names the namespace IDs to search; get-site-info lists a wiki's namespaces, and a wiki that keeps its content outside the main namespace returns nothing until they are named. Accepts up to 100 matches per call (default 10); additional matches beyond the cap are flagged in the response — narrow the query to surface more. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.",
 	inputSchema,
 	annotations: {
 		title: 'Search page',
@@ -32,7 +37,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 	failureVerb: 'retrieve search data',
 	target: (a) => a.query,
 
-	async handle({ query, limit }, ctx: ToolContext): Promise<CallToolResult> {
+	async handle({ query, limit, namespaces }, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
 
 		const params: Record<string, string | number | boolean> = {
@@ -46,6 +51,9 @@ export const searchPage: Tool<typeof inputSchema> = {
 
 		if (limit !== undefined) {
 			params.srlimit = limit;
+		}
+		if (namespaces !== undefined) {
+			params.srnamespace = namespaces.join('|');
 		}
 
 		const response = await mwn.request(params);
@@ -65,6 +73,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 			searchResults.map(async (r) => ({
 				title: r.title,
 				pageId: r.pageid,
+				namespace: r.ns,
 				snippet: r.snippet,
 				size: r.size,
 				wordCount: (r as ApiSearchResult & { wordcount?: number }).wordcount,
@@ -73,9 +82,57 @@ export const searchPage: Tool<typeof inputSchema> = {
 			})),
 		);
 
+		const scopeNotice = describeScopeLoss(namespaces, searchResults, searchWarning(response));
+
 		return ctx.format.ok({
 			results,
+			...(scopeNotice !== null ? { scopeNotice } : {}),
 			...(truncation !== null ? { truncation } : {}),
 		});
 	},
 };
+
+// Two different failures leave the caller reading results from a scope it did
+// not ask for. The wiki reports an unusable namespace ID as an API warning and
+// searches the rest; it reports nothing at all when a namespace prefix in the
+// query overrides srnamespace, where the returned rows are the only evidence.
+function describeScopeLoss(
+	requested: readonly number[] | undefined,
+	results: readonly ApiSearchResult[],
+	warning: string | undefined,
+): string | null {
+	if (requested === undefined) {
+		return null;
+	}
+
+	const parts: string[] = [];
+
+	if (warning !== undefined) {
+		parts.push(`The wiki reported: ${warning}`);
+	}
+
+	const unexpected = [...new Set(results.map((r) => r.ns))].filter((ns) => !requested.includes(ns));
+	if (unexpected.length > 0) {
+		parts.push(
+			`Requested namespaces ${requested.join(', ')}, but results include ${unexpected.join(', ')} — a namespace prefix in the query (such as "Help:") overrides the namespaces argument.`,
+		);
+	}
+
+	return parts.length > 0 ? parts.join(' ') : null;
+}
+
+// The action API reports a parameter it could not use under the module that
+// received it, leaving the response otherwise successful.
+function searchWarning(response: ApiResponse): string | undefined {
+	const { warnings } = response;
+	if (!isRecord(warnings) || !isRecord(warnings.search)) {
+		return undefined;
+	}
+
+	const warning = warnings.search.warnings;
+	return typeof warning === 'string' && warning !== '' ? warning : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/tests/errors/classifyError.test.ts
+++ b/tests/errors/classifyError.test.ts
@@ -47,6 +47,7 @@ describe('classifyError', () => {
 			['immobilenamespace', 'invalid_input'],
 			['nonfilenamespace', 'invalid_input'],
 			['filetypemismatch', 'invalid_input'],
+			['toomanyvalues', 'invalid_input'],
 			['editconflict', 'conflict'],
 			['articleexists', 'conflict'],
 			['fileexists', 'conflict'],

--- a/tests/tools/search-page.test.ts
+++ b/tests/tools/search-page.test.ts
@@ -5,6 +5,62 @@ import { searchPage } from '../../src/tools/search-page.ts';
 import { dispatch } from '../../src/runtime/dispatcher.ts';
 import { assertStructuredError, assertStructuredSuccess } from '../helpers/structuredResult.ts';
 import type { SiteInfo } from '../../src/wikis/siteInfoCache.ts';
+import { toolArgs } from '../helpers/toolArgs.ts';
+
+type SearchRow = {
+	ns: number;
+	title: string;
+	pageid: number;
+	size: number;
+	snippet: string;
+	timestamp: string;
+};
+
+function searchRow(overrides: Partial<SearchRow> = {}): SearchRow {
+	return {
+		ns: 0,
+		title: 'Test Page',
+		pageid: 1,
+		size: 1,
+		snippet: 's',
+		timestamp: '2026-01-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+function mockSearchReturning(search: SearchRow[], warning?: string) {
+	return createMockMwn({
+		request: vi.fn().mockResolvedValue({
+			query: { search },
+			...(warning !== undefined ? { warnings: { search: { warnings: warning } } } : {}),
+		}),
+	});
+}
+
+// Returns the scope notice alone. Asserting against the whole payload would
+// let a result row satisfy an assertion the notice was supposed to carry.
+function scopeNotice(text: string): string {
+	const marker = 'Scope notice:';
+	expect(text).toContain(marker);
+	// The formatter renders a short value inline and a long one as its own
+	// block, so skip any leading newlines before taking the notice's one line.
+	return text
+		.slice(text.indexOf(marker) + marker.length)
+		.replace(/^\n+/, '')
+		.split('\n')[0]
+		.trim();
+}
+
+// The search call is located by its own list parameter rather than by call
+// index, so a test stays honest if the handler ever issues another request
+// first.
+function searchParams(mock: ReturnType<typeof createMockMwn>): Record<string, unknown> {
+	const call = mock.request.mock.calls.find(
+		(args: unknown[]) => (args[0] as Record<string, unknown>).list === 'search',
+	);
+	expect(call).toBeDefined();
+	return call![0] as Record<string, unknown>;
+}
 
 describe('search-page', () => {
 	it('returns full-text search results with snippets', async () => {
@@ -189,5 +245,103 @@ describe('search-page', () => {
 		const text = assertStructuredSuccess(result);
 		expect(text).toContain('Truncation:');
 		expect(text).toContain('  Limit: 10');
+	});
+
+	it('searches page content rather than titles', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		expect(searchParams(mock).srwhat).toBe('text');
+	});
+
+	it('omits srnamespace when the caller names no namespaces', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		const params = searchParams(mock);
+		expect(params.srsearch).toBe('test');
+		expect(params).not.toHaveProperty('srnamespace');
+	});
+
+	it('joins requested namespaces into a single srnamespace value', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test', namespaces: [0, 4, 14] }), ctx);
+
+		expect(searchParams(mock).srnamespace).toBe('0|4|14');
+	});
+
+	it('reports the namespace each result came from', async () => {
+		const mock = mockSearchReturning([searchRow({ title: 'Help:Contents', ns: 12 })]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await searchPage.handle(
+			toolArgs(searchPage, { query: 'test', namespaces: [12] }),
+			ctx,
+		);
+
+		expect(assertStructuredSuccess(result)).toContain('  Namespace: 12');
+	});
+
+	it('flags results that fall outside the requested namespaces', async () => {
+		const mock = mockSearchReturning([searchRow({ title: 'Help:Contents', ns: 12 })]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await searchPage.handle(
+			toolArgs(searchPage, { query: 'Help:Contents', namespaces: [0] }),
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(scopeNotice(text)).toContain('results include 12');
+	});
+
+	it('omits the scope notice when every result is in a requested namespace', async () => {
+		const mock = mockSearchReturning([searchRow({ title: 'Test Page', ns: 0 })]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await searchPage.handle(
+			toolArgs(searchPage, { query: 'test', namespaces: [0] }),
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('- Title: Test Page');
+		expect(text).not.toContain('Scope notice:');
+	});
+
+	it('rejects an empty namespaces array rather than searching everywhere', () => {
+		expect(() => toolArgs(searchPage, { query: 'test', namespaces: [] })).toThrow();
+	});
+
+	it('reports a namespace the wiki refused to search', async () => {
+		const mock = mockSearchReturning(
+			[searchRow({ ns: 0 })],
+			'Unrecognized value for parameter "srnamespace": 9999',
+		);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await searchPage.handle(
+			toolArgs(searchPage, { query: 'test', namespaces: [0, 9999] }),
+			ctx,
+		);
+
+		expect(scopeNotice(assertStructuredSuccess(result))).toContain('9999');
+	});
+
+	it('omits the scope notice when the caller named no namespaces', async () => {
+		const mock = mockSearchReturning([searchRow({ title: 'Help:Contents', ns: 12 })]);
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'Help:Contents' }), ctx);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('- Title: Help:Contents');
+		expect(text).not.toContain('Scope notice:');
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/587

`search-page` sent no `srnamespace`, so it inherited the action API's default of namespace 0 and searched only the main namespace. Nothing in the tool surface said so, which on a wiki that keeps its content elsewhere reads as "this wiki has no such page" rather than as a filter.

The new `namespaces` argument names the namespace IDs to search. Omitting it keeps today's behaviour, and the description now states what that behaviour is. Each result reports the namespace it came from.

Two things discard the requested scope. The wiki refuses a namespace ID it does not have, reports that as an API warning and searches the rest; a namespace prefix in the query overrides `srnamespace` and is reported nowhere at all. The response carries a scope notice covering both, since a caller reading the results alone cannot tell either one happened.

An over-long list of values now classifies as invalid input rather than an upstream failure. That was already reachable from `get-category-members`, `get-links-here` and `get-recent-changes`.

## What the reviewer should decide

`namespaces` is `.optional()`, not `.default([0])`. Both are identical on the wire; the difference is that a schema default would collapse "omitted" into "explicitly asked for the main namespace", which forecloses any later wiki-aware default and conflicts with the team rule that defaults are for a genuine absent state rather than a hidden configuration decision. Note this diverges from the three sibling tools in meaning, not shape: `cmnamespace`, `blnamespace` and `rcnamespace` have no API default, so omitting them searches everywhere, whereas omitting `srnamespace` searches namespace 0 only.

## Considered, omitted

- **Changing the default scope.** This is the deeper defect: on mediawiki.org, searching "configuration settings" the way this tool does returns Requests-for-comment pages, because `Manual`, `Extension`, `API` and `Skin` are content namespaces that a namespace-0 search excludes. Deferred because there is no single right replacement. The two candidate signals give different sets on the same wiki — wiki.factorio.com flags `{0, Property, Concept, Tutorial, Archive}` as content namespaces but defaults its own search to `{0, Tutorial}` — and content namespaces over-cover for search purposes, taking in SMW metadata (`Property`, `Concept`) and Wikidata's machine-readable `Lexeme` and `EntitySchema`. Worth its own issue.
- **Exposing `srwhat`.** `srwhat=title` is a hard `search-title-disabled` error on CirrusSearch but works on the database engine, and paraminfo advertises the same enum on both, so a caller cannot discover which values work. Title search is also `intitle:` on CirrusSearch and `srwhat=title` on the database engine, so one parameter cannot express it portably.
- **A per-wiki `searchNamespaces` config.** Every existing `WikiConfig` field is cross-cutting, and a per-tool default would be invisible to `tools/list`, reintroducing the same undisclosed scope this PR removes.
- **A `.max(50)` schema cap.** The limit is 50 anonymous and 500 with `apihighlimits`, so a cap would refuse calls the wiki accepts. Classifying `toomanyvalues` handles it instead.
- **An all-namespaces escape.** `srnamespace=*` cannot be mixed with numeric values and does not fit a `number[]`. Enumerating from `get-site-info` covers it below 50 namespaces.
- **`search-page-by-prefix`.** It has the same undisclosed namespace-0 default. Left alone to keep this diff to one tool.

## Verification

TDD throughout. Each mechanism was reverted separately to confirm exactly one test fails for it — dropping `srwhat: 'text'`, always sending `srnamespace`, dropping the per-row namespace, dropping the API-warning branch, returning a notice when no namespaces were requested, and dropping the unexpected-namespace list.

Smoke-tested against en.wikipedia.org via the Inspector CLI: `namespaces=[4]` returns project-namespace rows; the default is unchanged; `namespaces=[0]` with the query `Help:Contents` reports the prefix override; `namespaces=[0,9999]` reports the refused ID. `namespaces=[0,4]` returns only namespace-0 rows in the top 15, which the raw API also does — the corpus goes from 30,633 to 73,083 hits, so both are in scope and CirrusSearch simply ranks article space higher.

Full suite (2194 tests), `lint`, `typecheck` and `check:mcp` all green.

> <sub>AI-authored — Claude Code, `Opus 5 (ultracode)`; question from @alistair3149 about whether this was already supported, which became a design decision; scope narrowed twice on their pushback (per-wiki config dropped, `srwhat` passthrough rejected); diff not yet human-reviewed; TDD with each mechanism reverted to prove its test fails, full suite / lint / typecheck / MCP conformance green, smoke-tested against a live wiki.</sub>

https://claude.ai/code/session_01CjqCAgSXf6BRQNi9MbQSvE

