### PR TITLE
Search the namespaces a wiki counts as content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Added
 
-- `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from. A call that omits `namespaces` searches the main namespace, which was always the case but went unstated; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.
+- `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.
 - `update-page` can now rewrite one passage of a page without resending the rest: `operation='find-replace'` takes `find`, the existing wikitext to change, and `replaceWith`, what it becomes. The server holds the page and applies the change, so a large page no longer has to travel to or from the caller to be edited. `find` is matched in full and exactly; one that matches nothing, or more than one place, is refused without writing.
 - `update-page` takes an `operation` argument naming what the write does — `replace`, `append`, `prepend` or `find-replace` — where the choice was previously inferred from which other arguments were present. `section` now reads as the scope of the write rather than as a mode of its own: `operation` says what, `section` says where.
 
 ### Changed
 
+- `search-page` now searches the namespaces a wiki counts as content, instead of the main namespace only. Pass `namespaces: [0]` for the previous behaviour.
 - `update-page`'s `mode` argument is deprecated in favour of `operation`, which spells the same choice and adds `find-replace`. Calls sending `mode='append'` or `mode='prepend'` keep working; a call sending both is refused when they disagree.
 - `update-page` now documents that a delta can be scoped with `section`: `operation='append'` writes at the end of the named section, and `operation='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
 - The section list `get-page` and `get-pages` report now labels each section with the number that edits it, as `1 (History)` where it was `History`, and leaves out headings that arrive by transclusion. This is the outline in every `metadata=true` response as well as the one attached to a truncated read. The list previously numbered by position, and a transcluded heading holds a position that no section number addresses, so on any page carrying one every later entry named a different section than the one it pointed at.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Every tool that operates on a wiki accepts an optional `wiki` argument naming th
 | `get-site-info` | Get a wiki's key settings: MediaWiki version, content language, title-case rules, namespaces, installed extensions, license, and (optionally) statistics. |
 | `list-wikis` | List every configured wiki — its key, sitename, server, whether it is read-only or the default, whether it is reachable, which extension-gated tools work on it, and, for an OAuth-configured wiki, its authorization server. Disabled when fewer than two wikis are configured. |
 | `parse-wikitext` | Render wikitext to HTML without saving. Returns parse warnings, wikilinks, templates, and external URLs. |
-| `search-page` | Search wiki page titles and contents (full-text). Searches the main namespace unless given other namespace IDs. |
+| `search-page` | Search wiki page titles and contents (full-text). Searches the wiki's content namespaces unless given other namespace IDs. |
 | `search-page-by-prefix` | Search page titles by prefix. |
 | `whoami` | Report the identity the current session is authenticated as on the targeted wiki — username, whether it is anonymous, and group memberships (optionally user rights). |
 

--- a/src/tools/search-page.ts
+++ b/src/tools/search-page.ts
@@ -4,6 +4,7 @@ import type { ApiResponse, ApiSearchResult } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl } from '../wikis/utils.ts';
+import { resolveSiteInfo } from '../wikis/siteInfo.ts';
 import type { TruncationInfo } from '../results/truncation.ts';
 
 const inputSchema = {
@@ -25,7 +26,7 @@ const inputSchema = {
 export const searchPage: Tool<typeof inputSchema> = {
 	name: 'search-page',
 	description:
-		"Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, timestamp, and the namespace the match came from. Covers the main namespace unless namespaces names the namespace IDs to search; get-site-info lists a wiki's namespaces, and a wiki that keeps its content outside the main namespace returns nothing until they are named. Accepts up to 100 matches per call (default 10); additional matches beyond the cap are flagged in the response — narrow the query to surface more. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.",
+		"Searches wiki page titles and page content (full-text) for the provided terms. Returns matching pages with a snippet, size, timestamp, and the namespace the match came from. Covers the namespaces the wiki counts as content unless namespaces names the namespace IDs to search; get-site-info lists a wiki's namespaces and flags which of them hold content. Accepts up to 100 matches per call (default 10); additional matches beyond the cap are flagged in the response — narrow the query to surface more. For title-prefix lookup (e.g. autocomplete), use search-page-by-prefix.",
 	inputSchema,
 	annotations: {
 		title: 'Search page',
@@ -39,6 +40,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 
 	async handle({ query, limit, namespaces }, ctx: ToolContext): Promise<CallToolResult> {
 		const mwn = await ctx.mwn();
+		const scope = await resolveScope(ctx, namespaces);
 
 		const params: Record<string, string | number | boolean> = {
 			action: 'query',
@@ -52,8 +54,9 @@ export const searchPage: Tool<typeof inputSchema> = {
 		if (limit !== undefined) {
 			params.srlimit = limit;
 		}
-		if (namespaces !== undefined) {
-			params.srnamespace = namespaces.join('|');
+		// CirrusSearch reads an empty value as every namespace, not none.
+		if (scope.namespaces.length > 0) {
+			params.srnamespace = scope.namespaces.join('|');
 		}
 
 		const response = await mwn.request(params);
@@ -82,7 +85,7 @@ export const searchPage: Tool<typeof inputSchema> = {
 			})),
 		);
 
-		const scopeNotice = describeScopeLoss(namespaces, searchResults, searchWarning(response));
+		const scopeNotice = describeScopeLoss(scope, searchResults, searchWarning(response));
 
 		return ctx.format.ok({
 			results,
@@ -92,37 +95,87 @@ export const searchPage: Tool<typeof inputSchema> = {
 	},
 };
 
-// Two different failures leave the caller reading results from a scope it did
-// not ask for. The wiki reports an unusable namespace ID as an API warning and
-// searches the rest; it reports nothing at all when a namespace prefix in the
-// query overrides srnamespace, where the returned rows are the only evidence.
-function describeScopeLoss(
+// Above this the wiki errors, naming a parameter the caller never sent.
+const MAX_NAMESPACE_VALUES = 50;
+
+interface SearchScope {
+	/** What reached srnamespace. Empty means the parameter was omitted. */
+	readonly namespaces: readonly number[];
+	readonly origin: 'caller' | 'wiki';
+	/** Content namespaces the value cap left out. */
+	readonly dropped: number;
+}
+
+// A wiki that reports no namespace map leaves the scope unresolved, and the
+// search falls back to MediaWiki's own default of the main namespace.
+async function resolveScope(
+	ctx: ToolContext,
 	requested: readonly number[] | undefined,
+): Promise<SearchScope> {
+	if (requested !== undefined) {
+		return { namespaces: requested, origin: 'caller', dropped: 0 };
+	}
+
+	const { key } = ctx.activeWiki.get();
+	const contentNamespaces = (await resolveSiteInfo(ctx, key)).contentNamespaces ?? [];
+
+	return {
+		namespaces: contentNamespaces.slice(0, MAX_NAMESPACE_VALUES),
+		origin: 'wiki',
+		dropped: Math.max(0, contentNamespaces.length - MAX_NAMESPACE_VALUES),
+	};
+}
+
+// Every way the effective scope can differ from the intended one. The prefix
+// override is the caller's own doing, so it is reported only against a scope
+// the caller named.
+function describeScopeLoss(
+	scope: SearchScope,
 	results: readonly ApiSearchResult[],
 	warning: string | undefined,
 ): string | null {
-	if (requested === undefined) {
-		return null;
-	}
-
 	const parts: string[] = [];
 
 	if (warning !== undefined) {
-		parts.push(`The wiki reported: ${warning}`);
+		const scopeSource =
+			scope.origin === 'wiki' && scope.namespaces.length > 0
+				? `Searched this wiki's content namespaces (${scope.namespaces.join(', ')}) by default. `
+				: '';
+		parts.push(`${scopeSource}The wiki reported: ${warning}`);
 	}
 
