### PR TITLE
Render the truncation marker as a sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- A truncation marker now reads as one sentence rather than a block of labelled fields, so a capped result states the follow-up call to make instead of leaving a caller to assemble one from a parameter and a value listed separately. `structuredContent` carries the same marker as a typed object, unchanged.
+
 ### Breaking changes
 
 - `update-page` now refuses a call that replaces a page or section when the source would shorten a target too large for one read to return whole. Pass `removeUnreadContent: true` to do it deliberately, or use `operation='find-replace'` to change part of a page without resending it; appends, growth and any target inside the byte budget are unaffected.

--- a/docs/tool-conventions.md
+++ b/docs/tool-conventions.md
@@ -133,13 +133,13 @@ Parameter descriptions must:
 
 #### Result caps and truncation signaling
 
-Tools that return variable-size result sets or content bodies have a per-call cap. When the cap is hit, the tool sets a `truncation` field on its payload, which reaches the caller through both response channels: rendered as prose in `content[0]` and typed in `structuredContent`. Three shapes, each a variant of `TruncationInfo` in `src/results/truncation.ts`:
+Tools that return variable-size result sets or content bodies have a per-call cap. When the cap is hit, the tool sets a `truncation` field on its payload, which reaches the caller through both response channels: as one sentence in `content[0]`, and as the typed object in `structuredContent`. A tool builds the object; `truncationSentence` in `src/results/truncation.ts` turns it into the sentence, so the wording of each variant is decided once rather than per tool. Three shapes:
 
 - **With continuation** (`more-available`, the caller can fetch more): the count returned, the item noun, and the parameter and value that fetch the next segment.
 - **Without continuation** (`capped-no-continuation`, the only remedy is a narrower query): the count returned, the limit, and a hint naming the narrowing available.
 - **Content truncated** (`content-truncated`, the response body exceeded the byte budget): the bytes returned and the bytes available, a `remedyHint` — a full sentence of the form `"To <purpose>, <action>."` — and, where narrower targets exist, a `sections` list naming them.
 
-Each `sections` entry carries the number that addresses it, as `"3 (History)"`. That number is the section's own `index` from the API, never its position in the list: a transcluded heading occupies a position but no `section=` value addresses it, so numbering by position sends a caller to a different section than the one it read. Transcluded headings are left out of the list for the same reason.
+The sentence states the follow-up call outright — `call get-page-history again with olderThan=…` — rather than leaving a caller to assemble one from a parameter and a value rendered as separate fields. Each `sections` entry carries the number that addresses it, as `"3 (History)"`. That number is the section's own `index` from the API, never its position in the list: a transcluded heading occupies a position but no `section=` value addresses it, so numbering by position sends a caller to a different section than the one it read. Transcluded headings are left out of the list for the same reason.
 
 Where the narrowing a parameter offers is exhausted — the call already names the single item the response can be narrowed to, so naming it again returns the same response — no action remains, and the `remedyHint` says so instead. `get-page` truncating a `section=N` read names that section's own subsections, the only narrower target it has; where the section has none, the remedy says no narrower read exists rather than pointing back at the call that just truncated.
 

--- a/src/results/format.ts
+++ b/src/results/format.ts
@@ -34,8 +34,20 @@ const ABBREVIATIONS = new Set([
 	'Wsl',
 ]);
 
