### PR TITLE
Add an operation argument to update-page, with a find-replace write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 
 - `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from. A call that omits `namespaces` searches the main namespace, which was always the case but went unstated; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.
+- `update-page` can now rewrite one passage of a page without resending the rest: `operation='find-replace'` takes `find`, the existing wikitext to change, and `replaceWith`, what it becomes. The server holds the page and applies the change, so a large page no longer has to travel to or from the caller to be edited. `find` is matched in full and exactly; one that matches nothing, or more than one place, is refused without writing.
+- `update-page` takes an `operation` argument naming what the write does — `replace`, `append`, `prepend` or `find-replace` — where the choice was previously inferred from which other arguments were present. `section` now reads as the scope of the write rather than as a mode of its own: `operation` says what, `section` says where.
 
 ### Changed
 
-- `update-page` now documents that `mode` can be scoped with `section`: `mode='append'` writes at the end of the named section, and `mode='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
+- `update-page`'s `mode` argument is deprecated in favour of `operation`, which spells the same choice and adds `find-replace`. Calls sending `mode='append'` or `mode='prepend'` keep working; a call sending both is refused when they disagree.
+- `update-page` now documents that a delta can be scoped with `section`: `operation='append'` writes at the end of the named section, and `operation='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
 - The section list `get-page` and `get-pages` report now labels each section with the number that edits it, as `1 (History)` where it was `History`, and leaves out headings that arrive by transclusion. This is the outline in every `metadata=true` response as well as the one attached to a truncated read. The list previously numbered by position, and a transcluded heading holds a position that no section number addresses, so on any page carrying one every later entry named a different section than the one it pointed at.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `undelete-page` 🔐 | Undelete a wiki page. | `Delete pages, revisions, and log entries` |
 | `update-file` 🔐 | Upload a new revision of an existing file from local disk. | `Upload, replace, and move files` |
 | `update-file-from-url` 🔐 | Upload a new revision of an existing file from a URL. | `Upload, replace, and move files` |
-| `update-page` 🔐 | Update an existing wiki page. | `Edit existing pages` |
+| `update-page` 🔐 | Update an existing wiki page: overwrite it, add to it, or rewrite one passage of it. | `Edit existing pages` |
 | `upload-file` 🔐 | Upload a file to the wiki from local disk. | `Upload new files` |
 | `upload-file-from-url` 🔐 | Upload a file to the wiki from a URL. | `Upload, replace, and move files` |
 

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -68,7 +68,7 @@ Do not restate this in prose. Prose is for context the schema cannot express.
 
 - **Tool names** appear bare in prose (`get-page`, not in backticks).
 - **Parameter names alone** appear bare (e.g., "paginate with continueFrom"). Use backticks only when the bare form would collide with an English word (e.g., the `wiki` parameter in `oauth-logout`).
-- **Parameter assignments** are bare for primitive RHS (`section=N`, `metadata=true`) and use single quotes for enum string values (`mode='append'`, `mode='prepend'`).
+- **Parameter assignments** are bare for primitive RHS (`section=N`, `metadata=true`) and use single quotes for enum string values (`operation='append'`, `operation='find-replace'`).
 - **Wiki syntax and code identifiers** use backticks: `[[Category:Person]]`, `_pageData`, `bucket("exchange")`, `MCP_CONTENT_MAX_BYTES`.
 
 #### Avoid tautology
@@ -177,7 +177,7 @@ Semantics (from the MCP 2025-11-25 spec):
 - Pure read-only tools: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: true` (for tools that read from the wiki).
 - Write tools that delete, overwrite, or remove: `readOnlyHint: false`, `destructiveHint: true`.
 - Write tools that only add (create, append, upload-new): `readOnlyHint: false`, `destructiveHint: false`.
-- If idempotency depends on which parameters a call uses (an `update-page` full-page replace is idempotent; `mode='append'` is not), declare the weakest case: `idempotentHint: false`.
+- If idempotency depends on which parameters a call uses (an `update-page` full-page replace is idempotent; `operation='append'` is not), declare the weakest case: `idempotentHint: false`.
 - If the tool does not make network calls and only mutates server-local state (e.g. `add-wiki` / `remove-wiki` editing the wiki registry), `openWorldHint: false`.
 
 #### Tool titles