-	const unexpected = [...new Set(results.map((r) => r.ns))].filter((ns) => !requested.includes(ns));
-	if (unexpected.length > 0) {
+	// MediaWiki always counts the main namespace as content, so an empty
+	// wiki-derived scope means siteinfo could not be read. Only an empty result
+	// leaves the caller unable to tell that apart from a wiki whose content
+	// really is main-namespace-only; a result carries its own namespace.
+	if (scope.origin === 'wiki' && scope.namespaces.length === 0 && results.length === 0) {
 		parts.push(
-			`Requested namespaces ${requested.join(', ')}, but results include ${unexpected.join(', ')} — a namespace prefix in the query (such as "Help:") overrides the namespaces argument.`,
+			"Could not read this wiki's content namespaces, so the search covered the main namespace only — name the namespaces to search to widen it.",
 		);
+	}
+
+	if (scope.dropped > 0) {
+		parts.push(
+			`This wiki has ${scope.namespaces.length + scope.dropped} content namespaces and the search accepts ${MAX_NAMESPACE_VALUES}, so ${scope.dropped} of them were not searched — name the namespaces to search to choose which.`,
+		);
+	}
+
+	if (scope.origin === 'caller') {
+		const unexpected = [...new Set(results.map((r) => r.ns))].filter(
+			(ns) => !scope.namespaces.includes(ns),
+		);
+		if (unexpected.length > 0) {
+			parts.push(
+				`Requested namespaces ${scope.namespaces.join(', ')}, but results include ${unexpected.join(', ')} — a namespace prefix in the query (such as "Help:") overrides the namespaces argument.`,
+			);
+		}
 	}
 
 	return parts.length > 0 ? parts.join(' ') : null;
 }
 
