### PR TITLE
Fix what a truncated read tells the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 
 - `update-page` now documents that `mode` can be scoped with `section`: `mode='append'` writes at the end of the named section, and `mode='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
+- The section list `get-page` and `get-pages` report now labels each section with the number that edits it, as `1 (History)` where it was `History`, and leaves out headings that arrive by transclusion. This is the outline in every `metadata=true` response as well as the one attached to a truncated read. The list previously numbered by position, and a transcluded heading holds a position that no section number addresses, so on any page carrying one every later entry named a different section than the one it pointed at.
 
 ### Fixed
 
 - Passing more namespace IDs than the wiki accepts (50, unless the account holds `apihighlimits`) is now reported as invalid input rather than as an upstream failure. This affects `get-category-members`, `get-links-here`, `get-recent-changes` and `search-page`.
+- A truncated page or section read no longer ends mid-character. The cut now falls on a character boundary, so what comes back is exactly what the page holds: a multi-byte character split by the cut previously arrived as a replacement character that was never on the page, and the response could exceed the byte cap it reported against.
+- A truncated read no longer offers a narrowing that returns the same bytes. A `section=N` read names that section's own subsections, and a read with nothing narrower left says so instead of repeating the call that had just truncated.
 - A wiki that stops answering no longer hangs a tool call for minutes. This covers the first call to a wiki, where connecting and signing in were previously unbounded. A timed-out write reports that the change may or may not have been applied, since the server cannot tell.
 - `add-wiki` no longer hangs on a URL whose host accepts the connection and then goes quiet. It now gives up after 30 seconds and reports a timeout, instead of suggesting the URL may be wrong.
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -133,17 +133,19 @@ Parameter descriptions must:
 
 #### Result caps and truncation signaling
 
-Tools that return variable-size result sets or content bodies have a per-call cap. When the cap is hit, the tool appends a trailing text block to `content` describing the truncation. Three shapes:
+Tools that return variable-size result sets or content bodies have a per-call cap. When the cap is hit, the tool sets a `truncation` field on its payload, which reaches the caller through both response channels: rendered as prose in `content[0]` and typed in `structuredContent`. Three shapes, each a variant of `TruncationInfo` in `src/results/truncation.ts`:
 
-- **With continuation** (the caller can fetch more): `"More results available. Returned N <items>. To fetch the next segment, call <tool-name> again with <param>=<value>."`
-- **Without continuation** (the only remedy is a narrower query): `"Result capped at N <items>. Additional <items> may exist — <narrow-hint>."`
-- **Content truncated** (the response body exceeded the byte budget): `"Content truncated at N of M bytes. [Available sections: 0 (Lead), 1 (<heading>), ....] <remedy>"` where `<remedy>` is a full sentence of the form `"To <purpose>, <action>."` (e.g. `"To read a specific section, call get-page again with section=N."`), matching the connector-phrase pattern used by the `more-available` shape.
+- **With continuation** (`more-available`, the caller can fetch more): the count returned, the item noun, and the parameter and value that fetch the next segment.
+- **Without continuation** (`capped-no-continuation`, the only remedy is a narrower query): the count returned, the limit, and a hint naming the narrowing available.
+- **Content truncated** (`content-truncated`, the response body exceeded the byte budget): the bytes returned and the bytes available, a `remedyHint` — a full sentence of the form `"To <purpose>, <action>."` — and, where narrower targets exist, a `sections` list naming them.
 
-Where the narrowing a parameter offers is exhausted — the call already names the single item the response can be narrowed to, so naming it again returns the same response — no action remains, and the `<remedy>` says so instead. A parameter that still has somewhere to go is repeated as normal: `get-page` truncating one oversize section still points at `section=N`, because the other sections remain.
+Each `sections` entry carries the number that addresses it, as `"3 (History)"`. That number is the section's own `index` from the API, never its position in the list: a transcluded heading occupies a position but no `section=` value addresses it, so numbering by position sends a caller to a different section than the one it read. Transcluded headings are left out of the list for the same reason.
+
+Where the narrowing a parameter offers is exhausted — the call already names the single item the response can be narrowed to, so naming it again returns the same response — no action remains, and the `remedyHint` says so instead. `get-page` truncating a `section=N` read names that section's own subsections, the only narrower target it has; where the section has none, the remedy says no narrower read exists rather than pointing back at the call that just truncated.
 
 Descriptions state the default cap with a "by default" qualifier (e.g., "truncated at 50000 bytes by default"). The qualifier is load-bearing because operators can override `DEFAULT_CONTENT_MAX_BYTES` via `MCP_CONTENT_MAX_BYTES`; without it, descriptions misrepresent customised deployments. If continuation is supported, descriptions reference the continuation parameter by name so the LLM can pick the right parameter without inspecting the schema.
 
-The byte budget for content bodies is centrally resolved via `contentMaxBytes()` in `src/results/truncation.ts` — it reads the `MCP_CONTENT_MAX_BYTES` environment variable and falls back to `DEFAULT_CONTENT_MAX_BYTES` (50000). Tools do not invent their own limits. Section-aware tools (`get-page`, `get-pages`) include a section list in the marker so the caller can navigate without a follow-up "list sections" call.
+The byte budget for content bodies is centrally resolved via `contentMaxBytes()` in `src/results/truncation.ts` — it reads the `MCP_CONTENT_MAX_BYTES` environment variable and falls back to `DEFAULT_CONTENT_MAX_BYTES` (50000). Tools do not invent their own limits. A cut body is a byte-exact prefix of the whole: the cut moves back to a character boundary rather than splitting a multi-byte character, because a caller may write the returned text back to the wiki and it must carry nothing the page did not. Section-aware tools (`get-page`, `get-pages`) include a section list in the marker so the caller can navigate without a follow-up "list sections" call.
 
 This convention doesn't apply to tools that reject oversize input (e.g. `get-pages`' 50-title cap): those return an error, not a truncation marker.
 

--- a/src/results/response.ts
+++ b/src/results/response.ts
@@ -2,7 +2,6 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ErrorEnvelope } from '../results/schemas.ts';
 import type { ErrorCategory } from '../errors/classifyError.ts';
 import { formatPayload } from './format.ts';
-import type { TruncationInfo } from './truncation.ts';
 
 export interface ResponseFormatter {
 	ok(payload: unknown): CallToolResult;
@@ -11,7 +10,6 @@ export interface ResponseFormatter {
 	invalidInput(message: string): CallToolResult;
 	conflict(message: string, code?: string): CallToolResult;
 	permissionDenied(message: string, code?: string): CallToolResult;
-	truncationMarker(info: TruncationInfo): string;
 }
 
 export function structuredResult(data: unknown): CallToolResult {
@@ -63,25 +61,5 @@ export class ResponseFormatterImpl implements ResponseFormatter {
 
 	public permissionDenied(message: string, code?: string): CallToolResult {
 		return this.error('permission_denied', message, code);
-	}
-
-	public truncationMarker(info: TruncationInfo): string {
-		switch (info.reason) {
-			case 'content-truncated': {
-				const sections =
-					info.sections && info.sections.length > 0
-						? ` Available sections: ${info.sections.map((s, i) => `${i} (${s || 'Lead'})`).join(', ')}.`
-						: '';
-				return `Content (${info.itemNoun}) truncated at ${info.returnedBytes} of ${info.totalBytes} bytes.${sections} ${info.remedyHint}`;
-			}
-			case 'more-available':
-				return `More results available. Returned ${info.returnedCount} ${info.itemNoun}. To fetch the next segment, call ${info.toolName} again with ${info.continueWith.param}=${info.continueWith.value}.`;
-			case 'capped-no-continuation':
-				return `Result capped at ${info.limit} ${info.itemNoun}. Additional ${info.itemNoun} may exist — ${info.narrowHint}`;
-			default: {
-				const _exhaustive: never = info;
-				return _exhaustive;
-			}
-		}
 	}
 }

--- a/src/results/truncation.ts
+++ b/src/results/truncation.ts
@@ -93,6 +93,12 @@ export function capLinesByBytes(lines: string[]): CappedLines {
 	return { lines: kept, returnedBytes, totalBytes, truncated: true };
 }
 
+// UTF-8 continuation bytes are 0b10xxxxxx. A cut whose next byte is one of them
+// lands inside a multi-byte character.
+function isContinuationByte(byte: number): boolean {
+	return (byte & 0xc0) === 0x80;
+}
+
 export function truncateByBytes(
 	text: string,
 	maxBytes: number = contentMaxBytes(),
@@ -102,14 +108,20 @@ export function truncateByBytes(
 	if (totalBytes <= maxBytes) {
 		return { text, truncated: false, returnedBytes: totalBytes, totalBytes };
 	}
-	// Slice on a byte boundary, then decode. Node's Buffer#toString handles
-	// incomplete trailing UTF-8 sequences by replacing them with U+FFFD,
-	// which is acceptable for a truncated preview.
-	const sliced = buffer.subarray(0, maxBytes).toString('utf8');
+	// Cut back to a character boundary, so the text returned is a byte-exact
+	// prefix of the input. Slicing mid-sequence leaves Node decoding the partial
+	// character as U+FFFD, which both pushes the result past maxBytes and puts a
+	// character in the caller's copy that the page never contained.
+	// Clamped here rather than at the call sites, because maxBytes is a public
+	// parameter and a negative one would make subarray count from the end.
+	let end = Math.max(0, maxBytes);
+	while (end > 0 && isContinuationByte(buffer[end])) {
+		end--;
+	}
 	return {
-		text: sliced,
+		text: buffer.subarray(0, end).toString('utf8'),
 		truncated: true,
-		returnedBytes: Buffer.byteLength(sliced, 'utf8'),
+		returnedBytes: end,
 		totalBytes,
 	};
 }

--- a/src/services/sectionMarker.ts
+++ b/src/services/sectionMarker.ts
@@ -1,0 +1,75 @@
+import type { TruncationInfo } from '../results/truncation.ts';
+import { toOutlineLines, type SectionEntry } from './sectionService.ts';
+import { editableChildrenOf } from './sectionSubtree.ts';
+
+/**
+ * The `content-truncated` marker for a tool that reads page content, where what
+ * the caller can do about a cut body depends on what it asked for.
+ *
+ * A whole-page read still has sections to narrow to. A section read has already
+ * spent that narrowing, so its own subsections are the only narrower target, and
+ * where it has none the convention is to say no action remains rather than to
+ * name the call that just truncated.
+ *
+ * Shared by every section-aware read, so the three variants and their wording
+ * are decided once. Tools whose content is not sections — a diff, a rendered
+ * fragment, a row listing — carry their own remedy, which is theirs alone and
+ * belongs with them.
+ */
+export function sectionContentTruncation({
+	entries,
+	section,
+	itemNoun,
+	toolName,
+	returnedBytes,
+	totalBytes,
+}: {
+	readonly entries: readonly SectionEntry[];
+	readonly section: number | undefined;
+	readonly itemNoun: string;
+	readonly toolName: string;
+	readonly returnedBytes: number;
+	readonly totalBytes: number;
+}): TruncationInfo {
+	const base = {
+		reason: 'content-truncated',
+		returnedBytes,
+		totalBytes,
+		itemNoun,
+		toolName,
+	} as const;
+
+	if (section === undefined) {
+		const outline = toOutlineLines(entries);
+		// A page whose only entry is the lead has no heading to narrow to, and
+		// section 0 of such a page is the page, so naming it returns these same
+		// bytes. Not naming get-page "again" keeps the sentence true for a
+		// get-pages caller, which never called get-page in the first place.
+		if (outline.length === 1) {
+			return {
+				...base,
+				remedyHint: 'The page has no sections, so no narrower read returns more of it.',
+			};
+		}
+		return {
+			...base,
+			sections: outline,
+			remedyHint: 'To read a specific section, call get-page with section=N.',
+		};
+	}
+
+	const subsections = editableChildrenOf(entries, String(section));
+	if (subsections.length === 0) {
+		return {
+			...base,
+			remedyHint:
+				"No narrower read returns more of this section. To add to it without resending it, use update-page with mode='append'.",
+		};
+	}
+	return {
+		...base,
+		sections: subsections.map((s) => `${s.index} (${s.line})`),
+		remedyHint:
+			'To read part of this section, call get-page again with one of the subsection numbers listed.',
+	};
+}

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -70,9 +70,11 @@ export class SectionServiceImpl implements SectionService {
 	}
 }
 
-// The outline shape tools publish today: the lead as an empty first entry, then
-// one heading line per section. Kept separate from the service so the richer
-// entries are available internally without changing any tool's output.
+// The published outline: one line per section, each labelled with the number
+// that edits it. Transcluded headings are left out — they appear on the page but
+// no `section=` value addresses them, so listing them shifts every later heading
+// away from its own number. Kept separate from the service so the richer entries
+// stay available internally to the guards and markers that need levels.
 export function toOutlineLines(entries: readonly SectionEntry[]): string[] {
-	return ['', ...entries.map((e) => e.line)];
+	return ['0 (Lead)', ...entries.filter((e) => e.editable).map((e) => `${e.index} (${e.line})`)];
 }

--- a/src/services/sectionSubtree.ts
+++ b/src/services/sectionSubtree.ts
@@ -23,3 +23,15 @@ export function childrenOf(entries: readonly SectionEntry[], index: string): Sec
 	}
 	return children;
 }
+
+/**
+ * The children of `index` a caller can both read and supply: a transcluded
+ * heading shows on the page but no `section=` value edits it, and it can never
+ * appear in a source the caller writes back.
+ */
+export function editableChildrenOf(
+	entries: readonly SectionEntry[],
+	index: string,
+): SectionEntry[] {
+	return childrenOf(entries, index).filter((c) => c.editable);
+}

--- a/src/tools/compare-pages.ts
+++ b/src/tools/compare-pages.ts
@@ -157,7 +157,7 @@ function buildPayload(
 export const comparePages: Tool<typeof inputSchema> = {
 	name: 'compare-pages',
 	description:
-		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Only the changes are returned over the wire. For the full text of both sides, fetch with get-page instead. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta. Diff output is truncated at 50000 bytes by default with a trailing marker; a narrower revision range or includeDiff=false avoids truncation.',
+		'Returns the changes between two versions of a wiki page as a compact text diff. Each side accepts a revision ID, page title (latest revision), or supplied wikitext; text-vs-text is rejected. Only the changes are returned over the wire. For the full text of both sides, fetch with get-page instead. If a title or revision ID does not exist, an error is returned. Set includeDiff=false for a cheap change-detection response that skips diff rendering and returns just the change flag, revision metadata, and size delta. Diff output is truncated at 50000 bytes by default, with a marker reporting how much of it was returned; a narrower revision range or includeDiff=false avoids truncation.',
 	inputSchema,
 	annotations: {
 		title: 'Compare pages',

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -5,7 +5,8 @@ import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { ContentFormat } from '../results/contentFormat.ts';
 import { truncateByBytes, type TruncationInfo } from '../results/truncation.ts';
-import { toOutlineLines } from '../services/sectionService.ts';
+import { toOutlineLines, type SectionEntry } from '../services/sectionService.ts';
+import { sectionContentTruncation } from '../services/sectionMarker.ts';
 
 const inputSchema = {
 	title: z.string().describe('Wiki page title'),
@@ -34,7 +35,7 @@ const inputSchema = {
 export const getPage: Tool<typeof inputSchema> = {
 	name: 'get-page',
 	description:
-		'Returns a single wiki page (wikitext source, rendered HTML, or metadata only). If the title does not exist, an error is returned. Use metadata=true to retrieve the revision ID (for edit-conflict detection), page size, and section outline. Set content="none" to fetch only metadata. Large content is truncated at 50000 bytes by default with a trailing marker listing available sections; a follow-up call with section=N fetches a specific section. For more than one page at a time, use get-pages. For a specific historical revision, use get-revision.',
+		'Returns a single wiki page (wikitext source, rendered HTML, or metadata only). If the title does not exist, an error is returned. Use metadata=true to retrieve the revision ID (for edit-conflict detection), page size, and section outline. Set content="none" to fetch only metadata. Large content is truncated at 50000 bytes by default, with a marker reporting how much of it was returned and which sections a narrower read can target; a follow-up call with section=N fetches a specific section. For more than one page at a time, use get-pages. For a specific historical revision, use get-revision.',
 	inputSchema,
 	annotations: {
 		title: 'Get page',
@@ -74,7 +75,7 @@ export const getPage: Tool<typeof inputSchema> = {
 			metadata || content === ContentFormat.source || content === ContentFormat.none;
 		const needsSource = content === ContentFormat.source;
 
-		let sections: string[] | undefined;
+		let entries: SectionEntry[] | undefined;
 
 		if (needsReadCall) {
 			const rvprop = needsSource
@@ -93,7 +94,7 @@ export const getPage: Tool<typeof inputSchema> = {
 			const rev = page.revisions?.[0];
 
 			if (metadata) {
-				sections = toOutlineLines(await ctx.sections.list(mwn, title));
+				entries = await ctx.sections.list(mwn, title);
 			}
 
 			if (metadata || content === ContentFormat.none) {
@@ -105,8 +106,8 @@ export const getPage: Tool<typeof inputSchema> = {
 				if (rev?.size !== undefined) {
 					payload.size = rev.size;
 				}
-				if (sections !== undefined) {
-					payload.sections = sections;
+				if (entries !== undefined) {
+					payload.sections = toOutlineLines(entries);
 				}
 				payload.url = await buildPageUrl(ctx, page.title);
 			}
@@ -115,18 +116,15 @@ export const getPage: Tool<typeof inputSchema> = {
 				const truncated = truncateByBytes(rev.content);
 				payload.source = truncated.text;
 				if (truncated.truncated) {
-					if (sections === undefined) {
-						sections = toOutlineLines(await ctx.sections.list(mwn, title));
-					}
-					payload.truncation = {
-						reason: 'content-truncated',
-						returnedBytes: truncated.returnedBytes,
-						totalBytes: truncated.totalBytes,
+					entries ??= await ctx.sections.list(mwn, title);
+					payload.truncation = sectionContentTruncation({
+						entries,
+						section,
 						itemNoun: 'wikitext',
 						toolName: 'get-page',
-						sections,
-						remedyHint: 'To read a specific section, call get-page again with section=N.',
-					};
+						returnedBytes: truncated.returnedBytes,
+						totalBytes: truncated.totalBytes,
+					});
 				}
 			}
 		}
@@ -158,18 +156,15 @@ export const getPage: Tool<typeof inputSchema> = {
 				}
 
 				if (truncated.truncated) {
-					if (sections === undefined) {
-						sections = toOutlineLines(await ctx.sections.list(mwn, title));
-					}
-					payload.truncation = {
-						reason: 'content-truncated',
-						returnedBytes: truncated.returnedBytes,
-						totalBytes: truncated.totalBytes,
+					entries ??= await ctx.sections.list(mwn, title);
+					payload.truncation = sectionContentTruncation({
+						entries,
+						section,
 						itemNoun: 'HTML',
 						toolName: 'get-page',
-						sections,
-						remedyHint: 'To read a specific section, call get-page again with section=N.',
-					};
+						returnedBytes: truncated.returnedBytes,
+						totalBytes: truncated.totalBytes,
+					});
 				}
 			}
 		}

--- a/src/tools/get-pages.ts
+++ b/src/tools/get-pages.ts
@@ -5,7 +5,7 @@ import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
 import { truncateByBytes, type TruncationInfo } from '../results/truncation.ts';
-import { toOutlineLines } from '../services/sectionService.ts';
+import { sectionContentTruncation } from '../services/sectionMarker.ts';
 
 const MAX_TITLES = 50;
 
@@ -222,19 +222,18 @@ async function applyTruncations(
 	if (pending.length === 0) {
 		return;
 	}
-	const sectionLists = await Promise.all(
-		pending.map(async (p) => toOutlineLines(await ctx.sections.list(mwn, p.title))),
-	);
+	const outlines = await Promise.all(pending.map((p) => ctx.sections.list(mwn, p.title)));
 	pending.forEach((p, i) => {
-		entries[p.entryIndex].truncation = {
-			reason: 'content-truncated',
-			returnedBytes: p.returnedBytes,
-			totalBytes: p.totalBytes,
+		entries[p.entryIndex].truncation = sectionContentTruncation({
+			entries: outlines[i],
+			// get-pages reads whole pages, so the narrowing on offer is always
+			// the page's own sections.
+			section: undefined,
 			itemNoun: 'wikitext',
 			toolName: 'get-pages',
-			sections: sectionLists[i],
-			remedyHint: 'To read a specific section, call get-page again with section=N.',
-		};
+			returnedBytes: p.returnedBytes,
+			totalBytes: p.totalBytes,
+		});
 	});
 }
 
@@ -274,7 +273,7 @@ async function assembleEntries(
 
 export const getPages: Tool<typeof inputSchema> = {
 	name: 'get-pages',
-	description: `Returns multiple wiki pages in one call (wikitext source or metadata only). Suited to reading a cluster of related pages, diffing a page family, or syncing pages to local storage. Accepts up to ${MAX_TITLES} titles; missing pages are reported inline (not as errors). Each page's content is truncated at 50000 bytes by default with a trailing marker listing available sections; get-page with section=N fetches a specific section. For a single page or HTML output, use get-page. requestedTitle is included only when it differs from the resolved title.`,
+	description: `Returns multiple wiki pages in one call (wikitext source or metadata only). Suited to reading a cluster of related pages, diffing a page family, or syncing pages to local storage. Accepts up to ${MAX_TITLES} titles; missing pages are reported inline (not as errors). Each page's content is truncated at 50000 bytes by default, with a marker reporting how much of it was returned and which sections a narrower read can target; get-page with section=N fetches a specific section. For a single page or HTML output, use get-page. requestedTitle is included only when it differs from the resolved title.`,
 	inputSchema,
 	annotations: {
 		title: 'Get pages',

--- a/src/tools/parse-wikitext.ts
+++ b/src/tools/parse-wikitext.ts
@@ -29,7 +29,7 @@ const inputSchema = {
 export const parseWikitext: Tool<typeof inputSchema> = {
 	name: 'parse-wikitext',
 	description:
-		'Renders wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Suited to dry-running a planned edit before create-page or update-page, or previewing standalone wikitext (template combinations, sanitizer checks) with no target page. HTML output is truncated at 50000 bytes by default with a trailing marker; a smaller wikitext fragment in a follow-up call returns the rest.',
+		'Renders wikitext through the live wiki without saving. Returns HTML, parse warnings, categories, wikilinks, templates, external URLs, and display title. Suited to dry-running a planned edit before create-page or update-page, or previewing standalone wikitext (template combinations, sanitizer checks) with no target page. HTML output is truncated at 50000 bytes by default, with a marker reporting how much of it was returned; a smaller wikitext fragment in a follow-up call returns the rest.',
 	inputSchema,
 	annotations: {
 		title: 'Preview wikitext',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -4,7 +4,7 @@ import type { Mwn } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
-import { childrenOf } from '../services/sectionSubtree.ts';
+import { editableChildrenOf } from '../services/sectionSubtree.ts';
 
 interface ApiEditResponse {
 	result?: string;
@@ -112,11 +112,11 @@ async function subsectionRemovalError(
 	}
 	const entries = await ctx.sections.list(mwn, args.title);
 	const index = String(section);
-	// childrenOf walks every entry so a transcluded heading still closes the
-	// subtree at the right point; transcluded children are filtered out here
-	// because they can never appear in source for the caller to carry back,
-	// and the guard must not refuse a write over content it cannot supply.
-	const children = childrenOf(entries, index).filter((c) => c.editable);
+	// The subtree walk counts every entry so a transcluded heading still closes
+	// it at the right point; the transcluded children themselves drop out,
+	// because the guard must not refuse a write over content the caller cannot
+	// supply.
+	const children = editableChildrenOf(entries, index);
 	if (children.length === 0) {
 		return undefined;
 	}

--- a/tests/results/response.test.ts
+++ b/tests/results/response.test.ts
@@ -46,45 +46,4 @@ describe('ResponseFormatterImpl', () => {
 			fmt.error('permission_denied', 'X', 'protectedpage'),
 		);
 	});
-
-	it('truncationMarker formats content-truncated info with sections', () => {
-		const text = fmt.truncationMarker({
-			reason: 'content-truncated',
-			returnedBytes: 50000,
-			totalBytes: 80000,
-			itemNoun: 'wikitext',
-			toolName: 'get-page',
-			sections: ['', 'Lead', 'Body'],
-			remedyHint: 'To read a specific section, call get-page again with section=N.',
-		});
-		expect(text).toContain('50000 of 80000');
-		expect(text).toContain('wikitext');
-		expect(text).toContain('Lead');
-		expect(text).toContain('To read a specific section');
-	});
-
-	it('truncationMarker formats more-available info with continuation', () => {
-		const text = fmt.truncationMarker({
-			reason: 'more-available',
-			returnedCount: 50,
-			itemNoun: 'changes',
-			toolName: 'get-recent-changes',
-			continueWith: { param: 'continue', value: 'tok123' },
-		});
-		expect(text).toContain('More results available');
-		expect(text).toContain('50 changes');
-		expect(text).toContain('continue=tok123');
-	});
-
-	it('truncationMarker formats capped-no-continuation info', () => {
-		const text = fmt.truncationMarker({
-			reason: 'capped-no-continuation',
-			returnedCount: 10,
-			limit: 10,
-			itemNoun: 'results',
-			narrowHint: 'narrow your filter',
-		});
-		expect(text).toContain('Result capped at 10 results');
-		expect(text).toContain('narrow your filter');
-	});
 });

--- a/tests/results/truncation.test.ts
+++ b/tests/results/truncation.test.ts
@@ -66,6 +66,18 @@ describe('capLinesByBytes', () => {
 
 		expect(capLinesByBytes(lines).lines).toEqual(['a-ver…']);
 	});
+
+	// The row listings this feeds carry multi-byte labels as a matter of course,
+	// so the one branch that cuts inside a line has to cut on a character.
+	it('cuts an oversized first line on a character boundary', () => {
+		vi.stubEnv('MCP_CONTENT_MAX_BYTES', '8');
+
+		const capped = capLinesByBytes(['漢漢漢漢']);
+
+		expect(capped.lines).toEqual(['漢…']);
+		expect(capped.returnedBytes).toBeLessThanOrEqual(8);
+		expect(capped.lines[0]).not.toContain('\uFFFD');
+	});
 });
 
 describe('DEFAULT_CONTENT_MAX_BYTES', () => {
@@ -139,19 +151,41 @@ describe('truncateByBytes', () => {
 		expect(result.totalBytes).toBe(DEFAULT_CONTENT_MAX_BYTES + 1);
 	});
 
-	it('handles a multi-byte UTF-8 character straddling the byte boundary', () => {
-		// '漢' is 3 bytes in UTF-8. Build a buffer whose first 100 bytes split
-		// the final character across the limit so the slice lands mid-sequence.
+	it('cuts back to a character boundary when the limit lands mid-sequence', () => {
+		// '漢' is 3 bytes in UTF-8, so a 100-byte cut falls inside the first one.
 		const input = 'x'.repeat(99) + '漢漢';
 		const result = truncateByBytes(input, 100);
 		expect(result.truncated).toBe(true);
-		// Buffer#toString('utf8') replaces the partial trailing byte with U+FFFD;
-		// returnedBytes reflects the decoded string's UTF-8 length, which may
-		// exceed the raw 100-byte slice but stays bounded by maxBytes + 2 bytes
-		// of replacement.
 		expect(result.totalBytes).toBe(99 + 6);
-		expect(result.returnedBytes).toBeLessThanOrEqual(100 + 2);
-		// The returned text must decode cleanly as a string (no thrown decode error)
-		expect(typeof result.text).toBe('string');
+		expect(result.text).toBe('x'.repeat(99));
+		expect(result.returnedBytes).toBe(99);
+	});
+
+	// A caller may write the returned text back to the wiki, so it must contain
+	// nothing the page did not.
+	it('returns a byte-exact prefix, never a replacement character', () => {
+		const input = 'x'.repeat(99) + '漢漢';
+		const result = truncateByBytes(input, 100);
+		expect(input.startsWith(result.text)).toBe(true);
+		expect(result.text).not.toContain('\uFFFD');
+	});
+
+	it.each([98, 99, 100, 101, 102, 103])(
+		'returns a prefix within the limit at maxBytes=%i',
+		(maxBytes) => {
+			const input = 'x'.repeat(99) + '漢漢';
+
+			const result = truncateByBytes(input, maxBytes);
+
+			expect(result.returnedBytes).toBeLessThanOrEqual(maxBytes);
+			expect(input.startsWith(result.text)).toBe(true);
+		},
+	);
+
+	it('returns nothing when the first character alone exceeds the limit', () => {
+		const result = truncateByBytes('漢x', 2);
+		expect(result.truncated).toBe(true);
+		expect(result.text).toBe('');
+		expect(result.returnedBytes).toBe(0);
 	});
 });

--- a/tests/services/sectionMarker.test.ts
+++ b/tests/services/sectionMarker.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { sectionContentTruncation } from '../../src/services/sectionMarker.ts';
+import type { SectionEntry } from '../../src/services/sectionService.ts';
+
+const OUTLINE: SectionEntry[] = [
+	{ index: '1', level: 2, line: 'History', editable: true },
+	{ index: '2', level: 3, line: 'Origins', editable: true },
+	{ index: '3', level: 3, line: 'Modern era', editable: true },
+	{ index: '4', level: 2, line: 'Geography', editable: true },
+];
+
+function marker(section: number | undefined, entries: SectionEntry[] = OUTLINE) {
+	return sectionContentTruncation({
+		entries,
+		section,
+		itemNoun: 'wikitext',
+		toolName: 'get-page',
+		returnedBytes: 50000,
+		totalBytes: 60000,
+	});
+}
+
+describe('sectionContentTruncation', () => {
+	it('offers the page outline when the read was not narrowed', () => {
+		const info = marker(undefined);
+
+		expect(info).toMatchObject({
+			reason: 'content-truncated',
+			returnedBytes: 50000,
+			totalBytes: 60000,
+			sections: ['0 (Lead)', '1 (History)', '2 (Origins)', '3 (Modern era)', '4 (Geography)'],
+		});
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain('section=N');
+	});
+
+	// Naming the whole page's sections is what sent a caller back to the call it
+	// had just made, so a narrowed read offers only what is nested under it.
+	it("offers the requested section's subsections when the read was narrowed", () => {
+		const info = marker(1);
+
+		expect(info).toMatchObject({ sections: ['2 (Origins)', '3 (Modern era)'] });
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain('subsection numbers');
+	});
+
+	it('reports that no narrower read exists for a section without subsections', () => {
+		const info = marker(4);
+
+		expect(info).not.toHaveProperty('sections');
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain(
+			'No narrower read returns more of this section',
+		);
+	});
+
+	// The lead carries no heading, so the outline holds no entry to nest under.
+	it('reports that no narrower read exists for the lead', () => {
+		const info = marker(0);
+
+		expect(info).not.toHaveProperty('sections');
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain(
+			'No narrower read returns more of this section',
+		);
+	});
+
+	// Section 0 of a page with no headings is the page, so naming it returns the
+	// same bytes: the narrowing is exhausted here too.
+	it('reports that no narrower read exists for a page with no sections', () => {
+		const info = marker(undefined, []);
+
+		expect(info).not.toHaveProperty('sections');
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain(
+			'The page has no sections',
+		);
+	});
+
+	it('reports that no narrower read exists for a page whose headings are all transcluded', () => {
+		const info = marker(undefined, [
+			{ index: 'T-1', level: 2, line: 'From a template', editable: false },
+		]);
+
+		expect(info).not.toHaveProperty('sections');
+		expect(info.reason === 'content-truncated' && info.remedyHint).toContain(
+			'The page has no sections',
+		);
+	});
+
+	// formatPayload renders a field value over 120 characters as its own
+	// unindented block, which lifts the sentence out of the marker it belongs to.
+	it.each([undefined, 1, 4])('keeps the remedy inline at section=%s', (section) => {
+		const info = marker(section);
+
+		expect(info.reason === 'content-truncated' && info.remedyHint.length).toBeLessThanOrEqual(120);
+	});
+
+	it('leaves a transcluded subsection out of the narrower targets it offers', () => {
+		const info = marker(1, [
+			{ index: '1', level: 2, line: 'History', editable: true },
+			{ index: 'T-1', level: 3, line: 'From a template', editable: false },
+			{ index: '2', level: 3, line: 'Origins', editable: true },
+		]);
+
+		expect(info).toMatchObject({ sections: ['2 (Origins)'] });
+	});
+});

--- a/tests/services/sectionService.test.ts
+++ b/tests/services/sectionService.test.ts
@@ -89,18 +89,28 @@ describe('listInSource', () => {
 });
 
 describe('toOutlineLines', () => {
-	// The published outline is unchanged by this task: a leading empty string
-	// for the lead, then one heading line per section.
-	it('renders the lead as an empty first entry', () => {
+	it('numbers each entry with the section number it is edited by', () => {
 		expect(
 			toOutlineLines([
 				{ index: '1', level: 2, line: 'Etymology', editable: true },
 				{ index: '2', level: 2, line: 'History', editable: true },
 			]),
-		).toEqual(['', 'Etymology', 'History']);
+		).toEqual(['0 (Lead)', '1 (Etymology)', '2 (History)']);
+	});
+
+	// A transcluded heading occupies a position in the outline but is not
+	// addressable by section number, so listing it shifts every later heading
+	// away from the number that edits it.
+	it('omits transcluded headings, which no section number addresses', () => {
+		expect(
+			toOutlineLines([
+				{ index: 'T-1', level: 2, line: 'From a template', editable: false },
+				{ index: '1', level: 2, line: 'Etymology', editable: true },
+			]),
+		).toEqual(['0 (Lead)', '1 (Etymology)']);
 	});
 
 	it('renders a page with no headings as the lead alone', () => {
-		expect(toOutlineLines([])).toEqual(['']);
+		expect(toOutlineLines([])).toEqual(['0 (Lead)']);
 	});
 });

--- a/tests/tools/get-page.test.ts
+++ b/tests/tools/get-page.test.ts
@@ -374,7 +374,7 @@ describe('get-page', () => {
 
 		const text = assertStructuredSuccess(result);
 		expect(text).toContain('Size: 12345');
-		expect(text).toContain('Sections:\n- (empty)\n- History\n- Background');
+		expect(text).toContain('Sections:\n- 0 (Lead)\n- 1 (History)\n- 2 (Background)');
 	});
 
 	it('attaches content-truncated truncation when source exceeds the byte cap', async () => {
@@ -393,7 +393,7 @@ describe('get-page', () => {
 				],
 			}),
 			request: vi.fn().mockResolvedValue({
-				parse: { sections: [{ line: 'History' }] },
+				parse: { sections: [{ line: 'History', index: '1', level: '2' }] },
 			}),
 		});
 		const ctx = fakeContext({
@@ -419,7 +419,7 @@ describe('get-page', () => {
 		expect(text).toContain('  Total bytes: 50001');
 		expect(text).toContain('  Item noun: wikitext');
 		expect(text).toContain('  Tool name: get-page');
-		expect(text).toContain('  Sections:\n  - (empty)\n  - History');
+		expect(text).toContain('  Sections:\n  - 0 (Lead)\n  - 1 (History)');
 	});
 
 	it('omits truncation when source is exactly at the byte cap', async () => {
@@ -459,7 +459,9 @@ describe('get-page', () => {
 		const request = vi
 			.fn()
 			.mockResolvedValueOnce({ parse: { text: bigHtml } })
-			.mockResolvedValueOnce({ parse: { sections: [{ line: 'Heading' }] } });
+			.mockResolvedValueOnce({
+				parse: { sections: [{ line: 'Heading', index: '1', level: '2' }] },
+			});
 		const mock = createMockMwn({ request });
 		const ctx = fakeContext({
 			mwn: async () => mock as never,
@@ -483,7 +485,97 @@ describe('get-page', () => {
 		expect(text).toContain('  Returned bytes: 50000');
 		expect(text).toContain('  Item noun: HTML');
 		expect(text).toContain('  Tool name: get-page');
-		expect(text).toContain('  Sections:\n  - (empty)\n  - Heading');
+		expect(text).toContain('  Sections:\n  - 0 (Lead)\n  - 1 (Heading)');
+	});
+
+	// A caller that already passed section=N cannot narrow by passing it again,
+	// so the marker names that section's own subsections instead of the outline
+	// of a page it did not ask for.
+	it("lists the requested section's subsections when a section read is truncated", async () => {
+		const list = vi.fn().mockResolvedValue([
+			{ index: '1', level: 2, line: 'History', editable: true },
+			{ index: '2', level: 3, line: 'Origins', editable: true },
+			{ index: '3', level: 3, line: 'Modern era', editable: true },
+			{ index: '4', level: 2, line: 'Geography', editable: true },
+		]);
+		const mock = createMockMwn({
+			read: vi.fn().mockResolvedValue({
+				pageid: 1,
+				title: 'Big',
+				revisions: [{ revid: 42, contentmodel: 'wikitext', content: 'x'.repeat(50001) }],
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			sections: { list, listInSource: vi.fn() },
+		});
+
+		const result = await getPage.handle(
+			{ title: 'Big', content: ContentFormat.source, metadata: false, section: 1 },
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('  Sections:\n  - 2 (Origins)\n  - 3 (Modern era)');
+		expect(text).not.toContain('Geography');
+		expect(text).toContain('subsection numbers');
+	});
+
+	it('reports that no narrower read exists when the truncated section has no subsections', async () => {
+		const list = vi.fn().mockResolvedValue([
+			{ index: '1', level: 2, line: 'History', editable: true },
+			{ index: '2', level: 2, line: 'Geography', editable: true },
+		]);
+		const mock = createMockMwn({
+			read: vi.fn().mockResolvedValue({
+				pageid: 1,
+				title: 'Big',
+				revisions: [{ revid: 42, contentmodel: 'wikitext', content: 'x'.repeat(50001) }],
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			sections: { list, listInSource: vi.fn() },
+		});
+
+		const result = await getPage.handle(
+			{ title: 'Big', content: ContentFormat.source, metadata: false, section: 1 },
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('No narrower read returns more of this section');
+		expect(text).toContain("mode='append'");
+		// Naming the sections of a page the caller did not ask for is what sent it
+		// back to the call it had just made.
+		expect(text).not.toContain('Sections:');
+		expect(text).not.toContain('Geography');
+	});
+
+	// The lead has no heading of its own, so childrenOf finds no entry for it.
+	it('reports that no narrower read exists when a truncated lead read has no subsections', async () => {
+		const list = vi
+			.fn()
+			.mockResolvedValue([{ index: '1', level: 2, line: 'History', editable: true }]);
+		const mock = createMockMwn({
+			read: vi.fn().mockResolvedValue({
+				pageid: 1,
+				title: 'Big',
+				revisions: [{ revid: 42, contentmodel: 'wikitext', content: 'x'.repeat(50001) }],
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			sections: { list, listInSource: vi.fn() },
+		});
+
+		const result = await getPage.handle(
+			{ title: 'Big', content: ContentFormat.source, metadata: false, section: 0 },
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('No narrower read returns more of this section');
 	});
 
 	it('builds the page URL from the public siteinfo server, not the configured server', async () => {

--- a/tests/tools/get-pages.test.ts
+++ b/tests/tools/get-pages.test.ts
@@ -542,9 +542,9 @@ describe('get-pages', () => {
 					pages: [massQueryPage('Big', 1, 10, big), massQueryPage('Small', 2, 20, small)],
 				}),
 			);
-			const request = vi
-				.fn()
-				.mockResolvedValueOnce({ parse: { sections: [{ line: 'Overview' }] } });
+			const request = vi.fn().mockResolvedValueOnce({
+				parse: { sections: [{ line: 'Overview', index: '1', level: '2' }] },
+			});
 			const mock = createMockMwn({ massQuery, request });
 			const ctx = fakeContext({
 				mwn: async () => mock as never,
@@ -572,7 +572,7 @@ describe('get-pages', () => {
 			expect(text).toContain('    Total bytes: 50001');
 			expect(text).toContain('    Item noun: wikitext');
 			expect(text).toContain('    Tool name: get-pages');
-			expect(text).toContain('    Sections:\n    - (empty)\n    - Overview');
+			expect(text).toContain('    Sections:\n    - 0 (Lead)\n    - 1 (Overview)');
 			expect(text).toContain(`  Source: ${small}`);
 			// Small entry has no truncation: block under it. We can verify only one Truncation block exists.
 			const truncationCount = (text.match(/Truncation:/g) ?? []).length;


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/536

A cut page or section body is now a byte-exact prefix of what the page holds. The cut moves back to a character boundary instead of splitting a multi-byte character, which Node decoded as U+FFFD: that put a character in the caller's copy that the page never contained, and pushed the response past the byte cap it reported against.

The section list a read reports now labels each entry with the number that edits it, taken from the API's own `index`, and leaves out headings that arrive by transclusion. Numbering by position sent a caller to a different section than the one it had read, because a transcluded heading holds a position that no `section=` value addresses. This is the outline in every `metadata=true` response as well as the one on a truncated read, which is why it is recorded under `Changed`.

A truncated read no longer offers a narrowing that returns the same bytes. A `section=N` read names that section's own subsections; a section with none says so, and so does a page with no sections at all, whose section 0 *is* the page. This is what the result-cap convention in `docs/tool-conventions.md` already required.

Each remedy stays inside the 120-character limit `formatPayload` renders against, so the sentence appears inside the marker rather than as an unindented block below it.

## One builder for the section marker

Both section-aware reads build the marker through `sectionContentTruncation`, so its variants and their wording are decided in one place. `get-pages` previously carried its own copy of the whole-page remedy sentence, and a third such tool would have carried a third. `editableChildrenOf` in `sectionSubtree.ts` holds the "children a caller can address and supply" rule that this and the subsection guard both need.

The remedy for a diff, a rendered fragment or a row listing stays with the tool that owns it. There are six `content-truncated` producers and four have a remedy that is theirs alone (`compare-pages` points at a narrower revision range, `parse-wikitext` at a smaller fragment, `wikibase-get-entity` computes one from its hidden-property counts), so a universal builder would take a parameter per caller and decide nothing.

`ResponseFormatterImpl.truncationMarker` is deleted. Nothing in `src` called it — `formatPayload` renders the `truncation` field into `content[0]` and `structuredContent` carries it typed — so it was a seam that looked central while contributing nothing, and the convention described its output as if it shipped. It had also gone stale: it numbered sections by array position, which on top of the fixed `index` labels would render `0 (2 (First Sub))`. Three tool descriptions still promised that trailing marker and no longer do.

Whether the prose channel should carry a one-sentence marker instead of `formatPayload`'s key-value block is specced separately in #606, since it changes the visible output of all six capped tools.

## What this does not do

The silent data loss in #536 is untouched: writing a truncated body back still deletes the remainder. That needs the anchored write and the write-side guard, which follow separately.

## Verified

Against a live MediaWiki 1.43.9, on a 130 KB fixture whose section 1 is 65 KB with two subsections and whose section 4 is 65 KB with none:

| Read | Marker |
|---|---|
| `section=1` | `Sections: 2 (First Sub), 3 (Second Sub)`, remedy pointing at those numbers |
| `section=4` | no section list; "No narrower read returns more of this section" |
| whole page | `0 (Lead)` through `5 (Small)`, numbered by section |
| a page with no headings | no section list; "The page has no sections" |

The CJK body came back at 49,999 bytes ending on a character boundary, where it would previously have been 50,002 bytes ending in `�`.

2206 tests, `typecheck`, `lint` and `fmt:check` green.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; one-line ask from @alistair3149 that then opened into a wider design question, steered through five explicit decisions including a redirect on this PR's shape; diff not yet human-reviewed, but reviewed by a fresh-context reviewer agent whose findings are all fixed here; tests written first and seen failing before each fix, full suite and gates run locally, marker output checked against a live MediaWiki 1.43.9 rather than asserted.</sub>