--- a/src/services/sectionMarker.ts
+++ b/src/services/sectionMarker.ts
@@ -63,7 +63,7 @@ export function sectionContentTruncation({
 		return {
 			...base,
 			remedyHint:
-				"No narrower read returns more of this section. To add to it without resending it, use update-page with mode='append'.",
+				"No narrower read returns more of this section. To change part of it, use update-page with operation='find-replace'.",
 		};
 	}
 	return {

--- a/src/tools/create-page.ts
+++ b/src/tools/create-page.ts
@@ -26,7 +26,7 @@ const inputSchema = {
 export const createPage: Tool<typeof inputSchema> = {
 	name: 'create-page',
 	description:
-		"Creates a new wiki page with the provided content and returns the new page's title, page ID, and first revision ID. Fails if a page with the given title already exists; for existing pages, use update-page. The optional contentModel parameter selects a non-default content format (e.g. javascript, css); when omitted, MediaWiki picks the default for the title's namespace. For building up a large page across multiple calls, pair create-page with chained update-page(mode='append') calls, each adding a chunk.",
+		"Creates a new wiki page with the provided content and returns the new page's title, page ID, and first revision ID. Fails if a page with the given title already exists; for existing pages, use update-page. The optional contentModel parameter selects a non-default content format (e.g. javascript, css); when omitted, MediaWiki picks the default for the title's namespace. For building up a large page across multiple calls, pair create-page with chained update-page(operation='append') calls, each adding a chunk.",
 	inputSchema,
 	annotations: {
 		title: 'Create page',

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -6,6 +6,9 @@ import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
 import { editableChildrenOf } from '../services/sectionSubtree.ts';
 
+const OPERATIONS = ['replace', 'append', 'prepend', 'find-replace'] as const;
+type Operation = (typeof OPERATIONS)[number];
+
 interface ApiEditResponse {
 	result?: string;
 	pageid?: number;
@@ -20,14 +23,34 @@ interface ApiEditResponse {
 // below once the release carrying that removal has shipped — see the Breaking
 // changes entry in CHANGELOG.md.
 const SECTION_NEW_REMOVED =
-	'update-page no longer creates sections. To add one, use mode=\'append\' with a source that begins with the heading, for example "\\n\\n== History ==\\n\\nBody.".';
+	'update-page no longer creates sections. To add one, use operation=\'append\' with a source that begins with the heading, for example "\\n\\n== History ==\\n\\nBody.".';
 
 const inputSchema = {
 	title: z.string().describe('Wiki page title'),
+	operation: z
+		.enum(OPERATIONS)
+		.optional()
+		.describe(
+			"What the write does to the target: 'replace' overwrites it with source, 'append' and 'prepend' add source to it, and 'find-replace' rewrites only the text find names and leaves the rest of the target byte for byte. With section=N, 'append' writes at the end of that section and 'prepend' immediately above that section's heading, which inserts a new section before an existing one. Defaults to 'replace'.",
+		),
 	source: z
 		.string()
+		.optional()
 		.describe(
-			'The content to write, in the existing page\'s content model. Interpreted as the full page by default; as the given section\'s content when section is set; or as a delta (appended or prepended) when mode is set. An appended source that opens a new section must begin on its own line, as in "\\n\\n== History ==\\n\\nBody."; without the leading newline the heading runs on from the last line of the page and is not recognised as a heading.',
+			'The content to write, in the existing page\'s content model. Required for every operation except find-replace, and refused for that one. An appended source that opens a new section must begin on its own line, as in "\\n\\n== History ==\\n\\nBody."; without the leading newline the heading runs on from the last line of the page and is not recognised as a heading.',
+		),
+	find: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			"The existing wikitext to rewrite, matched in full and exactly, whitespace and template markup included. Required when operation is 'find-replace'. A find that matches nothing, or more than one place, is refused without writing: extend it with the text around it to name one occurrence.",
+		),
+	replaceWith: z
+		.string()
+		.optional()
+		.describe(
+			"What find becomes. Required when operation is 'find-replace'; an empty string deletes the text find matched.",
 		),
 	latestId: z
 		.number()
@@ -46,15 +69,13 @@ const inputSchema = {
 		.nonnegative()
 		.optional()
 		.describe(
-			"Section number (0 = lead; 1..N = heading sections). Replaces that section's content, along with every subsection nested under it; see removeSubsections.",
+			'Section number (0 = lead; 1..N = heading sections), from the section list get-page reports. Confines the write to that section: omit it to act on the whole page. A replace also takes out every subsection nested under the section; see removeSubsections.',
 		),
 	mode: z
 		.enum(['append', 'prepend'])
 		.optional()
 		.describe(
-			"Adds source to the existing content instead of replacing it: 'append' to the end, 'prepend' to the start. " +
-				"With section=N, 'append' writes at the end of that section and 'prepend' immediately above that section's " +
-				'heading, which inserts a new section before an existing one.',
+			"Deprecated older spelling of operation='append' and operation='prepend'. Send operation instead.",
 		),
 	bot: z
 		.boolean()
@@ -72,23 +93,108 @@ const inputSchema = {
 
 type UpdatePageArgs = z.infer<z.ZodObject<typeof inputSchema>>;
 
-function buildEditParams(
+// The operation a call means, resolved once with the fields it needs already
+// narrowed. `mode` is the older spelling of the same choice and stays accepted.
+// Which fields an operation requires is a rule the flat schema cannot state —
+// every field is independently optional — so it is stated here instead, and
+// each refusal names both the field and the operation that decided it.
+type WritePlan =
+	| { readonly error: string }
+	| { readonly operation: 'find-replace'; readonly find: string; readonly replaceWith: string }
+	| { readonly operation: 'replace' | 'append' | 'prepend'; readonly source: string };
+
+function writePlan(args: UpdatePageArgs): WritePlan {
+	const { operation, mode, source, find, replaceWith } = args;
+	if (operation !== undefined && mode !== undefined && operation !== mode) {
+		return {
+			error: `operation is '${operation}' but mode is '${mode}'. mode is the older spelling of the same choice; send operation alone.`,
+		};
+	}
+	const resolved: Operation = operation ?? mode ?? 'replace';
+	if (resolved === 'find-replace') {
+		if (find === undefined || replaceWith === undefined) {
+			return {
+				error:
+					"operation 'find-replace' needs find, the existing wikitext to rewrite, and replaceWith, what it becomes.",
+			};
+		}
+		if (source !== undefined) {
+			return {
+				error:
+					"operation 'find-replace' rewrites only the text find matches, so it takes no source. To overwrite the whole target instead, send source with operation 'replace'.",
+			};
+		}
+		return { operation: resolved, find, replaceWith };
+	}
+	if (source === undefined) {
+		return { error: `operation '${resolved}' needs source, the content to write.` };
+	}
+	if (find !== undefined || replaceWith !== undefined) {
+		return {
+			error: `find and replaceWith belong to operation 'find-replace', not '${resolved}'.`,
+		};
+	}
+	if (
+		args.removeSubsections !== undefined &&
+		(resolved !== 'replace' || args.section === undefined)
+	) {
+		return {
+			error:
+				"removeSubsections confirms a section replace that drops the subsections nested under it, so it applies only to operation 'replace' with section set.",
+		};
+	}
+	return { operation: resolved, source };
+}
+
+// Every write shares its title, summary, scope and flags; only the field
+// carrying the content and the revision it is based on differ by operation.
+function commonEditParams(
 	ctx: ToolContext,
-	{ title, source, latestId, comment, section, mode, bot }: UpdatePageArgs,
+	{ title, comment, section, bot }: UpdatePageArgs,
 ): Record<string, string | number | boolean> {
-	const sourceField =
-		mode === 'append' ? 'appendtext' : mode === 'prepend' ? 'prependtext' : 'text';
 	const summary = formatEditComment(ctx, 'update-page', comment);
 	return {
 		action: 'edit',
 		title,
 		...(summary !== undefined ? { summary } : {}),
 		nocreate: true,
-		[sourceField]: source,
-		...(latestId !== undefined ? { baserevid: latestId } : {}),
 		...(section !== undefined ? { section: String(section) } : {}),
 		...(bot === true ? { bot: true } : {}),
 	};
+}
+
+function buildEditParams(
+	ctx: ToolContext,
+	args: UpdatePageArgs,
+	plan: { operation: 'replace' | 'append' | 'prepend'; source: string },
+): Record<string, string | number | boolean> {
+	const sourceField =
+		plan.operation === 'append'
+			? 'appendtext'
+			: plan.operation === 'prepend'
+				? 'prependtext'
+				: 'text';
+	return {
+		...commonEditParams(ctx, args),
+		[sourceField]: plan.source,
+		...(args.latestId !== undefined ? { baserevid: args.latestId } : {}),
+	};
+}
+
+// Advances one character at a time, not by the needle's length: a needle that
+// can begin inside its own previous match names two different splices, and
+// String#split would report one. Self-overlapping strings are ordinary in
+// wikitext — `}}\n}}`, `\n\n`, `==\n\n==`.
+function occurrenceCount(haystack: string, needle: string): number {
+	let count = 0;
+	for (let at = haystack.indexOf(needle); at !== -1; at = haystack.indexOf(needle, at + 1)) {
+		count++;
+	}
+	return count;
+}
+
+function scopeName(title: string, section: number | undefined): string {
+	return section === undefined ? `page "${title}"` : `section ${section} of "${title}"`;
 }
 
 // Replacing a section replaces everything nested under it. A source that brings
@@ -99,11 +205,12 @@ function buildEditParams(
 // side. Headings are counted rather than matched by text, so a rename passes.
 async function subsectionRemovalError(
 	args: UpdatePageArgs,
+	source: string,
 	ctx: ToolContext,
 	mwn: Mwn,
 ): Promise<string | undefined> {
-	const { section, source, mode, removeSubsections } = args;
-	if (section === undefined || mode !== undefined || removeSubsections === true) {
+	const { section, removeSubsections } = args;
+	if (section === undefined || removeSubsections === true) {
 		return undefined;
 	}
 	// The lead has no heading and cannot contain a subsection.
@@ -136,10 +243,141 @@ async function subsectionRemovalError(
 	return `Section ${index} (${parent.line}) contains ${children.length} subsection${children.length === 1 ? '' : 's'}: ${names}. The source supplied would remove them. Include them in source to keep them, or pass removeSubsections: true to remove them deliberately.`;
 }
 
+// Submits a built edit and shapes the response. Shared by every operation, so
+// one place decides what a successful write reports.
+async function submitEdit(
+	ctx: ToolContext,
+	mwn: Mwn,
+	params: Record<string, string | number | boolean>,
+	args: UpdatePageArgs,
+): Promise<CallToolResult> {
+	const response =
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		(await ctx.edit.submit(mwn, params)) as { edit?: ApiEditResponse } | undefined;
+	const edit = response?.edit;
+	if (!edit || edit.result !== 'Success') {
+		return ctx.format.error(
+			'upstream_failure',
+			`Failed to update page: ${JSON.stringify(edit ?? response)}`,
+		);
+	}
+	const resolvedTitle = edit.title ?? args.title;
+	return ctx.format.ok({
+		pageId: edit.pageid,
+		title: resolvedTitle,
+		latestRevisionId: edit.newrevid,
+		latestRevisionTimestamp: edit.newtimestamp,
+		contentModel: edit.contentmodel,
+		...(args.bot === true ? { botMarked: await ctx.edit.botRight(mwn) } : {}),
+		url: await buildPageUrl(ctx, resolvedTitle),
+	});
+}
+
+// The server holds the target and the caller holds only the text it is
+// changing, so the bytes the caller never sent are the bytes that cannot be
+// lost. `find` is matched in full and exactly: a fuzzy or whitespace-tolerant
+// match would change what a page means, since a single leading space turns a
+// wikitext line into a `<pre>` block. The splice is by index rather than
+// String#replace, which would read `$&` and `$1` in the replacement as
+// references to the match.
+async function findReplace(
+	args: UpdatePageArgs,
+	plan: { find: string; replaceWith: string },
+	ctx: ToolContext,
+	mwn: Mwn,
+): Promise<CallToolResult> {
+	const { title, section, latestId } = args;
+	const { find, replaceWith } = plan;
+	const readParams: Record<string, string | number | boolean> = {
+		rvprop: 'ids|content',
+		// mwn.read follows redirects by default, which would resolve the title to
+		// the redirect's target while the edit below still goes to the title the
+		// caller named — splicing the target's text over the redirect page and
+		// leaving the target untouched.
+		redirects: false,
+	};
+	if (section !== undefined) {
+		readParams.rvsection = section;
+	}
+	const page = await mwn.read(title, readParams);
+	if (page.missing) {
+		return ctx.format.notFound(`Page "${title}" not found`);
+	}
+	if (page.invalid) {
+		return ctx.format.invalidInput(`"${title}" is not a valid page title`);
+	}
+	const rev = page.revisions?.[0];
+	const current = rev?.content;
+	if (typeof current !== 'string') {
+		// The API answers all three of these with a slot carrying no content
+		// rather than with an error, so the tool has to tell them apart itself.
+		if (section !== undefined) {
+			// Matching what the dispatcher reports when the wiki raises this on a
+			// write, so one condition does not have two names.
+			return ctx.format.notFound(`Section ${section} does not exist`, 'nosuchsection');
+		}
+		// mwn's ApiRevision does not declare the flag MediaWiki sets on a revision
+		// whose text is hidden, so it is read structurally.
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		if ((rev as { texthidden?: boolean } | undefined)?.texthidden === true) {
+			return ctx.format.permissionDenied(
+				`The current revision of "${title}" has its text hidden, so it cannot be read to edit`,
+			);
+		}
+		return ctx.format.error('upstream_failure', `The wiki returned no content for "${title}"`);
+	}
+	// The anchor makes a splice tolerant of edits that did not touch it, so
+	// latestId keeps the meaning it has everywhere else: the caller asked to be
+	// refused if the page moved on at all.
+	if (latestId !== undefined && rev?.revid !== latestId) {
+		return ctx.format.conflict(
+			`Page "${title}" is at revision ${rev?.revid}, not ${latestId}, so it has been edited since the revision named. Re-read it and send the edit again.`,
+		);
+	}
+
+	const scope = scopeName(title, section);
+	const occurrences = occurrenceCount(current, find);
+	if (occurrences === 0) {
+		// A retried call whose first attempt landed looks exactly like a bad
+		// anchor, and saying so saves the caller a wasted retry. It is claimed
+		// only when replaceWith is at least as specific as the find it replaced
+		// and sits in the target exactly once, because a short replacement that
+		// merely happens to occur would assert an edit that never happened —
+		// the one direction of error that costs the caller its change.
+		const applied =
+			replaceWith.length >= find.length && occurrenceCount(current, replaceWith) === 1
+				? ' The text replaceWith names is already present, so this edit may have landed already.'
+				: '';
+		return ctx.format.invalidInput(
+			`No replacement was made: find did not appear in ${scope}.${applied} Read the current wikitext with get-page and copy find from it exactly, whitespace and template markup included.`,
+		);
+	}
+	if (occurrences > 1) {
+		return ctx.format.invalidInput(
+			`No replacement was made: find appears ${occurrences} times in ${scope}. Extend find with the text around it so it names one occurrence${section === undefined ? ', or set section to search one section only' : ''}.`,
+		);
+	}
+
+	const at = current.indexOf(find);
+	const updated = current.slice(0, at) + replaceWith + current.slice(at + find.length);
+	return submitEdit(
+		ctx,
+		mwn,
+		{
+			...commonEditParams(ctx, args),
+			text: updated,
+			// The base for this write is the revision the splice was computed
+			// from, which is the one just read, never a revision the caller named.
+			...(rev?.revid !== undefined ? { baserevid: rev.revid } : {}),
+		},
+		args,
+	);
+}
+
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Replaces the existing content of a wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. Pass latestId (obtained from get-page with metadata=true) to enable edit-conflict detection: if the page has been edited since that revision, the update is rejected rather than silently clobbering concurrent changes. For large pages, two modifiers avoid shipping the full source: section=N replaces one section together with every subsection nested under it, and is refused when source would drop those subsections; paired with get-page section=N it reads, changes and writes back a single section, which is also how to add content in the middle of a page; mode='append' or 'prepend' sends a delta, and adding a new section at the end of the page means appending a source that begins with a heading. Each call is a separate revision; for chains of mode='append' calls, re-fetching latestId between calls confirms the previous chunk landed before the next. Resending a mode='append' or 'prepend' call whose result never arrived adds the delta a second time.",
+		"Writes to an existing wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. operation says what the write does and section says where: omit section to act on the whole page, or set it to confine the write to one section. For changing part of a page, use operation='find-replace', which carries only the text being rewritten, so nothing outside find can be lost and the rest of the page never has to travel to or from the caller; a find that matches nothing, or more than one place, is refused without writing, which also makes it safe to resend a call whose result never arrived. For replacing a target outright, use operation='replace', whose source must carry every byte meant to survive; with section set it also takes out every subsection nested under that section, and is refused when source would drop them. operation='append' and 'prepend' add a delta: a new section at the end of the page is an append whose source begins with the heading, and with section set a prepend inserts one immediately above that section. Pass latestId (from get-page with metadata=true) for edit-conflict detection: the write is rejected rather than silently clobbering a concurrent change. Each call is a separate revision, and resending an append or prepend whose result never arrived adds the delta a second time.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',
@@ -152,32 +390,24 @@ export const updatePage: Tool<typeof inputSchema> = {
 	target: (a) => a.title,
 
 	async handle(args, ctx: ToolContext): Promise<CallToolResult> {
+		const plan = writePlan(args);
+		if ('error' in plan) {
+			return ctx.format.invalidInput(plan.error);
+		}
 		const mwn = await ctx.mwn();
-		const removalError = await subsectionRemovalError(args, ctx, mwn);
-		if (removalError) {
-			return ctx.format.invalidInput(removalError);
+
+		if (plan.operation === 'find-replace') {
+			return findReplace(args, plan, ctx, mwn);
 		}
-		const response =
-			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
-			(await ctx.edit.submit(mwn, buildEditParams(ctx, args))) as
-				| { edit?: ApiEditResponse }
-				| undefined;
-		const edit = response?.edit;
-		if (!edit || edit.result !== 'Success') {
-			return ctx.format.error(
-				'upstream_failure',
-				`Failed to update page: ${JSON.stringify(edit ?? response)}`,
-			);
+
+		// Only a replace takes the section's subtree with it; a delta adds to the
+		// section and removes nothing.
+		if (plan.operation === 'replace') {
+			const removalError = await subsectionRemovalError(args, plan.source, ctx, mwn);
+			if (removalError) {
+				return ctx.format.invalidInput(removalError);
+			}
 		}
-		const resolvedTitle = edit.title ?? args.title;
-		return ctx.format.ok({
-			pageId: edit.pageid,
-			title: resolvedTitle,
-			latestRevisionId: edit.newrevid,
-			latestRevisionTimestamp: edit.newtimestamp,
-			contentModel: edit.contentmodel,
-			...(args.bot === true ? { botMarked: await ctx.edit.botRight(mwn) } : {}),
-			url: await buildPageUrl(ctx, resolvedTitle),
-		});
+		return submitEdit(ctx, mwn, buildEditParams(ctx, args, plan), args);
 	},
 };

--- a/tests/tools/get-page.test.ts
+++ b/tests/tools/get-page.test.ts
@@ -545,7 +545,7 @@ describe('get-page', () => {
 
 		const text = assertStructuredSuccess(result);
 		expect(text).toContain('No narrower read returns more of this section');
-		expect(text).toContain("mode='append'");
+		expect(text).toContain("operation='find-replace'");
 		// Naming the sections of a page the caller did not ask for is what sent it
 		// back to the call it had just made.
 		expect(text).not.toContain('Sections:');

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -296,7 +296,7 @@ describe('update-page', () => {
 				section: 'new',
 			});
 
-			expect(assertRefusedArgument(result)).toContain("mode='append'");
+			expect(assertRefusedArgument(result)).toContain("operation='append'");
 			expect(submit).not.toHaveBeenCalled();
 		});
 
@@ -725,5 +725,408 @@ describe('update-page', () => {
 			expect(envelope.message).toContain('source parse failed');
 			expect(submit).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('update-page find-replace', () => {
+	const PAGE =
+		'Lead text.\n\n== History ==\nThe city was founded in 1104.\n\n== Geography ==\nThe river runs east.\n';
+
+	// The whole point of the operation is that the server holds the page and the
+	// caller holds only the text it is changing, so the read is part of the tool.
+	function fakeFindReplace(current: string = PAGE, revid = 41) {
+		const base = fakeEdit();
+		const read = vi.fn().mockResolvedValue({
+			pageid: 5,
+			title: 'My Page',
+			revisions: [{ revid, content: current }],
+		});
+		const mock = createMockMwn({
+			read,
+			request: base.request,
+			getCsrfToken: vi.fn().mockResolvedValue('csrf-token'),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never, edit: base.ctx.edit });
+		return { ...base, ctx, read };
+	}
+
+	it('rewrites the single match and submits the whole target', async () => {
+		const { submit, ctx } = fakeFindReplace();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1104',
+			replaceWith: 'founded in 1105',
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit.mock.calls[0][1]).toMatchObject({
+			text: PAGE.replace('founded in 1104', 'founded in 1105'),
+			nocreate: true,
+			// The base for the server's own splice is the revision it just read,
+			// not a revision the caller named.
+			baserevid: 41,
+		});
+	});
+
+	it('leaves every byte outside the match alone', async () => {
+		const { submit, ctx } = fakeFindReplace();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'The river runs east.',
+			replaceWith: 'The river runs west.',
+		});
+
+		const written = submit.mock.calls[0][1].text as string;
+		expect(written).toContain('Lead text.');
+		expect(written).toContain('The city was founded in 1104.');
+		expect(written.length).toBe(PAGE.length);
+	});
+
+	it('refuses when find matches nothing, and says where to copy it from', async () => {
+		const { submit, ctx } = fakeFindReplace();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1204',
+			replaceWith: 'founded in 1105',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('did not appear');
+		expect(envelope.message).toContain('get-page');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// A retried call whose first attempt landed looks exactly like a bad anchor,
+	// so the refusal distinguishes them.
+	it('reports that the replacement is already present when find is gone', async () => {
+		const { ctx, submit } = fakeFindReplace();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1105',
+			replaceWith: 'The river runs east.',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('already present');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// Claiming an edit already landed when it did not costs the caller its change,
+	// so a replacement that merely happens to occur does not earn the claim.
+	it('does not claim the edit landed when replaceWith is a short incidental match', async () => {
+		const { ctx, submit } = fakeFindReplace();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1204',
+			replaceWith: 'e',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('did not appear');
+		expect(envelope.message).not.toContain('already present');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('refuses when find matches more than once, naming the count', async () => {
+		const { submit, ctx } = fakeFindReplace('a\nrepeat me\nb\nrepeat me\nc\nrepeat me\n');
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'repeat me',
+			replaceWith: 'once',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('3 times');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('narrows both the search and the write to one section', async () => {
+		const { submit, ctx, read } = fakeFindReplace('== History ==\nThe river runs east.\n');
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			section: 1,
+			find: 'runs east',
+			replaceWith: 'runs west',
+		});
+
+		expect(read.mock.calls[0][1]).toMatchObject({ rvsection: 1 });
+		expect(submit.mock.calls[0][1]).toMatchObject({ section: '1' });
+	});
+
+	// String#replace reads $&, $1 and friends as references to the match.
+	it('writes replaceWith literally, including dollar sequences', async () => {
+		const { submit, ctx } = fakeFindReplace('Template call: {{foo}}\n');
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: '{{foo}}',
+			replaceWith: '{{bar|$1=$& and $$}}',
+		});
+
+		expect(submit.mock.calls[0][1].text).toBe('Template call: {{bar|$1=$& and $$}}\n');
+	});
+
+	it('deletes the matched text when replaceWith is empty', async () => {
+		const { submit, ctx } = fakeFindReplace('keep\ndrop this line\nkeep\n');
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'drop this line\n',
+			replaceWith: '',
+		});
+
+		expect(submit.mock.calls[0][1].text).toBe('keep\nkeep\n');
+	});
+
+	it('reports a conflict when the page has moved on from the revision the caller read', async () => {
+		const { submit, ctx } = fakeFindReplace(PAGE, 99);
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1104',
+			replaceWith: 'founded in 1105',
+			latestId: 41,
+		});
+
+		assertStructuredError(result, 'conflict');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// The wiki reports this as `nosuchsection` on a write, and the dispatcher
+	// turns that into not_found with this message. Reading it first must not
+	// give the same condition a second name.
+	it('refuses a section the page does not have, as the write path does', async () => {
+		const base = fakeEdit();
+		const read = vi.fn().mockResolvedValue({
+			pageid: 5,
+			title: 'My Page',
+			revisions: [{ nosuchsection: true }],
+		});
+		const mock = createMockMwn({ read, request: base.request });
+		const ctx = fakeContext({ mwn: async () => mock as never, edit: base.ctx.edit });
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			section: 9,
+			find: 'anything',
+			replaceWith: 'x',
+		});
+
+		const envelope = assertStructuredError(result, 'not_found');
+		expect(envelope.message).toBe('Section 9 does not exist');
+		expect(envelope.code).toBe('nosuchsection');
+		expect(base.submit).not.toHaveBeenCalled();
+	});
+
+	// mwn.read follows redirects by default while the edit goes to the title the
+	// caller named, so the read would resolve to the target page and the splice
+	// would land the target's whole text on the redirect.
+	it('reads the title it will write to, not the page it redirects to', async () => {
+		const { ctx, read } = fakeFindReplace();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1104',
+			replaceWith: 'founded in 1105',
+		});
+
+		expect(read.mock.calls[0][1]).toMatchObject({ redirects: false });
+	});
+
+	// A needle that can begin inside its own previous match names two different
+	// splices; String#split reports one of them.
+	it('refuses a find that overlaps itself', async () => {
+		const { submit, ctx } = fakeFindReplace('x}}\n}}\n}}y');
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: '}}\n}}',
+			replaceWith: 'ZZ',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('2 times');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('carries the comment and the bot flag like every other write', async () => {
+		const { submit, ctx } = fakeFindReplace();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'founded in 1104',
+			replaceWith: 'founded in 1105',
+			comment: 'date correction',
+			bot: true,
+		});
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ bot: true });
+		expect(submit.mock.calls[0][1].summary).toContain('date correction');
+	});
+
+	// The subsection guard exists for a replace, which takes the subtree with it.
+	// find-replace changes only the text it matched, so it must not consult the
+	// outline at all.
+	it('does not consult the section outline', async () => {
+		const base = fakeEdit();
+		const read = vi.fn().mockResolvedValue({
+			pageid: 5,
+			title: 'My Page',
+			revisions: [{ revid: 41, content: '== History ==\nThe river runs east.\n' }],
+		});
+		const list = vi.fn();
+		const mock = createMockMwn({ read, request: base.request });
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			edit: base.ctx.edit,
+			sections: { list, listInSource: vi.fn() },
+		});
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			section: 1,
+			find: 'runs east',
+			replaceWith: 'runs west',
+		});
+
+		assertStructuredSuccess(result);
+		expect(list).not.toHaveBeenCalled();
+	});
+});
+
+describe('update-page operation', () => {
+	it('defaults to replacing the whole target', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', { title: 'My Page', source: 'Whole new page' });
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ text: 'Whole new page' });
+	});
+
+	it("sends appendtext for operation='append'", async () => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'append',
+			source: '\n* row',
+		});
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ appendtext: '\n* row' });
+	});
+
+	// mode is the older spelling and stays accepted for a release.
+	it('accepts mode as the older spelling of the same choice', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', { title: 'My Page', source: '\n* row', mode: 'append' });
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ appendtext: '\n* row' });
+	});
+
+	it('refuses a call whose operation and mode disagree', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'prepend',
+			source: 'x',
+			mode: 'append',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('mode');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('accepts operation and mode when they agree', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'append',
+			source: '\n* row',
+			mode: 'append',
+		});
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ appendtext: '\n* row' });
+	});
+
+	// The flag confirms that a section replace is meant to drop the subsections
+	// it takes with it; no other operation takes them.
+	it('refuses removeSubsections outside a section replace', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'append',
+			source: 'x',
+			section: 2,
+			removeSubsections: true,
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('removeSubsections');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('refuses find-replace without find', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			replaceWith: 'x',
+		});
+
+		assertStructuredError(result, 'invalid_input');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('refuses find-replace that also carries source', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			find: 'a',
+			replaceWith: 'b',
+			source: 'whole page',
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('source');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it('refuses a replace with no source', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', { title: 'My Page' });
+
+		assertStructuredError(result, 'invalid_input');
+		expect(submit).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/536

Follows-up to https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/604, whose commit this branch carries until that one merges. Review the second commit.

`update-page` inferred what a write did from which of its optional arguments were present: `source` alone overwrote the page, `source` with `section` overwrote that section and its subtree, and `mode` turned either into a delta. Nothing in the schema named those choices, so the description had to teach the combinations, and a new choice could only be added by overloading them further.

`operation` names them: `replace`, `append`, `prepend` and `find-replace`. `section` becomes the scope of the write rather than a mode of its own, so **`operation` says what and `section` says where**. `mode` spells the same choice and stays accepted for a release; a call sending both is refused when they disagree, and `removeSubsections` is refused outside the one operation it means anything for.

`find-replace` takes `find`, the existing wikitext to rewrite, and `replaceWith`, what it becomes. The server reads the target, splices, and submits the whole text with `baserevid` set to the revision it read, so a caller sends only the passage it is changing and the bytes it never sent cannot be lost.

`find` is matched in full and exactly. A fuzzy or whitespace-tolerant match would change what a page means, since a single leading space turns a wikitext line into a `<pre>` block, so there is no tolerant tier at any level. A `find` that matches nothing, or more than one place, is refused without writing, and the refusal says which of the two it was. Occurrences are counted one character at a time rather than by the needle's length, because a needle that can begin inside its own previous match names two different splices. The splice is by index rather than `String#replace`, which reads `$&` and `$1` in the replacement as references to the match.

The read names `redirects: false`. `mwn.read` follows redirects by default while the edit goes to the title the caller named, so without it the splice lands the target's whole text on the redirect page and leaves the target untouched.

## Why this shape

A separate tool was the other candidate. This one wins on routing: a model asked to change a page reaches for the tool called `update-page`, so a safe primitive in a second tool only helps when the model goes looking, whereas an enum in the schema of the tool it already reaches for is the menu.

A true `z.discriminatedUnion` is the better end state and is not this PR. `Tool<TSchema extends ZodRawShape>` binds every descriptor to a flat field record, and `buildToolInputSchema` merges the shared `wiki` argument by object spread, so a union input schema needs a change at the boundary all ~40 tools cross plus a client-compatibility check no one has run. The four enum values become the discriminator tags unchanged if that lands later.

## What this does not do

The silent loss in #536 is still reachable through `operation='replace'`: a truncated body written back wholesale still deletes the remainder. `find-replace` is the route that makes it unnecessary; refusing the unsafe write, and requiring `latestId` for a section write, follow separately.

## Verified

Driven against a live MediaWiki 1.43.9 through the built handlers, not only through mocks:

| Case | Result |
|---|---|
| unique match | wrote, page differs only at the match |
| no match | refused, page byte-identical |
| two matches, including a `find` that overlaps itself | refused naming the count, page byte-identical |
| `section` scoped | section 2 rewritten, section 1 byte-identical |
| `$1`/`$&`/`$$` in `replaceWith` | written literally |
| stale `latestId` | `conflict`, page byte-identical |
| section the page lacks | `not_found` / `nosuchsection`, same message the write path gives |
| a redirect page | refused, redirect and target both byte-identical |
| `comment` and `bot` | carried, with the attribution suffix |

End to end on a 130 KB fixture, which is the case #536 is about: `get-page section=4` returned 50,000 of 64,814 bytes, leaving 14,814 the caller never saw; rewriting a line inside what it did see moved the page from 129,701 to 129,723 bytes, exactly the 22 bytes inserted. **Zero bytes lost**, where writing that prefix back with `operation='replace'` deletes 14,814.

2230 tests, `typecheck`, `lint`, `fmt:check` and `check:mcp` green locally. `mcpjam server diff --fail-on breaking` against the base classifies the one surface change (`source` no longer required) as non-breaking.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; design chosen by @alistair3149 from a researched comparison, then redirected once from a separate-tool shape to this one; diff not yet human-reviewed, but reviewed by a fresh-context reviewer agent whose critical and important findings are all fixed here; tests written first and seen failing, full suite and gates run locally, and every write path exercised against a live MediaWiki 1.43.9 — which is how the redirect bug was found and how the fix was confirmed.</sub>