-// The action API reports a parameter it could not use under the module that
-// received it, leaving the response otherwise successful.
+// The API reports an unusable parameter under the module that received it,
+// leaving the response otherwise successful.
 function searchWarning(response: ApiResponse): string | undefined {
 	const { warnings } = response;
 	if (!isRecord(warnings) || !isRecord(warnings.search)) {

--- a/src/wikis/siteInfo.ts
+++ b/src/wikis/siteInfo.ts
@@ -13,6 +13,7 @@ interface SiteInfoApiResponse {
 			'wikibase-sparql'?: string;
 		};
 		rightsinfo?: { url?: string; text?: string };
+		namespaces?: Record<string, { id?: number; content?: boolean }>;
 	};
 }
 
@@ -41,7 +42,7 @@ async function fetchSiteInfo(ctx: ToolContext, wikiKey: string): Promise<SiteInf
 		const response = (await mwn.request({
 			action: 'query',
 			meta: 'siteinfo',
-			siprop: 'general|rightsinfo',
+			siprop: 'general|rightsinfo|namespaces',
 			formatversion: '2',
 		})) as SiteInfoApiResponse;
 
@@ -56,6 +57,8 @@ async function fetchSiteInfo(ctx: ToolContext, wikiKey: string): Promise<SiteInf
 		const license: LicenseInfo | undefined =
 			rights?.url && rights.text ? { url: rights.url, title: rights.text } : undefined;
 
+		const contentNamespaces = readContentNamespaces(response.query?.namespaces);
+
 		const resolved: SiteInfo = {
 			server: normalizeServer(general.server),
 			articlepath:
@@ -67,6 +70,7 @@ async function fetchSiteInfo(ctx: ToolContext, wikiKey: string): Promise<SiteInf
 				? { sparqlEndpoint: general['wikibase-sparql'] }
 				: {}),
 			...(license ? { license } : {}),
+			...(contentNamespaces.length > 0 ? { contentNamespaces } : {}),
 		};
 		ctx.siteInfoCache.set(wikiKey, resolved);
 		return resolved;
@@ -105,4 +109,24 @@ export async function resolveSiteInfo(ctx: ToolContext, wikiKey: string): Promis
 	});
 	inflight.set(wikiKey, promise);
 	return promise;