-export function formatPayload(data: unknown): string {
-	const rendered = renderValue(data, '').trim();
+/**
+ * `inlineKeys` names fields whose value is prose rather than content, and so
+ * stays on the label's own line however long it runs. Everything else over
+ * INLINE_STRING_LIMIT becomes its own block at column 0, which is right for a
+ * content body — indenting one would add leading spaces, and a leading space
+ * turns a wikitext line into a `<pre>` block — and wrong for a sentence, which
+ * then reads as belonging to the response rather than to the entry it sits in.
+ */
+export interface FormatOptions {
+	readonly inlineKeys?: ReadonlySet<string>;
+}
+
+export function formatPayload(data: unknown, options: FormatOptions = {}): string {
+	const rendered = renderValue(data, '', options).trim();
 	return rendered.length > 0 ? rendered : '(empty)';
 }
 
@@ -59,7 +71,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function renderValue(value: unknown, indent: string): string {
+function renderValue(value: unknown, indent: string, options: FormatOptions): string {
 	if (value === null || value === undefined) {
 		return '—';
 	}
@@ -70,23 +82,37 @@ function renderValue(value: unknown, indent: string): string {
 		return String(value);
 	}
 	if (Array.isArray(value)) {
-		return renderArray(value, indent);
+		return renderArray(value, indent, options);
 	}
 	if (isPlainObject(value)) {
-		return renderObject(value, indent);
+		return renderObject(value, indent, options);
 	}
 	return stringifyUnknown(value);
 }
 
-function renderObject(obj: Record<string, unknown>, indent: string): string {
+function renderObject(
+	obj: Record<string, unknown>,
+	indent: string,
+	options: FormatOptions,
+): string {
 	const entries = Object.entries(obj).filter(([, v]) => v !== undefined);
 	if (entries.length === 0) {
 		return '(empty)';
 	}
-	return entries.map(([key, value]) => renderField(humanizeKey(key), value, indent)).join('\n');
+	return entries
+		.map(([key, value]) =>
+			renderField(humanizeKey(key), value, indent, options, options.inlineKeys?.has(key) ?? false),
+		)
+		.join('\n');
 }
 
-function renderField(label: string, value: unknown, indent: string): string {
+function renderField(
+	label: string,
+	value: unknown,
+	indent: string,
+	options: FormatOptions,
+	inline: boolean,
+): string {
 	const prefix = `${indent}${label}:`;
 	if (value === null || value === undefined) {
 		return `${prefix} —`;
@@ -95,7 +121,7 @@ function renderField(label: string, value: unknown, indent: string): string {
 		if (value === '') {
 			return `${prefix} (empty)`;
 		}
-		if (value.length <= INLINE_STRING_LIMIT && !value.includes('\n')) {
+		if (inline || (value.length <= INLINE_STRING_LIMIT && !value.includes('\n'))) {
 			return `${prefix} ${value}`;
 		}
 		// Closed with a blank line. Without one the next field's label is the only
@@ -110,15 +136,15 @@ function renderField(label: string, value: unknown, indent: string): string {
 		if (value.length === 0) {
 			return `${prefix} (none)`;
 		}
-		return `${prefix}\n${renderArray(value, indent)}`;
+		return `${prefix}\n${renderArray(value, indent, options)}`;
 	}
 	if (isPlainObject(value)) {
-		return `${prefix}\n${renderObject(value, indent + '  ')}`;
+		return `${prefix}\n${renderObject(value, indent + '  ', options)}`;
 	}
 	return `${prefix} ${stringifyUnknown(value)}`;
 }
 
-function renderArray(arr: unknown[], indent: string): string {
+function renderArray(arr: unknown[], indent: string, options: FormatOptions): string {
 	const itemIndent = `${indent}- `;
 	const continuationIndent = `${indent}  `;
 	return arr
@@ -133,10 +159,10 @@ function renderArray(arr: unknown[], indent: string): string {
 				return `${itemIndent}${item}`;
 			}
 			if (Array.isArray(item)) {
-				return `${itemIndent}\n${renderArray(item, continuationIndent)}`;
+				return `${itemIndent}\n${renderArray(item, continuationIndent, options)}`;
 			}
 			if (isPlainObject(item)) {
-				const objText = renderObject(item, continuationIndent);
+				const objText = renderObject(item, continuationIndent, options);
 				const lines = objText.split('\n');
 				if (lines.length === 0) {
 					return `${itemIndent}(empty)`;

--- a/src/results/response.ts
+++ b/src/results/response.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from '@modelcontextprotocol/server';
 import type { ErrorEnvelope } from '../results/schemas.ts';
 import type { ErrorCategory } from '../errors/classifyError.ts';
 import { formatPayload } from './format.ts';
+import { truncationSentence, type TruncationInfo } from './truncation.ts';
 
 export interface ResponseFormatter {
 	ok(payload: unknown): CallToolResult;
@@ -12,9 +13,59 @@ export interface ResponseFormatter {
 	permissionDenied(message: string, code?: string): CallToolResult;
 }
 
+// The marker is a sentence once rendered, so it stays on its label's line
+// however long it runs.
+const PROSE_KEYS: ReadonlySet<string> = new Set(['truncation']);
+
+const TRUNCATION_REASONS = new Set([
+	'more-available',
+	'capped-no-continuation',
+	'content-truncated',
+]);
+
+function isTruncationInfo(value: unknown): value is TruncationInfo {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+	const reason = (value as { reason?: unknown }).reason;
+	return typeof reason === 'string' && TRUNCATION_REASONS.has(reason);
+}
+
+/**
+ * Replaces every truncation marker in a payload with its sentence, for the
+ * prose channel alone.
+ *
+ * The generic formatter renders a marker field by field, which spells internal
+ * field names as labels and leaves a caller to assemble its own follow-up call
+ * out of a nested `Param`/`Value` pair. One sentence states it. The payload is
+ * walked rather than checked at its root because `get-pages` carries a marker
+ * per entry as well as one for the response.
+ */
+function withProseTruncation(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(withProseTruncation);
+	}
+	if (typeof value !== 'object' || value === null) {
+		return value;
+	}
+	return Object.fromEntries(
+		Object.entries(value).map(([key, entry]) => [
+			key,
+			key === 'truncation' && isTruncationInfo(entry)
+				? truncationSentence(entry)
+				: withProseTruncation(entry),
+		]),
+	);
+}
+
 export function structuredResult(data: unknown): CallToolResult {
 	return {
-		content: [{ type: 'text', text: formatPayload(data) }],
+		content: [
+			{
+				type: 'text',
+				text: formatPayload(withProseTruncation(data), { inlineKeys: PROSE_KEYS }),
+			},
+		],
 		// structuredContent mirrors the typed payload so the dispatcher can detect
 		// truncation via the `truncation` field without reparsing the rendered text.
 		structuredContent: data,

--- a/src/results/truncation.ts
+++ b/src/results/truncation.ts
@@ -38,6 +38,35 @@ export type TruncationInfo =
 			remedyHint: string;
 	  };
 
+/**
+ * The marker as one sentence, which is what the prose channel carries;
+ * `structuredContent` keeps the typed object.
+ *
+ * Phrased so a count never modifies its noun directly. Every `itemNoun` is
+ * plural, so "Returned 1 pages" is the alternative, and singularising a noun
+ * this vocabulary already includes — `properties`, `matches` — needs more rules
+ * than the sentence is worth.
+ */
+export function truncationSentence(info: TruncationInfo): string {
+	switch (info.reason) {
+		case 'content-truncated': {
+			const sections =
+				info.sections !== undefined && info.sections.length > 0
+					? ` Available sections: ${info.sections.join(', ')}.`
+					: '';
+			return `Content (${info.itemNoun}) truncated at ${info.returnedBytes} of ${info.totalBytes} bytes.${sections} ${info.remedyHint}`;
+		}
+		case 'more-available':
+			return `More ${info.itemNoun} available; ${info.returnedCount} returned. To fetch the next segment, call ${info.toolName} again with ${info.continueWith.param}=${info.continueWith.value}.`;
+		case 'capped-no-continuation':
+			return `Capped at the ${info.itemNoun} limit of ${info.limit}; ${info.returnedCount} returned. Additional ${info.itemNoun} may exist — ${info.narrowHint}`;
+		default: {
+			const _exhaustive: never = info;
+			return _exhaustive;
+		}
+	}
+}
+
 export interface TruncatedContent {
 	text: string;
 	truncated: boolean;

--- a/tests/results/truncationSentence.test.ts
+++ b/tests/results/truncationSentence.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { truncationSentence } from '../../src/results/truncation.ts';
+import { structuredResult } from '../../src/results/response.ts';
+import { assertStructuredSuccess } from '../helpers/structuredResult.ts';
+
+describe('truncationSentence', () => {
+	it('states the call that fetches the next segment', () => {
+		expect(
+			truncationSentence({
+				reason: 'more-available',
+				returnedCount: 50,
+				itemNoun: 'revisions',
+				toolName: 'get-page-history',
+				continueWith: { param: 'olderThan', value: '2026-01-01T00:00:00Z' },
+			}),
+		).toBe(
+			'More revisions available; 50 returned. To fetch the next segment, call get-page-history again with olderThan=2026-01-01T00:00:00Z.',
+		);
+	});
+
+	it('states the cap and the narrowing when there is no continuation', () => {
+		expect(
+			truncationSentence({
+				reason: 'capped-no-continuation',
+				returnedCount: 50,
+				limit: 50,
+				itemNoun: 'results',
+				narrowHint: 'refine the search terms.',
+			}),
+		).toBe(
+			'Capped at the results limit of 50; 50 returned. Additional results may exist — refine the search terms.',
+		);
+	});
+
+	it('states the bytes, the narrower targets and the remedy', () => {
+		expect(
+			truncationSentence({
+				reason: 'content-truncated',
+				returnedBytes: 75000,
+				totalBytes: 129723,
+				itemNoun: 'wikitext',
+				toolName: 'get-page',
+				sections: ['2 (Origins)', '3 (Modern era)'],
+				remedyHint:
+					'To read part of this section, call get-page again with one of the subsection numbers listed.',
+			}),
+		).toBe(
+			'Content (wikitext) truncated at 75000 of 129723 bytes. Available sections: 2 (Origins), 3 (Modern era). To read part of this section, call get-page again with one of the subsection numbers listed.',
+		);
+	});
+
+	it('leaves out the section clause when there are no narrower targets', () => {
+		const sentence = truncationSentence({
+			reason: 'content-truncated',
+			returnedBytes: 75000,
+			totalBytes: 129723,
+			itemNoun: 'wikitext',
+			toolName: 'get-page',
+			remedyHint: 'No narrower read returns more of this section.',
+		});
+
+		expect(sentence).not.toContain('Available sections');
+		expect(sentence).toBe(
+			'Content (wikitext) truncated at 75000 of 129723 bytes. No narrower read returns more of this section.',
+		);
+	});
+
+	// Every itemNoun is plural, so a count must never modify one directly.
+	it('reads correctly when one item was returned', () => {
+		expect(
+			truncationSentence({
+				reason: 'more-available',
+				returnedCount: 1,
+				itemNoun: 'pages',
+				toolName: 'get-pages',
+				continueWith: { param: 'titles', value: 'Amsterdam|Antwerp' },
+			}),
+		).toContain('More pages available; 1 returned.');
+	});
+});
+
+describe('truncation in a result', () => {
+	const marker = {
+		reason: 'more-available' as const,
+		returnedCount: 50,
+		itemNoun: 'revisions',
+		toolName: 'get-page-history',
+		continueWith: { param: 'olderThan', value: '2026-01-01T00:00:00Z' },
+	};
+
+	it('renders the sentence in the prose channel and keeps the object in the typed one', () => {
+		const result = structuredResult({ title: 'Japan', truncation: marker });
+
+		expect(assertStructuredSuccess(result)).toContain(
+			'Truncation: More revisions available; 50 returned.',
+		);
+		expect(result.structuredContent).toEqual({ title: 'Japan', truncation: marker });
+	});
+
+	// The sentence runs past the length at which a value becomes its own block,
+	// which would put it at column 0, outside the entry it belongs to.
+	it('keeps a nested marker on its own label line, indented under its entry', () => {
+		const result = structuredResult({
+			pages: [{ title: 'Big', truncation: { ...marker, itemNoun: 'wikitext' } }],
+		});
+
+		expect(assertStructuredSuccess(result)).toContain('  Truncation: More wikitext available;');
+	});
+
+	it('leaves a truncation field that is not a marker alone', () => {
+		const result = structuredResult({ truncation: { reason: 'something else', n: 1 } });
+
+		expect(assertStructuredSuccess(result)).toContain('Reason: something else');
+	});
+});

--- a/tests/tools/compare-pages.test.ts
+++ b/tests/tools/compare-pages.test.ts
@@ -437,11 +437,7 @@ describe('compare-pages', () => {
 		);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: content-truncated');
-		expect(text).toContain('  Returned bytes: 75000');
-		expect(text).toContain('  Item noun: diff');
-		expect(text).toContain('  Tool name: compare-pages');
+		expect(text).toContain('Content (diff) truncated at 75000 of');
 	});
 
 	it('cheap mode (includeDiff=false) never attaches a content-truncated truncation', async () => {

--- a/tests/tools/extensions/bucket/bucket-query.test.ts
+++ b/tests/tools/extensions/bucket/bucket-query.test.ts
@@ -234,10 +234,7 @@ describe('bucket-query', () => {
 		);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('Reason: more-available');
-		expect(text).toContain('Param: continueFrom');
-		expect(text).toContain('Value: 50');
+		expect(text).toContain('call bucket-query again with continueFrom=50.');
 	});
 
 	it('continueFrom advances by rows.length on subsequent pages', async () => {
@@ -259,7 +256,7 @@ describe('bucket-query', () => {
 		);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Value: 100');
+		expect(text).toContain('with continueFrom=100.');
 	});
 
 	it('emits no truncation when rows.length < effectiveLimit', async () => {

--- a/tests/tools/extensions/cargo/cargo-query.test.ts
+++ b/tests/tools/extensions/cargo/cargo-query.test.ts
@@ -172,10 +172,7 @@ describe('cargo-query', () => {
 		const result = await cargoQuery.handle({ tables: 'items', limit: 50 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('Reason: more-available');
-		expect(text).toContain('Param: continueFrom');
-		expect(text).toContain('Value: 50');
+		expect(text).toContain('call cargo-query again with continueFrom=50.');
 	});
 
 	it('continueWith.value advances by rows.length on subsequent pages', async () => {
@@ -190,7 +187,7 @@ describe('cargo-query', () => {
 		const result = await cargoQuery.handle({ tables: 'items', limit: 50, continueFrom: '50' }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Value: 100');
+		expect(text).toContain('with continueFrom=100.');
 	});
 
 	it('emits no truncation when rows.length < effectiveLimit', async () => {

--- a/tests/tools/extensions/smw/smw-list-properties.test.ts
+++ b/tests/tools/extensions/smw/smw-list-properties.test.ts
@@ -200,10 +200,7 @@ describe('smw-list-properties', () => {
 		const result = await smwListProperties.handle({ limit: 50 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('Reason: more-available');
-		expect(text).toContain('Param: continueFrom');
-		expect(text).toContain('Value: 50');
+		expect(text).toContain('call smw-list-properties again with continueFrom=50.');
 	});
 
 	it('omits truncation when query-continue-offset is 0', async () => {

--- a/tests/tools/extensions/smw/smw-query.test.ts
+++ b/tests/tools/extensions/smw/smw-query.test.ts
@@ -174,10 +174,7 @@ describe('smw-query', () => {
 		const result = await smwQuery.handle({ query: '[[Category:X]]', limit: 1 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('Reason: more-available');
-		expect(text).toContain('Param: continueFrom');
-		expect(text).toContain('Value: 1');
+		expect(text).toContain('call smw-query again with continueFrom=1.');
 	});
 
 	it('omits empty printouts from a row', async () => {

--- a/tests/tools/get-category-members.test.ts
+++ b/tests/tools/get-category-members.test.ts
@@ -134,14 +134,8 @@ describe('get-category-members', () => {
 		const result = await getCategoryMembers.handle({ category: 'Foo' }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Returned count: 1');
-		expect(text).toContain('  Item noun: members');
-		expect(text).toContain('  Tool name: get-category-members');
-		expect(text).toContain('  Continue with:');
-		expect(text).toContain('    Param: continueFrom');
-		expect(text).toContain('    Value: page|DOE|456');
+		expect(text).toContain('More members available; 1 returned.');
+		expect(text).toContain('call get-category-members again with continueFrom=page|DOE|456.');
 	});
 
 	it('omits truncation when response.continue is absent', async () => {

--- a/tests/tools/get-links-here.test.ts
+++ b/tests/tools/get-links-here.test.ts
@@ -192,12 +192,8 @@ describe('get-links-here', () => {
 		const result = await getLinksHere.handle(args({ expandRedirects: false }), ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Item noun: links');
-		expect(text).toContain('  Tool name: get-links-here');
-		expect(text).toContain('    Param: continueFrom');
-		expect(text).toContain('    Value: 0|123');
+		expect(text).toContain('More links available;');
+		expect(text).toContain('call get-links-here again with continueFrom=0|123.');
 	});
 
 	it('returns an empty list without error when the target has no references', async () => {

--- a/tests/tools/get-page-history.test.ts
+++ b/tests/tools/get-page-history.test.ts
@@ -325,14 +325,8 @@ describe('get-page-history', () => {
 		const result = await getPageHistory.handle({ title: 'Test Page' }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Returned count: 2');
-		expect(text).toContain('  Item noun: revisions');
-		expect(text).toContain('  Tool name: get-page-history');
-		expect(text).toContain('  Continue with:');
-		expect(text).toContain('    Param: olderThan');
-		expect(text).toContain('    Value: 99');
+		expect(text).toContain('More revisions available; 2 returned.');
+		expect(text).toContain('call get-page-history again with olderThan=99.');
 	});
 
 	it('attaches a more-available truncation with newerThan when walking forward', async () => {
@@ -372,14 +366,8 @@ describe('get-page-history', () => {
 		const result = await getPageHistory.handle({ title: 'Test Page', newerThan: 49 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Returned count: 2');
-		expect(text).toContain('  Item noun: revisions');
-		expect(text).toContain('  Tool name: get-page-history');
-		expect(text).toContain('  Continue with:');
-		expect(text).toContain('    Param: newerThan');
-		expect(text).toContain('    Value: 60');
+		expect(text).toContain('More revisions available; 2 returned.');
+		expect(text).toContain('call get-page-history again with newerThan=60.');
 
 		const call = mock.request.mock.calls[0][0];
 		expect(call.rvdir).toBe('newer');

--- a/tests/tools/get-page.test.ts
+++ b/tests/tools/get-page.test.ts
@@ -413,13 +413,8 @@ describe('get-page', () => {
 		const text = assertStructuredSuccess(result);
 		// Source body is ~75000 chars, rendered as long-string block after Source: label.
 		expect(text).toMatch(/Source:\n\nx{75000}/);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: content-truncated');
-		expect(text).toContain('  Returned bytes: 75000');
-		expect(text).toContain('  Total bytes: 75001');
-		expect(text).toContain('  Item noun: wikitext');
-		expect(text).toContain('  Tool name: get-page');
-		expect(text).toContain('  Sections:\n  - 0 (Lead)\n  - 1 (History)');
+		expect(text).toContain('Content (wikitext) truncated at 75000 of 75001 bytes.');
+		expect(text).toContain('Available sections: 0 (Lead), 1 (History).');
 	});
 
 	it('omits truncation when source is exactly at the byte cap', async () => {
@@ -480,12 +475,8 @@ describe('get-page', () => {
 		const text = assertStructuredSuccess(result);
 		// Truncated HTML is rendered as long-string block.
 		expect(text).toMatch(/HTML:\n\n<p>x+/);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: content-truncated');
-		expect(text).toContain('  Returned bytes: 75000');
-		expect(text).toContain('  Item noun: HTML');
-		expect(text).toContain('  Tool name: get-page');
-		expect(text).toContain('  Sections:\n  - 0 (Lead)\n  - 1 (Heading)');
+		expect(text).toContain('Content (HTML) truncated at 75000 of');
+		expect(text).toContain('Available sections: 0 (Lead), 1 (Heading).');
 	});
 
 	// A caller that already passed section=N cannot narrow by passing it again,
@@ -516,7 +507,7 @@ describe('get-page', () => {
 		);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('  Sections:\n  - 2 (Origins)\n  - 3 (Modern era)');
+		expect(text).toContain('Available sections: 2 (Origins), 3 (Modern era).');
 		expect(text).not.toContain('Geography');
 		expect(text).toContain('subsection numbers');
 	});

--- a/tests/tools/get-pages.test.ts
+++ b/tests/tools/get-pages.test.ts
@@ -568,16 +568,12 @@ describe('get-pages', () => {
 			// without it the wikitext runs straight into `Truncation:`, and a page whose
 			// own text contains such a line would read as a field of this payload.
 			expect(text).toMatch(/Page ID: 1[\s\S]*?Source:\n\nx{1000}\n\n {2}Truncation:/);
-			expect(text).toContain('    Reason: content-truncated');
-			expect(text).toContain('    Returned bytes: 1000');
-			expect(text).toContain('    Total bytes: 1001');
-			expect(text).toContain('    Item noun: wikitext');
-			expect(text).toContain('    Tool name: get-pages');
-			expect(text).toContain('    Sections:\n    - 0 (Lead)\n    - 1 (Overview)');
+			expect(text).toContain('Content (wikitext) truncated at 1000 of 1001 bytes.');
+			expect(text).toContain('Available sections: 0 (Lead), 1 (Overview).');
 			// The first body reached the response budget, so the page after it is
 			// named rather than returned.
 			expect(text).not.toContain(`  Source: ${small}`);
-			expect(text).toContain('    Value: Small');
+			expect(text).toContain('call get-pages again with titles=Small.');
 
 			expect(request).toHaveBeenCalledTimes(1);
 			expect(request).toHaveBeenCalledWith(
@@ -621,8 +617,7 @@ describe('get-pages', () => {
 
 			const text = assertStructuredSuccess(result);
 			expect((text.match(/Truncation:/g) ?? []).length).toBe(2);
-			expect(text).toContain('  Reason: content-truncated');
-			expect(text).toContain('  Reason: more-available');
+			expect(text).toContain('More pages available;');
 			expect(text).not.toContain('Title: BigB');
 			expect(request).toHaveBeenCalledTimes(1);
 		});
@@ -717,11 +712,8 @@ describe('get-pages response budget', () => {
 		expect(text).toContain('Title: P1');
 		expect(text).toContain('Title: P2');
 		expect(text).not.toContain('Title: P3');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Returned count: 2');
-		expect(text).toContain('  Item noun: pages');
-		expect(text).toContain('    Param: titles');
-		expect(text).toContain('    Value: P3');
+		expect(text).toContain('More pages available; 2 returned.');
+		expect(text).toContain('call get-pages again with titles=P3.');
 	});
 
 	// A page the wiki does not have and a page left out for the budget are
@@ -744,7 +736,7 @@ describe('get-pages response budget', () => {
 		const text = assertStructuredSuccess(await read(ctx, ['P1', 'Gone', 'P3']));
 
 		expect(text).toContain('Missing:\n- Gone');
-		expect(text).toContain('    Value: P3');
+		expect(text).toContain('call get-pages again with titles=P3.');
 		expect(text).not.toContain('Title: P3');
 	});
 
@@ -756,7 +748,7 @@ describe('get-pages response budget', () => {
 		const text = assertStructuredSuccess(await read(ctx, ['P1', 'P2']));
 
 		expect(text).toContain('Title: P1');
-		expect(text).toContain('  Reason: content-truncated');
+		expect(text).toContain('Content (wikitext) truncated at');
 		expect(text).not.toContain('Title: P2');
 	});
 
@@ -769,7 +761,7 @@ describe('get-pages response budget', () => {
 		const text = assertStructuredSuccess(await read(ctx, ['P1', 'P2']));
 
 		expect(text).toContain('Title: P2');
-		expect(text).toContain('  Reason: content-truncated');
+		expect(text).toContain('Content (wikitext) truncated at');
 		expect(text).toMatch(/Source:\n\nx{1000}/);
 	});
 
@@ -792,6 +784,6 @@ describe('get-pages response budget', () => {
 
 		const text = assertStructuredSuccess(await read(ctx, ['P1', 'Shortcut']));
 
-		expect(text).toContain('    Value: Shortcut');
+		expect(text).toContain('call get-pages again with titles=Shortcut.');
 	});
 });

--- a/tests/tools/get-recent-changes.test.ts
+++ b/tests/tools/get-recent-changes.test.ts
@@ -479,14 +479,8 @@ describe('get-recent-changes — truncation and empty results', () => {
 		const result = await getRecentChanges.handle({}, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: more-available');
-		expect(text).toContain('  Returned count: 2');
-		expect(text).toContain('  Item noun: changes');
-		expect(text).toContain('  Tool name: get-recent-changes');
-		expect(text).toContain('  Continue with:');
-		expect(text).toContain('    Param: continue');
-		expect(text).toContain('    Value: 20260101000000|1234');
+		expect(text).toContain('More changes available; 2 returned.');
+		expect(text).toContain('call get-recent-changes again with continue=20260101000000|1234.');
 	});
 
 	it('omits truncation when rccontinue is absent', async () => {

--- a/tests/tools/get-revision.test.ts
+++ b/tests/tools/get-revision.test.ts
@@ -35,10 +35,7 @@ describe('get-revision', () => {
 
 			const text = assertStructuredSuccess(result);
 			expect(text).toMatch(/Source:\n\nx{500}\n/);
-			expect(text).toContain('  Reason: content-truncated');
-			expect(text).toContain('  Returned bytes: 500');
-			expect(text).toContain('  Total bytes: 501');
-			expect(text).toContain('  Tool name: get-revision');
+			expect(text).toContain('Content (wikitext) truncated at 500 of 501 bytes.');
 		});
 
 		it('leaves source alone at exactly the cap', async () => {
@@ -69,8 +66,7 @@ describe('get-revision', () => {
 			);
 
 			const text = assertStructuredSuccess(result);
-			expect(text).toContain('  Item noun: HTML');
-			expect(text).toContain('  Returned bytes: 500');
+			expect(text).toContain('Content (HTML) truncated at 500 of');
 			// Rendering HTML alone makes no revisions query, so which revision this
 			// is cannot be known and the remedy names both routes.
 			expect(text).toContain('If this is the page');

--- a/tests/tools/parse-wikitext.test.ts
+++ b/tests/tools/parse-wikitext.test.ts
@@ -290,12 +290,7 @@ describe('parse-wikitext', () => {
 
 		const text = assertStructuredSuccess(result);
 		expect(text).toMatch(/HTML:\n\n<p>x+/);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: content-truncated');
-		expect(text).toContain('  Returned bytes: 75000');
-		expect(text).toContain('  Total bytes: 85007');
-		expect(text).toContain('  Item noun: HTML');
-		expect(text).toContain('  Tool name: parse-wikitext');
+		expect(text).toContain('Content (HTML) truncated at 75000 of 85007 bytes.');
 		expect(text).toContain('Categories:\n- Category: Foo');
 	});
 

--- a/tests/tools/search-page-by-prefix.test.ts
+++ b/tests/tools/search-page-by-prefix.test.ts
@@ -76,11 +76,7 @@ describe('search-page-by-prefix', () => {
 		const result = await searchPageByPrefix.handle({ prefix: 'A', limit: 10 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: capped-no-continuation');
-		expect(text).toContain('  Returned count: 1');
-		expect(text).toContain('  Limit: 10');
-		expect(text).toContain('  Item noun: titles');
+		expect(text).toContain('Capped at the titles limit of 10; 1 returned.');
 	});
 
 	it('omits truncation when response.continue is absent', async () => {

--- a/tests/tools/search-page.test.ts
+++ b/tests/tools/search-page.test.ts
@@ -166,11 +166,7 @@ describe('search-page', () => {
 		const result = await searchPage.handle({ query: 'test', limit: 10 }, ctx);
 
 		const text = assertStructuredSuccess(result);
-		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Reason: capped-no-continuation');
-		expect(text).toContain('  Returned count: 1');
-		expect(text).toContain('  Limit: 10');
-		expect(text).toContain('  Item noun: matches');
+		expect(text).toContain('Capped at the matches limit of 10; 1 returned.');
 	});
 
 	it('omits truncation when response.continue is absent', async () => {
@@ -265,7 +261,7 @@ describe('search-page', () => {
 
 		const text = assertStructuredSuccess(result);
 		expect(text).toContain('Truncation:');
-		expect(text).toContain('  Limit: 10');
+		expect(text).toContain('limit of 10;');
 	});
 
 	it('searches page content rather than titles', async () => {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/issues/606

The marker reached the caller as a block of labelled fields, because the function that rendered it as prose was never called and `formatPayload` walked the object generically instead. That spelled internal field names as labels, and — the part that actually costs something — rendered a continuation as a nested `Param`/`Value` pair:

```
Truncation:
  Reason: more-available
  Returned count: 50
  Item noun: revisions
  Tool name: get-page-history
  Continue with:
    Param: olderThan
    Value: 2026-01-01T00:00:00Z
```

Nine tools produce that variant, and every one of them left the caller to work out that this means `olderThan=2026-01-01T00:00:00Z`. Now:

```
Truncation: More revisions available; 50 returned. To fetch the next segment, call get-page-history again with olderThan=2026-01-01T00:00:00Z.
```

All three variants, as they render today:

| | |
|---|---|
| `more-available` | `More pages available; 1 returned. To fetch the next segment, call get-pages again with titles=Amsterdam\|Antwerp.` |
| `capped-no-continuation` | `Capped at the results limit of 50; 50 returned. Additional results may exist — refine the search terms.` |
| `content-truncated` | `Content (wikitext) truncated at 75000 of 129723 bytes. Available sections: 2 (Origins), 3 (Modern era). To read part of this section, …` |

## Where the sentence is built

`truncationSentence` sits beside the type it renders and takes nothing but the marker, so each variant's wording is decided once rather than per tool. `structuredResult` substitutes it into a copy of the payload before formatting and passes the original as `structuredContent`, so the typed channel is byte-identical and `detectTruncation` still works unchanged. The payload is walked rather than checked at its root, because `get-pages` carries a marker per entry as well as one for the response.

## Why formatPayload gained an option rather than knowledge

Its contract is its first line — *"Generic recursive markdown formatter for tool payloads"* — and teaching it about `TruncationInfo` would trade that away. It now takes `inlineKeys`, naming fields whose value is prose rather than content; prose stays on its label's line however long it runs.

Content deliberately does not. A body over the inline limit becomes its own block at column 0, and I confirmed why that has to stay: indenting a nested body would add leading spaces, and a leading space turns a wikitext line into a `<pre>` block. Left to that rule the sentence broke out of the entry it belonged to:

```
- Page ID: 1
  Title: Big
  Truncation:

Content (wikitext) truncated at 75000 of 129723 bytes. …      <- reads as the response's
```

## Sentence wording

Phrased so a count never modifies its noun. Every `itemNoun` is plural, so the alternative is "Returned 1 pages" — and `get-pages` genuinely returns one page when a large first page spends the budget. Singularising the nouns this vocabulary already has (`properties`, `matches`) needs more rules than the sentence is worth.

## Scope

No tool changes; every producer builds the same object it did. The diff is the renderer, the option, and the assertions: 21 runs of field-by-field `toContain` across 16 test files became assertions on the sentence, each keeping exactly the coverage its original had — where an original never asserted the total bytes, the new one stops before it rather than inventing a number.

Mutation-checked: rendering the payload without the substitution, letting `structuredContent` take the substituted copy, emptying `inlineKeys`, and ignoring `inlineKeys` in `renderField` are all caught.

2299 tests, `typecheck`, `lint`, `fmt:check`, `build` and `check:mcp` green locally.

## The issue's three open questions, as answered here

1. **Replace the block, or supplement it?** Replaced. Keeping both duplicates every fact in the channel meant to be the readable one.
2. **Does the `Truncation:` label stay?** Yes — it keeps the marker a payload field like any other, and it is what associates a nested marker with its entry.
3. **A trailing `content` block instead?** No. A client that renders only `content[0]` would lose the notice entirely, which is worse than a noisy one.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; specced in #606 at @alistair3149's request and built from that spec, with the `inlineKeys` design chosen after the first attempt rendered nested markers at column 0; diff not yet human-reviewed; tests written first, mutation-checked, every gate run locally, and each variant's output read back from the built renderer rather than asserted from the source.</sub>