### PR TITLE
Refuse the two writes that delete content the caller never read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `update-page` now refuses a call that replaces a page or section when the source would shorten a target too large for one read to return whole. Pass `removeUnreadContent: true` to do it deliberately, or use `operation='find-replace'` to change part of a page without resending it; appends, growth and any target inside the byte budget are unaffected.
+- `update-page` now requires `latestId` when `section` names the section being replaced, so the wiki resolves the number against the revision it was read from. `get-page` with `metadata=true` returns it alongside the section list; the lead, appends and prepends are unaffected.
+
 ### Added
 
 - `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -12,7 +12,7 @@ export interface SectionEntry {
 }
 
 export interface SectionService {
-	list(mwn: Mwn, title: string): Promise<SectionEntry[]>;
+	list(mwn: Mwn, title: string, revisionId?: number): Promise<SectionEntry[]>;
 	listInSource(mwn: Mwn, title: string, source: string): Promise<SectionEntry[]>;
 }
 
@@ -30,10 +30,14 @@ function isEditableIndex(index: string): boolean {
 }
 
 export class SectionServiceImpl implements SectionService {
-	public async list(mwn: Mwn, title: string): Promise<SectionEntry[]> {
+	// `revisionId` asks for the outline as that revision had it. A write scoped
+	// to a section resolves the number against the revision it names, so a guard
+	// reading the current outline judges a different section than the one the
+	// write will replace.
+	public async list(mwn: Mwn, title: string, revisionId?: number): Promise<SectionEntry[]> {
 		return this.parseSections(mwn, {
 			action: 'parse',
-			page: title,
+			...(revisionId === undefined ? { page: title } : { oldid: String(revisionId) }),
 			prop: 'sections',
 			formatversion: '2',
 		});

--- a/src/tools/get-page.ts
+++ b/src/tools/get-page.ts
@@ -97,6 +97,15 @@ export const getPage: Tool<typeof inputSchema> = {
 				entries = await ctx.sections.list(mwn, title);
 			}
 
+			// The revision ID rides on every read that fetches content, and a write
+			// scoped to a section needs it to say which revision its section
+			// number was read from. Withholding it behind metadata=true made the
+			// natural read-modify-write sequence fail on the write and then need a
+			// second read to recover, so it is reported whenever content is.
+			if (needsSource && rev?.revid !== undefined) {
+				payload.latestRevisionId = rev.revid;
+			}
+
 			if (metadata || content === ContentFormat.none) {
 				payload.pageId = page.pageid;
 				payload.title = page.title;

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -4,6 +4,7 @@ import type { Mwn } from 'mwn';
 import type { Tool } from '../runtime/tool.ts';
 import type { ToolContext } from '../runtime/context.ts';
 import { buildPageUrl, formatEditComment } from '../wikis/utils.ts';
+import { contentMaxBytes } from '../results/truncation.ts';
 import { editableChildrenOf } from '../services/sectionSubtree.ts';
 
 const OPERATIONS = ['replace', 'append', 'prepend', 'find-replace'] as const;
@@ -58,7 +59,7 @@ const inputSchema = {
 		.positive()
 		.optional()
 		.describe(
-			'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. If omitted, the update is applied without conflict detection.',
+			'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. Required when section is set, because the wiki resolves a section number against this revision rather than against whichever is current. If omitted on a write that is not scoped to a section, the update is applied without conflict detection.',
 		),
 	comment: z.string().optional().describe('Summary of the edit'),
 	section: z
@@ -83,6 +84,12 @@ const inputSchema = {
 		.describe(
 			'Marks the edit as a bot edit, which Special:RecentChanges hides by default. Takes effect only when the authenticated account has the `bot` right (granted by the bot group, or by the high-volume grant on a bot password or OAuth consumer); without it the edit saves unflagged and the response reports botMarked: false. Use when performing bulk or automated edit runs, or when the user requests it.',
 		),
+	removeUnreadContent: z
+		.boolean()
+		.optional()
+		.describe(
+			'Confirms that replacing content larger than a single read returns is meant to discard the part that was never returned. Required only when the target holds more bytes than one response carries and source holds fewer.',
+		),
 	removeSubsections: z
 		.boolean()
 		.optional()
@@ -104,13 +111,27 @@ type WritePlan =
 	| { readonly operation: 'replace' | 'append' | 'prepend'; readonly source: string };
 
 function writePlan(args: UpdatePageArgs): WritePlan {
-	const { operation, mode, source, find, replaceWith } = args;
+	const { operation, mode, source, find, replaceWith, section, latestId } = args;
 	if (operation !== undefined && mode !== undefined && operation !== mode) {
 		return {
 			error: `operation is '${operation}' but mode is '${mode}'. mode is the older spelling of the same choice; send operation alone.`,
 		};
 	}
 	const resolved: Operation = operation ?? mode ?? 'replace';
+	// A section number is only meaningful alongside the revision it was read
+	// from: the wiki resolves it against whichever revision is current, so an
+	// index that has since shifted addresses a different section. Required for a
+	// replace alone, because that is where the mistake destroys the section it
+	// lands on; a delta put in the wrong section is misplaced, not lost, and
+	// shows in the diff. find-replace addresses its target by the text it
+	// matches rather than by position, so it is unaffected either way. Section 0
+	// is the lead, which no insertion can move, so there is no ambiguity to
+	// resolve and nothing to require.
+	if (resolved === 'replace' && section !== undefined && section > 0 && latestId === undefined) {
+		return {
+			error: `Section ${section} names a different section once the page changes, so replacing a section needs latestId to say which revision the number was read from. get-page with metadata=true returns it.`,
+		};
+	}
 	if (resolved === 'find-replace') {
 		if (find === undefined || replaceWith === undefined) {
 			return {
@@ -132,6 +153,11 @@ function writePlan(args: UpdatePageArgs): WritePlan {
 	if (find !== undefined || replaceWith !== undefined) {
 		return {
 			error: `find and replaceWith belong to operation 'find-replace', not '${resolved}'.`,
+		};
+	}
+	if (args.removeUnreadContent !== undefined && resolved !== 'replace') {
+		return {
+			error: `removeUnreadContent confirms a replace that discards content too large to have been read, so it applies only to operation 'replace', not '${resolved}'.`,
 		};
 	}
 	if (
@@ -197,6 +223,85 @@ function scopeName(title: string, section: number | undefined): string {
 	return section === undefined ? `page "${title}"` : `section ${section} of "${title}"`;
 }
 
+// Content larger than one response cannot have been read whole through this
+// server, so a replace that shortens it is discarding bytes the caller never
+// saw. That is the loss #536 records: a truncated read written straight back.
+// Growth and same-size writes pass untouched, and a target inside the budget is
+// never measured, because a caller could have read all of it.
+async function unreadContentError(
+	args: UpdatePageArgs,
+	source: string,
+	mwn: Mwn,
+): Promise<string | undefined> {
+	if (args.removeUnreadContent === true) {
+		return undefined;
+	}
+	const cap = contentMaxBytes();
+	// prop=info reports the page's byte length, and unlike mwn.read it resolves
+	// no redirect, so it measures the page this write will land on.
+	const response =
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		(await mwn.request({
+			action: 'query',
+			prop: 'info',
+			titles: args.title,
+			formatversion: '2',
+		})) as { query?: { pages?: { length?: number }[] } } | undefined;
+	const pageBytes = response?.query?.pages?.[0]?.length;
+	// No section of a page inside the budget can be outside it either, so one
+	// small request answers for both scopes in the ordinary case. A page the
+	// wiki reports no length for is one it is about to refuse the edit on — a
+	// missing or invalid title — and that error says more than this guard could,
+	// so it is left to speak. A probe that throws propagates and no write
+	// happens, as with the subsection guard.
+	if (pageBytes === undefined || pageBytes <= cap) {
+		return undefined;
+	}
+	const sourceBytes = Buffer.byteLength(source, 'utf8');
+	if (args.section === undefined) {
+		return sourceBytes < pageBytes
+			? unreadContentMessage(`Page "${args.title}"`, pageBytes, sourceBytes, cap)
+			: undefined;
+	}
+	// The write resolves the section number against latestId, so the guard has to
+	// measure that same revision. Reading the current one certifies a section the
+	// write will not touch: once a section has been inserted, section 2 of the
+	// page now and section 2 of the base revision are different sections. Only
+	// the lead reaches here without a base, and the lead cannot move.
+	const sectionRead =
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mwn API response shape; trusted at this boundary
+		(await mwn.request({
+			action: 'query',
+			prop: 'revisions',
+			...(args.latestId === undefined ? { titles: args.title } : { revids: args.latestId }),
+			rvprop: 'content',
+			rvslots: 'main',
+			rvsection: args.section,
+			formatversion: '2',
+		})) as
+			| { query?: { pages?: { revisions?: { slots?: { main?: { content?: string } } }[] }[] } }
+			| undefined;
+	const current = sectionRead?.query?.pages?.[0]?.revisions?.[0]?.slots?.main?.content;
+	// A section the revision does not have is the edit's own error to report.
+	if (typeof current !== 'string') {
+		return undefined;
+	}
+	const sectionBytes = Buffer.byteLength(current, 'utf8');
+	if (sectionBytes <= cap || sourceBytes >= sectionBytes) {
+		return undefined;
+	}
+	return unreadContentMessage(`Section ${args.section}`, sectionBytes, sourceBytes, cap);
+}
+
+function unreadContentMessage(
+	target: string,
+	targetBytes: number,
+	sourceBytes: number,
+	cap: number,
+): string {
+	return `${target} holds ${targetBytes} bytes, more than the ${cap} bytes one read returns, so the ${sourceBytes}-byte source supplied cannot contain all of it and this replace would delete the rest. To change part of it without resending it, use operation='find-replace'. To replace it with something shorter deliberately, pass removeUnreadContent: true.`;
+}
+
 // Replacing a section replaces everything nested under it. A source that brings
 // the subsections back is not destructive; one that drops them deletes content
 // the caller may never have read. Both sides of the comparison are parsed by
@@ -217,7 +322,9 @@ async function subsectionRemovalError(
 	if (section === 0) {
 		return undefined;
 	}
-	const entries = await ctx.sections.list(mwn, args.title);
+	// Scoped to the revision the write names, for the same reason the size guard
+	// is: the section numbers being compared are the ones the write resolves.
+	const entries = await ctx.sections.list(mwn, args.title, args.latestId);
 	const index = String(section);
 	// The subtree walk counts every entry so a transcluded heading still closes
 	// it at the right point; the transcluded children themselves drop out,
@@ -377,7 +484,7 @@ async function findReplace(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Writes to an existing wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. operation says what the write does and section says where: omit section to act on the whole page, or set it to confine the write to one section. For changing part of a page, use operation='find-replace', which carries only the text being rewritten, so nothing outside find can be lost and the rest of the page never has to travel to or from the caller; a find that matches nothing, or more than one place, is refused without writing, which also makes it safe to resend a call whose result never arrived. For replacing a target outright, use operation='replace', whose source must carry every byte meant to survive; with section set it also takes out every subsection nested under that section, and is refused when source would drop them. operation='append' and 'prepend' add a delta: a new section at the end of the page is an append whose source begins with the heading, and with section set a prepend inserts one immediately above that section. Pass latestId (from get-page with metadata=true) for edit-conflict detection: the write is rejected rather than silently clobbering a concurrent change. Each call is a separate revision, and resending an append or prepend whose result never arrived adds the delta a second time.",
+		"Writes to an existing wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. operation says what the write does and section says where: omit section to act on the whole page, or set it to confine the write to one section. For changing part of a page, use operation='find-replace', which carries only the text being rewritten, so nothing outside find can be lost and the rest of the page never has to travel to or from the caller; a find that matches nothing, or more than one place, is refused without writing, which also makes it safe to resend a call whose result never arrived. For replacing a target outright, use operation='replace', whose source must carry every byte meant to survive; it is refused when source would shorten a target too large for one read to return whole, since the rest was never seen. With section set it also takes out every subsection nested under that section, is refused when source would drop them, and needs latestId to say which revision the section number was read from. operation='append' and 'prepend' add a delta: a new section at the end of the page is an append whose source begins with the heading, and with section set a prepend inserts one immediately above that section. Pass latestId (from get-page with metadata=true) for edit-conflict detection: the write is rejected rather than silently clobbering a concurrent change. Each call is a separate revision, and resending an append or prepend whose result never arrived adds the delta a second time.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',
@@ -403,6 +510,13 @@ export const updatePage: Tool<typeof inputSchema> = {
 		// Only a replace takes the section's subtree with it; a delta adds to the
 		// section and removes nothing.
 		if (plan.operation === 'replace') {
+			// Before the subsection guard: a source that is a truncated prefix may
+			// appear to drop subsections that simply lie past the cut, so that
+			// guard's verdict on it would misdirect.
+			const unreadError = await unreadContentError(args, plan.source, mwn);
+			if (unreadError) {
+				return ctx.format.invalidInput(unreadError);
+			}
 			const removalError = await subsectionRemovalError(args, plan.source, ctx, mwn);
 			if (removalError) {
 				return ctx.format.invalidInput(removalError);

--- a/tests/tools/get-page.test.ts
+++ b/tests/tools/get-page.test.ts
@@ -578,6 +578,27 @@ describe('get-page', () => {
 		expect(text).toContain('No narrower read returns more of this section');
 	});
 
+	// A write scoped to a section needs the revision its number was read from, so
+	// the read that produced the number has to carry it.
+	it('reports the revision ID on a source read without metadata', async () => {
+		const mock = createMockMwn({
+			read: vi.fn().mockResolvedValue({
+				pageid: 1,
+				title: 'Test Page',
+				revisions: [{ revid: 42, contentmodel: 'wikitext', content: '== One ==\nbody' }],
+			}),
+		});
+		const ctx = fakeContext({ mwn: async () => mock as never });
+
+		const result = await getPage.handle(
+			{ title: 'Test Page', content: ContentFormat.source, metadata: false, section: 1 },
+			ctx,
+		);
+
+		const text = assertStructuredSuccess(result);
+		expect(text).toContain('Latest revision ID: 42');
+	});
+
 	it('builds the page URL from the public siteinfo server, not the configured server', async () => {
 		const mock = createMockMwn({
 			request: vi.fn().mockImplementation((params: { meta?: string; action?: string }) => {

--- a/tests/tools/update-page.test.ts
+++ b/tests/tools/update-page.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { Mwn } from 'mwn';
 import { createMockMwn } from '../helpers/mock-mwn.ts';
 import { fakeContext } from '../helpers/fakeContext.ts';
@@ -83,6 +83,27 @@ function fakeEditWithOutline(
 	return { ...base, ctx, list, listInSource };
 }
 
+const PAGE =
+	'Lead text.\n\n== History ==\nThe city was founded in 1104.\n\n== Geography ==\nThe river runs east.\n';
+
+// The whole point of the operation is that the server holds the page and the
+// caller holds only the text it is changing, so the read is part of the tool.
+function fakeFindReplace(current: string = PAGE, revid = 41) {
+	const base = fakeEdit();
+	const read = vi.fn().mockResolvedValue({
+		pageid: 5,
+		title: 'My Page',
+		revisions: [{ revid, content: current }],
+	});
+	const mock = createMockMwn({
+		read,
+		request: base.request,
+		getCsrfToken: vi.fn().mockResolvedValue('csrf-token'),
+	});
+	const ctx = fakeContext({ mwn: async () => mock as never, edit: base.ctx.edit });
+	return { ...base, ctx, read };
+}
+
 describe('update-page', () => {
 	describe('full-page replacement', () => {
 		it('sends text=source with nocreate and baserevid for conflict detection', async () => {
@@ -120,7 +141,8 @@ describe('update-page', () => {
 			expect(params).not.toHaveProperty('formatversion');
 
 			// Sanity check: submit forwarded to mwn.request with token + formatversion.
-			const requestParams = request.mock.calls[0][0];
+			// The edit is the last request; the size guard probes before it.
+			const requestParams = request.mock.calls.at(-1)?.[0];
 			expect(requestParams).toMatchObject({
 				token: 'csrf-token',
 				formatversion: '2',
@@ -235,6 +257,7 @@ describe('update-page', () => {
 					title: 'My Page',
 					source: 'new section body',
 					section: 2,
+					latestId: 41,
 				},
 				ctx,
 			);
@@ -252,6 +275,7 @@ describe('update-page', () => {
 					title: 'My Page',
 					source: 'lead',
 					section: 0,
+					latestId: 41,
 				},
 				ctx,
 			);
@@ -279,6 +303,7 @@ describe('update-page', () => {
 				title: 'My Page',
 				source: 'x',
 				section: 99,
+				latestId: 41,
 			});
 
 			const envelope = assertStructuredError(result, 'not_found');
@@ -325,6 +350,7 @@ describe('update-page', () => {
 				title: 'My Page',
 				source: 'body',
 				section: 2,
+				latestId: 41,
 				sectionTitle: 'History',
 			});
 
@@ -339,6 +365,7 @@ describe('update-page', () => {
 				title: 'My Page',
 				source: 'new section body',
 				section: 2,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -487,6 +514,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== History ==\nRewritten.',
 				section: 2,
+				latestId: 41,
 			});
 
 			const envelope = assertStructuredError(result, 'invalid_input');
@@ -514,6 +542,7 @@ describe('update-page', () => {
 				source:
 					'== History ==\nIntro.\n\n=== Prehistoric to classical history ===\na\n\n=== Feudal era ===\nb\n\n=== Modern era ===\nc',
 				section: 2,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -534,6 +563,7 @@ describe('update-page', () => {
 				source:
 					'== History ==\nIntro.\n\n=== Prehistory ===\na\n\n=== Feudal period ===\nb\n\n=== Modern era ===\nc',
 				section: 2,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -555,6 +585,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== History ==\n{{ThreeHeadings}}',
 				section: 2,
+				latestId: 41,
 			});
 
 			assertStructuredError(result, 'invalid_input');
@@ -568,6 +599,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== History ==\nRewritten.',
 				section: 2,
+				latestId: 41,
 				removeSubsections: true,
 			});
 
@@ -582,6 +614,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== Etymology ==\nRewritten.',
 				section: 1,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -608,6 +641,7 @@ describe('update-page', () => {
 				title: 'Wikipedia:Requests for adminship',
 				source: '== Nominations ==\nIntro.\n{{RfA/Candidate A}}\n{{RfA/Candidate B}}',
 				section: 1,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -630,6 +664,7 @@ describe('update-page', () => {
 				title: 'Wikipedia:Requests for adminship',
 				source: '== Nominations ==\nRewritten, dropping the discussion subsection.',
 				section: 1,
+				latestId: 41,
 			});
 
 			const envelope = assertStructuredError(result, 'invalid_input');
@@ -674,6 +709,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: 'New lead.',
 				section: 0,
+				latestId: 41,
 			});
 
 			assertStructuredSuccess(result);
@@ -696,6 +732,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== History ==\nRewritten.',
 				section: 2,
+				latestId: 41,
 			});
 
 			const envelope = assertStructuredError(result, 'upstream_failure');
@@ -719,6 +756,7 @@ describe('update-page', () => {
 				title: 'Japan',
 				source: '== History ==\nRewritten.',
 				section: 2,
+				latestId: 41,
 			});
 
 			const envelope = assertStructuredError(result, 'upstream_failure');
@@ -729,27 +767,6 @@ describe('update-page', () => {
 });
 
 describe('update-page find-replace', () => {
-	const PAGE =
-		'Lead text.\n\n== History ==\nThe city was founded in 1104.\n\n== Geography ==\nThe river runs east.\n';
-
-	// The whole point of the operation is that the server holds the page and the
-	// caller holds only the text it is changing, so the read is part of the tool.
-	function fakeFindReplace(current: string = PAGE, revid = 41) {
-		const base = fakeEdit();
-		const read = vi.fn().mockResolvedValue({
-			pageid: 5,
-			title: 'My Page',
-			revisions: [{ revid, content: current }],
-		});
-		const mock = createMockMwn({
-			read,
-			request: base.request,
-			getCsrfToken: vi.fn().mockResolvedValue('csrf-token'),
-		});
-		const ctx = fakeContext({ mwn: async () => mock as never, edit: base.ctx.edit });
-		return { ...base, ctx, read };
-	}
-
 	it('rewrites the single match and submits the whole target', async () => {
 		const { submit, ctx } = fakeFindReplace();
 
@@ -1127,6 +1144,422 @@ describe('update-page operation', () => {
 		const result = await callTool(ctx, 'update-page', { title: 'My Page' });
 
 		assertStructuredError(result, 'invalid_input');
+		expect(submit).not.toHaveBeenCalled();
+	});
+});
+
+// A section number means nothing without the revision it was read from: the wiki
+// resolves it against whatever the page is now, so an index that has since
+// shifted addresses a different section.
+describe('update-page section base revision', () => {
+	it('refuses a section replace without latestId', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'body',
+			section: 2,
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('latestId');
+		expect(envelope.message).toContain('get-page');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// The lead is always section 0, and no insertion moves it, so there is no
+	// ambiguity to resolve and nothing to require.
+	it('leaves a lead replace alone', async () => {
+		const { submit, ctx } = fakeEditWithOutline(JAPAN_OUTLINE, []);
+
+		await callTool(ctx, 'update-page', { title: 'Japan', source: 'new lead', section: 0 });
+
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	// A delta put in the wrong section is misplaced, not lost, and shows in the
+	// diff, so it is not worth refusing a call over.
+	it.each(['append', 'prepend'])('leaves a %s scoped to a section alone', async (operation) => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation,
+			source: 'body',
+			section: 2,
+		});
+
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	// The payoff of requiring it: the wiki resolves the index against this
+	// revision rather than against whichever is current.
+	it("forwards the caller's base revision on a section replace", async () => {
+		const { submit, ctx } = fakeEditWithOutline(JAPAN_OUTLINE, [
+			{ index: '1', level: 2, line: 'History', editable: true },
+			{ index: '2', level: 3, line: 'Prehistoric to classical history', editable: true },
+			{ index: '3', level: 3, line: 'Feudal era', editable: true },
+			{ index: '4', level: 3, line: 'Modern era', editable: true },
+		]);
+
+		await callTool(ctx, 'update-page', {
+			title: 'Japan',
+			source:
+				'== History ==\nkept\n\n=== Prehistoric to classical history ===\na\n\n=== Feudal era ===\nb\n\n=== Modern era ===\nc',
+			section: 2,
+			latestId: 41,
+		});
+
+		expect(submit.mock.calls[0][1]).toMatchObject({ section: '2', baserevid: 41 });
+	});
+
+	// The subsection guard compares section numbers, so it has to read the
+	// outline of the revision those numbers came from.
+	it('reads the section outline at the revision the write names', async () => {
+		const { ctx, list } = fakeEditWithOutline(JAPAN_OUTLINE, []);
+
+		await callTool(ctx, 'update-page', {
+			title: 'Japan',
+			source: '== Geography ==\nrewritten',
+			section: 6,
+			latestId: 41,
+		});
+
+		expect(list).toHaveBeenCalledWith(expect.anything(), 'Japan', 41);
+	});
+
+	// find-replace addresses its target by the text it matches, so a shifted
+	// index either fails to match or names text that genuinely holds the anchor.
+	it('does not require latestId for find-replace', async () => {
+		const { submit, ctx } = fakeFindReplace();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'find-replace',
+			section: 1,
+			find: 'founded in 1104',
+			replaceWith: 'founded in 1105',
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('leaves a whole-page write alone', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		await callTool(ctx, 'update-page', { title: 'My Page', source: 'whole page' });
+
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+});
+
+// Content larger than one read returns cannot have been read whole through this
+// server, so a replace that shortens it is discarding something unseen.
+describe('update-page unread content guard', () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	// Routed by parameter rather than by call order, so a change to how either
+	// probe reads its response shows up as a failure instead of a skipped guard.
+	function fakeSizedEdit(pageBytes: number, sectionContent?: string) {
+		const base = fakeEdit();
+		const request = vi.fn().mockImplementation((params: Record<string, unknown>) => {
+			if (params.prop === 'info') {
+				return Promise.resolve({ query: { pages: [{ title: 'My Page', length: pageBytes }] } });
+			}
+			if (params.prop === 'revisions') {
+				return Promise.resolve({
+					query: {
+						pages: [
+							{
+								revisions: [
+									{
+										slots: {
+											main: {
+												...(sectionContent === undefined ? {} : { content: sectionContent }),
+											},
+										},
+									},
+								],
+							},
+						],
+					},
+				});
+			}
+			return base.request(params);
+		});
+		const mock = createMockMwn({ request, getCsrfToken: vi.fn().mockResolvedValue('t') });
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			edit: base.ctx.edit,
+			sections: { list: vi.fn().mockResolvedValue([]), listInSource: vi.fn() },
+		});
+		return { ...base, ctx, request };
+	}
+
+	const infoProbes = (request: ReturnType<typeof vi.fn>) =>
+		request.mock.calls.filter((c) => c[0]?.prop === 'info');
+	const sectionReads = (request: ReturnType<typeof vi.fn>) =>
+		request.mock.calls.filter((c) => c[0]?.prop === 'revisions');
+
+	it('refuses a whole-page replace that shortens a page too large to have been read', async () => {
+		const { submit, ctx } = fakeSizedEdit(150000);
+
+		const result = await callTool(ctx, 'update-page', { title: 'My Page', source: 'short' });
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('150000');
+		expect(envelope.message).toContain("operation='find-replace'");
+		expect(envelope.message).toContain('removeUnreadContent');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// The guard and the read cap have to agree on what "returned whole" means,
+	// and truncateByBytes cuts only above the cap.
+	it('allows a shortening replace of a page at exactly the cap', async () => {
+		vi.stubEnv('MCP_CONTENT_MAX_BYTES', '1000');
+		const { submit, ctx } = fakeSizedEdit(1000);
+
+		assertStructuredSuccess(await callTool(ctx, 'update-page', { title: 'My Page', source: 'x' }));
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('refuses a shortening replace of a page one byte over the cap', async () => {
+		vi.stubEnv('MCP_CONTENT_MAX_BYTES', '1000');
+		const { submit, ctx } = fakeSizedEdit(1001);
+
+		assertStructuredError(
+			await callTool(ctx, 'update-page', { title: 'My Page', source: 'x' }),
+			'invalid_input',
+		);
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// The probe must measure the page the write lands on, and mwn resolves
+	// redirects unless told not to.
+	it('measures the page named, not the page it redirects to', async () => {
+		const { ctx, request } = fakeSizedEdit(150000);
+
+		await callTool(ctx, 'update-page', { title: 'My Page', source: 'short' });
+
+		expect(infoProbes(request)[0][0]).not.toHaveProperty('redirects');
+	});
+
+	// A source of multi-byte characters is longer in bytes than in characters,
+	// and the target is measured in bytes.
+	it('compares source and target in bytes, not characters', async () => {
+		vi.stubEnv('MCP_CONTENT_MAX_BYTES', '100');
+		const { submit, ctx } = fakeSizedEdit(150);
+
+		// 60 characters, 180 bytes: longer than the 150-byte page it replaces.
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: '漢'.repeat(60),
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('allows the shortening replace when it is confirmed', async () => {
+		const { submit, ctx } = fakeSizedEdit(150000);
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			removeUnreadContent: true,
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	// Nothing is measured when the confirmation has already answered the question.
+	it('makes no probe at all when the replace is confirmed', async () => {
+		const { ctx, request } = fakeSizedEdit(150000);
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			removeUnreadContent: true,
+		});
+
+		expect(infoProbes(request)).toHaveLength(0);
+	});
+
+	it('allows a replace that does not shorten the page', async () => {
+		const { submit, ctx } = fakeSizedEdit(150000);
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'x'.repeat(150001),
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('allows a shortening replace of a page small enough to have been read whole', async () => {
+		const { submit, ctx } = fakeSizedEdit(500);
+
+		const result = await callTool(ctx, 'update-page', { title: 'My Page', source: 'short' });
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	// No section of an under-cap page can be over it, so the section is never read.
+	it('does not measure a section of a page that fits within one read', async () => {
+		const { submit, ctx, request } = fakeSizedEdit(500);
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			section: 1,
+			latestId: 41,
+		});
+
+		expect(sectionReads(request)).toHaveLength(0);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('measures the section itself on a page too large to have been read whole', async () => {
+		const { submit, ctx } = fakeSizedEdit(150000, 'y'.repeat(120000));
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			section: 1,
+			latestId: 41,
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('Section 1');
+		expect(envelope.message).toContain('120000');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// The write resolves the section number against latestId, so measuring the
+	// current revision would certify a section the write does not touch.
+	it('measures the section at the revision the write names', async () => {
+		const { ctx, request } = fakeSizedEdit(150000, 'y'.repeat(120000));
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			section: 1,
+			latestId: 41,
+		});
+
+		expect(sectionReads(request)[0][0]).toMatchObject({ revids: 41, rvsection: 1 });
+	});
+
+	// The section is measured in bytes too: a section of multi-byte characters is
+	// over the cap while its character count is well under it.
+	it('measures the section in bytes, not characters', async () => {
+		vi.stubEnv('MCP_CONTENT_MAX_BYTES', '100');
+		const { submit, ctx } = fakeSizedEdit(150, '漢'.repeat(50));
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'x',
+			section: 1,
+			latestId: 41,
+		});
+
+		assertStructuredError(result, 'invalid_input');
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	// Neither probe may opt into redirect resolution: the write goes to the title
+	// the caller named, so a probe that resolves one measures a different page.
+	it('never asks either probe to follow a redirect', async () => {
+		const { ctx, request } = fakeSizedEdit(150000, 'y'.repeat(120000));
+
+		await callTool(ctx, 'update-page', { title: 'My Page', source: 'short', section: 0 });
+
+		for (const call of [...infoProbes(request), ...sectionReads(request)]) {
+			expect(call[0].redirects ?? false).toBe(false);
+		}
+	});
+
+	it('allows replacing a small section of a large page', async () => {
+		const { submit, ctx } = fakeSizedEdit(150000, 'y'.repeat(200));
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			source: 'short',
+			section: 1,
+			latestId: 41,
+		});
+
+		assertStructuredSuccess(result);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	// A source that is a truncated prefix may appear to drop subsections that
+	// simply lie past the cut, so this guard answers before that one.
+	it('reports the unread content before the subsections', async () => {
+		const base = fakeEdit();
+		const request = vi.fn().mockImplementation((params: Record<string, unknown>) => {
+			if (params.prop === 'info') {
+				return Promise.resolve({ query: { pages: [{ title: 'Japan', length: 150000 }] } });
+			}
+			if (params.prop === 'revisions') {
+				return Promise.resolve({
+					query: { pages: [{ revisions: [{ slots: { main: { content: 'y'.repeat(120000) } } }] }] },
+				});
+			}
+			return base.request(params);
+		});
+		const mock = createMockMwn({ request, getCsrfToken: vi.fn().mockResolvedValue('t') });
+		const ctx = fakeContext({
+			mwn: async () => mock as never,
+			edit: base.ctx.edit,
+			sections: { list: vi.fn().mockResolvedValue(JAPAN_OUTLINE), listInSource: vi.fn() },
+		});
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'Japan',
+			source: '== History ==\nshort',
+			section: 2,
+			latestId: 41,
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('bytes');
+		expect(envelope.message).not.toContain('subsection');
+	});
+
+	it.each(['append', 'prepend'])('never measures anything for a %s', async (operation) => {
+		const { submit, ctx, request } = fakeSizedEdit(150000);
+
+		await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation,
+			source: 'x',
+			section: 1,
+			latestId: 41,
+		});
+
+		expect(infoProbes(request)).toHaveLength(0);
+		expect(submit).toHaveBeenCalledTimes(1);
+	});
+
+	it('refuses removeUnreadContent outside a replace', async () => {
+		const { submit, ctx } = fakeEdit();
+
+		const result = await callTool(ctx, 'update-page', {
+			title: 'My Page',
+			operation: 'append',
+			source: 'x',
+			removeUnreadContent: true,
+		});
+
+		const envelope = assertStructuredError(result, 'invalid_input');
+		expect(envelope.message).toContain('removeUnreadContent');
 		expect(submit).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/536

Two guards on `operation='replace'`, both for writes that delete content the caller never saw.

## A section number is meaningless without its revision

The wiki resolves a section number against whichever revision is current, so an index read before someone inserted a section addresses a different one. Verified on 1.43.9: the caller read at revision R meaning to edit `== Beta ==`, another edit inserted a section, the caller wrote `section=2`, and the result was `Success` with `== Alpha ==` destroyed and the page carrying two `== Beta ==` headings. No conflict, no warning.

MediaWiki resolves it correctly when the caller's base revision travels with the edit, and that value can only come from the caller: the server substituting its own just-read revision reproduces the destruction exactly, because that revision *is* the current one. So a section replace now requires `latestId`. The lead is exempt — it is always section 0 and no insertion moves it.

Deltas keep working without it: a delta in the wrong section is misplaced rather than lost and shows in the diff. `find-replace` addresses its target by matched text rather than by position.

## A replace cannot shorten what it could not have read

Content larger than one response cannot have been read whole through this server, so a replace whose source is shorter than such a target is discarding bytes the caller never saw — the loss #536 records. Refused unless `removeUnreadContent` says the shortening is meant. Growth and same-size writes pass untouched, and a target inside the budget is never measured. Per the `removeSubsections` precedent, the override is named in its own parameter description and in the refusal, never in the tool description.

## Both guards measure the revision the write acts on

The first draft of this PR did not, and review caught it deleting 300 unread bytes **through the guard**. Requiring `latestId` means the write resolves the section number against that revision, while the guard was reading the section as the page stands now. After an insertion those are different sections, so the guard certified a small one while the write destroyed a large one — the exact race the sibling guard in this same commit exists to close.

Both now read at `latestId`: the size probe via `revids` + `rvsection`, and the subsection guard via `action=parse&oldid=`. That second one also closes a pre-existing mismatch in the 0.17.0 guard, which this PR would otherwise have moved from an opt-in path onto the default one.

## Verified

Against a live MediaWiki 1.43.9, the reviewer's own reproduction at a 100-byte cap: page with `1=Small (4B)`, `2=Big (310B)`, then a section inserted so section 2 is now `Small`. `section=2, latestId=R1, source='== Small ==\nrewritten'` is **refused**, naming 310 bytes, page byte-identical. Before the fix that call succeeded and the page went 352 → 63 bytes.

Also verified: whole-page replace of a truncated read refused and page intact; the same write confirmed goes through; growth allowed; shortening inside the budget allowed; a section replace with no `latestId` refused; with `latestId` allowed; appends unaffected.

## Tests, mutation-checked

The reviewer found six mutants surviving the first draft's tests. Every one is now killed, verified by applying each mutation and running the suite:

| Mutation | |
|---|---|
| `pageBytes <= cap` → `< cap` | killed |
| either probe made to follow redirects | killed |
| source measured in characters | killed |
| section measured in characters | killed |
| section read at the current revision | killed |
| outline read at the current revision | killed |
| the lead loses its exemption | killed |
| the two guards swapped in order | killed |

2278 tests, `typecheck`, `lint`, `fmt:check` and `build` green locally.

## One push-back

The review suggests deriving section sizes from `byteoffset` in the outline the subsection guard already fetches, to save a request. `byteoffset` is a **codepoint** offset despite its name — measured earlier in this work, it reported 618 where the true byte offset was 1734. Sizes derived from it under-report on every multi-byte page, which is exactly where sections are largest, and the guard would fail open there. The extra request stands.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; scope agreed with @alistair3149 as part of a four-PR plan, with the narrowing of the section rule my own call; diff not yet human-reviewed, but reviewed by a fresh-context reviewer agent whose critical and important findings are all fixed here; tests written first and seen failing, mutation-checked, every gate run locally, and both guards exercised against a live MediaWiki 1.43.9.</sub>