+}
+
+// MediaWiki always flags the main namespace as content, so an empty result means
+// the wiki reported no namespace map rather than that it holds no content. The
+// negative namespaces (Media, Special) are dropped because the search API
+// refuses them, and one refused value costs the whole scope.
+function readContentNamespaces(
+	namespaces: Record<string, { id?: number; content?: boolean }> | undefined,
+): number[] {
+	if (!namespaces) {
+		return [];
+	}
+
+	const ids = new Set<number>();
+	for (const entry of Object.values(namespaces)) {
+		if (entry.content === true && typeof entry.id === 'number' && entry.id >= 0) {
+			ids.add(entry.id);
+		}
+	}
+	return [...ids].sort((a, b) => a - b);
 }

--- a/src/wikis/siteInfoCache.ts
+++ b/src/wikis/siteInfoCache.ts
@@ -7,6 +7,11 @@ export type SiteInfo = {
 	lang?: string;
 	license?: LicenseInfo;
 	/**
+	 * Namespace IDs the wiki counts as content ($wgContentNamespaces), ascending;
+	 * absent when siteinfo did not report a namespace map.
+	 */
+	contentNamespaces?: readonly number[];
+	/**
 	 * SPARQL endpoint of the query service backing this wiki's Wikibase
 	 * repository, as published in siteinfo; absent on a wiki that publishes none.
 	 */

--- a/tests/tools/search-page.test.ts
+++ b/tests/tools/search-page.test.ts
@@ -62,6 +62,27 @@ function searchParams(mock: ReturnType<typeof createMockMwn>): Record<string, un
 	return call![0] as Record<string, unknown>;
 }
 
+// fakeContext seeds a siteinfo cache with no content namespaces, so every test
+// that does not call this exercises the unresolved path and proves nothing
+// about the wiki-derived default.
+function contextKnowing(mock: ReturnType<typeof createMockMwn>, contentNamespaces: number[]) {
+	const map = new Map<string, SiteInfo>([
+		['test-wiki', { server: 'https://test.wiki', articlepath: '/wiki', contentNamespaces }],
+	]);
+	return fakeContext({
+		mwn: async () => mock as never,
+		siteInfoCache: {
+			get: (k: string) => map.get(k),
+			set: (k: string, v: SiteInfo) => {
+				map.set(k, v);
+			},
+			delete: (k: string) => {
+				map.delete(k);
+			},
+		} as never,
+	});
+}
+
 describe('search-page', () => {
 	it('returns full-text search results with snippets', async () => {
 		const mock = createMockMwn({
@@ -256,7 +277,7 @@ describe('search-page', () => {
 		expect(searchParams(mock).srwhat).toBe('text');
 	});
 
-	it('omits srnamespace when the caller names no namespaces', async () => {
+	it('falls back to the wiki default when siteinfo reports no content namespaces', async () => {
 		const mock = mockSearchReturning([]);
 		const ctx = fakeContext({ mwn: async () => mock as never });
 
@@ -336,12 +357,97 @@ describe('search-page', () => {
 
 	it('omits the scope notice when the caller named no namespaces', async () => {
 		const mock = mockSearchReturning([searchRow({ title: 'Help:Contents', ns: 12 })]);
-		const ctx = fakeContext({ mwn: async () => mock as never });
+		const ctx = contextKnowing(mock, [0, 12]);
 
 		const result = await searchPage.handle(toolArgs(searchPage, { query: 'Help:Contents' }), ctx);
 
 		const text = assertStructuredSuccess(result);
 		expect(text).toContain('- Title: Help:Contents');
+		expect(text).not.toContain('Scope notice:');
+	});
+
+	it('searches the wiki content namespaces when the caller names none', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = contextKnowing(mock, [0, 100, 102]);
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		expect(searchParams(mock).srnamespace).toBe('0|100|102');
+	});
+
+	it('prefers the namespaces the caller named over the wiki content namespaces', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = contextKnowing(mock, [0, 100, 102]);
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test', namespaces: [12] }), ctx);
+
+		expect(searchParams(mock).srnamespace).toBe('12');
+	});
+
+	it('never sends an empty srnamespace, which would search the whole wiki', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = contextKnowing(mock, []);
+
+		await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		const params = searchParams(mock);
+		expect(params.srsearch).toBe('test');
+		expect(params).not.toHaveProperty('srnamespace');
+	});
+
+	it('caps the wiki scope at the fifty values the search API accepts', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = contextKnowing(
+			mock,
+			Array.from({ length: 60 }, (_, i) => i * 2),
+		);
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		expect(String(searchParams(mock).srnamespace).split('|')).toHaveLength(50);
+		expect(scopeNotice(assertStructuredSuccess(result))).toContain('50');
+	});
+
+	it('does not blame the caller for namespaces the wiki default reached', async () => {
+		const mock = mockSearchReturning([searchRow({ title: 'Help:Contents', ns: 12 })]);
+		const ctx = contextKnowing(mock, [0, 100]);
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'Help:Contents' }), ctx);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('- Title: Help:Contents');
+		expect(text).not.toContain('Scope notice:');
+	});
+
+	it('reports a wiki warning even when the scope came from the wiki', async () => {
+		const mock = mockSearchReturning(
+			[searchRow({ ns: 0 })],
+			'Unrecognized value for parameter "srnamespace": 999',
+		);
+		const ctx = contextKnowing(mock, [0, 999]);
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		expect(scopeNotice(assertStructuredSuccess(result))).toContain('999');
+	});
+
+	it('explains an empty result the wiki namespaces could not be read for', async () => {
+		const mock = mockSearchReturning([]);
+		const ctx = contextKnowing(mock, []);
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		expect(scopeNotice(assertStructuredSuccess(result))).toContain('main namespace');
+	});
+
+	it('stays quiet about an unread namespace list when the search found something', async () => {
+		const mock = mockSearchReturning([searchRow({ ns: 0 })]);
+		const ctx = contextKnowing(mock, []);
+
+		const result = await searchPage.handle(toolArgs(searchPage, { query: 'test' }), ctx);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('- Title: Test Page');
 		expect(text).not.toContain('Scope notice:');
 	});
 });

--- a/tests/wikis/siteInfo.test.ts
+++ b/tests/wikis/siteInfo.test.ts
@@ -261,4 +261,67 @@ describe('resolveSiteInfo', () => {
 		expect(info.server).toBe('https://public.example');
 		expect(info.articlepath).toBe('/wiki');
 	});
+
+	it('keeps the namespace IDs the wiki flags as content', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: {
+					general: { server: 'https://public.example', articlepath: '/wiki/$1' },
+					namespaces: {
+						'0': { id: 0, name: '', content: true },
+						'1': { id: 1, name: 'Talk' },
+						'100': { id: 100, name: 'Manual', content: true },
+						'102': { id: 102, name: 'Extension', content: true },
+					},
+				},
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			siteInfoCache: emptyCache() as never,
+		});
+
+		const info = await resolveSiteInfo(ctx, 'test-wiki');
+
+		expect(info.contentNamespaces).toEqual([0, 100, 102]);
+	});
+
+	it('drops namespace IDs below zero, which the search API refuses', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: {
+					general: { server: 'https://public.example', articlepath: '/wiki/$1' },
+					namespaces: {
+						'-2': { id: -2, name: 'Media', content: true },
+						'0': { id: 0, name: '', content: true },
+					},
+				},
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			siteInfoCache: emptyCache() as never,
+		});
+
+		const info = await resolveSiteInfo(ctx, 'test-wiki');
+
+		expect(info.contentNamespaces).toEqual([0]);
+	});
+
+	it('leaves contentNamespaces absent when siteinfo reports no namespace map', async () => {
+		const mock = createMockMwn({
+			request: vi.fn().mockResolvedValue({
+				query: { general: { server: 'https://public.example', articlepath: '/wiki/$1' } },
+			}),
+		});
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			siteInfoCache: emptyCache() as never,
+		});
+
+		const info = await resolveSiteInfo(ctx, 'test-wiki');
+
+		expect(info.server).toBe('https://public.example');
+		expect(info.contentNamespaces).toBeUndefined();
+	});
 });


### PR DESCRIPTION
Follows-up to https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/pull/603

`search-page` inherited the action API's default of namespace 0, so it searched main-namespace articles only. On mediawiki.org that means "configuration settings" cannot reach `Manual:Configuration settings`; on any wiki that keeps its content outside the main namespace the tool looks empty rather than scoped.

The wiki already declares where its content lives. `resolveSiteInfo` now also carries the namespaces flagged as content, and a call that names no namespaces of its own searches those. Naming namespaces still overrides it, so `namespaces: [0]` restores the previous scope, and a wiki whose only content namespace is the main one — en.wikipedia.org included — is unchanged.

Three things can leave the effective scope different from the intended one, and each reports itself:

- **An empty value is never sent.** Verified on mediawiki.org: `srnamespace=` returns 46,028 whole-wiki hits against 4,718 for namespace 0, because CirrusSearch reads an empty value as every namespace. An unresolved scope omits the parameter instead.
- **A wiki-derived list is capped at 50**, the value limit for an anonymous caller. Above it the wiki returns `toomanyvalues`, which #603 classifies as `invalid_input` — blaming the caller for a list the server built. No real wiki is close; the maximum across ~55 public wikis is 14.
- **A failed siteinfo read falls back to the main namespace and says so.** This is not hypothetical: during smoke testing a rate-limited siteinfo call silently returned the tool to the old behaviour, which is the failure this change exists to remove.

The scope notice reports a namespace prefix in the query only against a scope the caller chose. Under a wiki-derived default those rows come from the caller's own prefix — verified identical with and without `srnamespace` — so naming namespaces the caller never asked for would misattribute it.

## What the reviewer should decide

The list is sourced from `resolveSiteInfo` rather than `wikiProbe`, even though the probe already has a 1-hour TTL and this cache has none. The probe is anonymous and SSRF-guarded, so it returns `reachable: false` for loopback, private-network and login-required wikis — exactly the wikis that keep content outside namespace 0, and ones where `search-page` itself still works through authenticated mwn. Riding the probe would make the new default silently wrong precisely where it matters most.

## Considered, omitted

- **A TTL on `SiteInfoCacheImpl`.** It is a bare `Map` with no expiry, so a wiki that gains a content namespace keeps the stale scope for the process lifetime. Adding expiry would also change the lifetime of `server`, `articlepath`, `lang`, `license` and `sparqlEndpoint`, and `src/resources/index.ts` reads that cache synchronously — a second behaviour change riding along with this one. The staleness is bounded and self-correcting, and a caller can name namespaces meanwhile. Worth its own PR.
- **Raising the default limit when the scope widens.** With `limit` 10 and no continuation, main-namespace hits can now be displaced by other content namespaces. That is the point of the change, and the caller can narrow.
- **`search-page-by-prefix`.** `apnamespace` is `multi=false`, so it cannot take a namespace list at all. The two siblings now differ in default scope with no way to align them short of one request per namespace.
- **Disclosing the effective scope on every call.** The per-row `namespace` field already covers a non-empty response, and the description states the default.

## Verification

TDD throughout, with every mechanism reverted separately to confirm exactly one test fails for it: the empty-value guard, the caller-origin gate on the prefix branch, the 50-value cap, using the wiki list at all, caller-precedence, and the unresolved-scope disclosure.

Smoke-tested against live wikis. mediawiki.org, default scope: `Manual:Configuration settings` at rank 1, namespace 100. Same wiki with `namespaces: [0]`: the previous main-namespace results. en.wikipedia.org: unchanged, no notice.

Full suite (2206 tests), `lint`, `typecheck` and `fmt:check` green.

> <sub>AI-authored — Claude Code, `Opus 5 (ultracode)`; @alistair3149 chose content namespaces over `$wgNamespacesToBeSearchedDefault` after I argued the other way and was shown wrong on the data; no revisions to the implementation; diff not yet human-reviewed; TDD with each mechanism reverted to prove its test fails, full suite / lint / typecheck green, smoke-tested against mediawiki.org and en.wikipedia.org.</sub>

https://claude.ai/code/session_01CjqCAgSXf6BRQNi9MbQSvE
