### PR TITLE
Correct the release notes before tagging 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Breaking changes
 
 - `update-page` now refuses a call that replaces a page or section when the source would shorten a target too large for one read to return whole. Pass `removeUnreadContent: true` to do it deliberately, or use `operation='find-replace'` to change part of a page without resending it; appends, growth and any target inside the byte budget are unaffected.
-- `update-page` now requires `latestId` when `section` names the section being replaced, so the wiki resolves the number against the revision it was read from. `get-page` with `metadata=true` returns it alongside the section list; the lead, appends and prepends are unaffected.
+- `update-page` now requires `latestId` on a replace scoped to a section, so the wiki resolves the section number against the revision it was read from. The lead, appends and prepends are unaffected.
+- `update-page` now refuses `removeSubsections` unless the write is a section replace, the only case it means anything for.
 
 ### Added
 
-- `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from; `get-site-info` lists a wiki's namespace IDs. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response now says so.
+- `update-page` takes an `operation` argument naming what the write does: `replace`, `append`, `prepend` or `find-replace`. Omitting it means `replace`; with `section` set, `append` writes at the end of that section and `prepend` immediately above its heading, which inserts a section before an existing one.
 - `update-page` can now rewrite one passage of a page without resending the rest: `operation='find-replace'` takes `find`, the existing wikitext to change, and `replaceWith`, what it becomes. `find` is matched in full and exactly; one that matches nothing, or more than one place, is refused without writing.
-- `update-page` takes an `operation` argument naming what the write does — `replace`, `append`, `prepend` or `find-replace` — where the choice was previously inferred from which other arguments were present. `section` now reads as the scope of the write rather than as a mode of its own: `operation` says what, `section` says where.
+- `search-page` accepts `namespaces` to name the namespace IDs to search, and each result now reports the namespace it came from. When the namespaces searched are not the ones asked for — the wiki refused an ID, or a namespace prefix in the query overrode them — the response says so.
 
 ### Changed
 
-- The content byte cap is now one budget per response rather than one per body, and its default rises from 50000 to 75000 bytes. Operators who set `MCP_CONTENT_MAX_BYTES` are unaffected.
+- The content byte cap is now one budget for the whole response rather than one per body, and its default rises from 50000 to 75000 bytes. `get-pages` returns whole pages until that budget is spent and names the ones left out for a follow-up call to fetch.
 - `get-revision` now applies the same content cap as every other read, to both wikitext and rendered HTML.
+- `get-page` now reports `latestRevisionId` on any read that returns wikitext, so a section replace no longer needs a separate `metadata=true` call to obtain it.
 - `search-page` now searches the namespaces a wiki counts as content, instead of the main namespace only. Pass `namespaces: [0]` for the previous behaviour.
-- `update-page`'s `mode` argument is deprecated in favour of `operation`, which spells the same choice and adds `find-replace`. Calls sending `mode='append'` or `mode='prepend'` keep working; a call sending both is refused when they disagree.
-- `update-page` now documents that a delta can be scoped with `section`: `operation='append'` writes at the end of the named section, and `operation='prepend'` immediately above its heading, which inserts a new section before an existing one without sending the whole page. The combination already worked; nothing about where content lands has changed.
-- The section list `get-page` and `get-pages` report now labels each section with the number that edits it, as `1 (History)` where it was `History`, and leaves out headings that arrive by transclusion, which no section number addresses. This is the outline in every `metadata=true` response as well as the one attached to a truncated read.
+- `update-page`'s `mode` argument is deprecated in favour of `operation`, which spells the same choice. Calls sending `mode='append'` or `mode='prepend'` keep working; a call sending both is refused when they disagree.
+- The section list `get-page` reports now labels each section with the number that edits it, as `1 (History)` where it was `History`, and leaves out headings that arrive by transclusion, which no section number addresses. The same list appears in the truncation marker of both `get-page` and `get-pages`.
 
 ### Fixed
 
-- Passing more namespace IDs than the wiki accepts (50, unless the account holds `apihighlimits`) is now reported as invalid input rather than as an upstream failure. This affects `get-category-members`, `get-links-here`, `get-recent-changes` and `search-page`.
-- A truncated page or section read no longer ends mid-character: the cut falls on a character boundary, so what comes back is a byte-exact prefix of what the page holds and never exceeds the cap it reports against.
+- A truncated body no longer ends mid-character: the cut falls on a character boundary, so what comes back is a byte-exact prefix and never exceeds the cap it reports against. This affects every capped read, including `get-page`, `get-pages`, `get-revision`, `compare-pages` and `parse-wikitext`.
 - A truncated read no longer offers a narrowing that returns the same bytes. A `section=N` read names that section's own subsections, and a read with nothing narrower left says so instead of repeating the call that had just truncated.
-- A wiki that stops answering no longer hangs a tool call for minutes. This covers the first call to a wiki, where connecting and signing in were previously unbounded. A timed-out write reports that the change may or may not have been applied, since the server cannot tell.
+- Passing more namespace IDs than the wiki accepts (50, unless the account holds `apihighlimits`) is now reported as invalid input rather than as an upstream failure. This affects `get-category-members`, `get-links-here` and `get-recent-changes`.
+- A tool call to a wiki that stops answering now fails after 150 seconds, and a first call that cannot connect or sign in after 30 seconds. A timed-out write reports that the change may or may not have been applied and asks you to check the wiki before retrying; neither limit is configurable.
 - `add-wiki` no longer hangs on a URL whose host accepts the connection and then goes quiet. It now gives up after 30 seconds and reports a timeout, instead of suggesting the URL may be wrong.
+- `add-wiki` now registers a wiki whose `$wgServer` is protocol-relative, such as `//example.org`, instead of producing an unusable entry.
 
 ## [0.17.0] - 2026-08-13
 

--- a/src/tools/update-page.ts
+++ b/src/tools/update-page.ts
@@ -59,7 +59,7 @@ const inputSchema = {
 		.positive()
 		.optional()
 		.describe(
-			'Base revision ID for edit-conflict detection; obtain from get-page with metadata=true. Required when section is set, because the wiki resolves a section number against this revision rather than against whichever is current. If omitted on a write that is not scoped to a section, the update is applied without conflict detection.',
+			'Base revision ID for edit-conflict detection; any get-page read that returns wikitext reports it as latestRevisionId. Required when section is set, because the wiki resolves a section number against this revision rather than against whichever is current. If omitted on a write that is not scoped to a section, the update is applied without conflict detection.',
 		),
 	comment: z.string().optional().describe('Summary of the edit'),
 	section: z
@@ -129,7 +129,7 @@ function writePlan(args: UpdatePageArgs): WritePlan {
 	// resolve and nothing to require.
 	if (resolved === 'replace' && section !== undefined && section > 0 && latestId === undefined) {
 		return {
-			error: `Section ${section} names a different section once the page changes, so replacing a section needs latestId to say which revision the number was read from. get-page with metadata=true returns it.`,
+			error: `Section ${section} names a different section once the page changes, so replacing a section needs latestId to say which revision the number was read from. Any get-page read that returns wikitext reports it as latestRevisionId.`,
 		};
 	}
 	if (resolved === 'find-replace') {
@@ -484,7 +484,7 @@ async function findReplace(
 export const updatePage: Tool<typeof inputSchema> = {
 	name: 'update-page',
 	description:
-		"Writes to an existing wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. operation says what the write does and section says where: omit section to act on the whole page, or set it to confine the write to one section. For changing part of a page, use operation='find-replace', which carries only the text being rewritten, so nothing outside find can be lost and the rest of the page never has to travel to or from the caller; a find that matches nothing, or more than one place, is refused without writing, which also makes it safe to resend a call whose result never arrived. For replacing a target outright, use operation='replace', whose source must carry every byte meant to survive; it is refused when source would shorten a target too large for one read to return whole, since the rest was never seen. With section set it also takes out every subsection nested under that section, is refused when source would drop them, and needs latestId to say which revision the section number was read from. operation='append' and 'prepend' add a delta: a new section at the end of the page is an append whose source begins with the heading, and with section set a prepend inserts one immediately above that section. Pass latestId (from get-page with metadata=true) for edit-conflict detection: the write is rejected rather than silently clobbering a concurrent change. Each call is a separate revision, and resending an append or prepend whose result never arrived adds the delta a second time.",
+		"Writes to an existing wiki page and returns the new revision ID. Fails if the page does not exist; for new pages, use create-page. operation says what the write does and section says where: omit section to act on the whole page, or set it to confine the write to one section. For changing part of a page, use operation='find-replace', which carries only the text being rewritten, so nothing outside find can be lost and the rest of the page never has to travel to or from the caller; a find that matches nothing, or more than one place, is refused without writing, which also makes it safe to resend a call whose result never arrived. For replacing a target outright, use operation='replace', whose source must carry every byte meant to survive; it is refused when source would shorten a target too large for one read to return whole, since the rest was never seen. With section set it also takes out every subsection nested under that section, is refused when source would drop them, and needs latestId to say which revision the section number was read from. operation='append' and 'prepend' add a delta: a new section at the end of the page is an append whose source begins with the heading, and with section set a prepend inserts one immediately above that section. Pass latestId (reported as latestRevisionId by any get-page read that returns wikitext) for edit-conflict detection: the write is rejected rather than silently clobbering a concurrent change. Each call is a separate revision, and resending an append or prepend whose result never arrived adds the delta a second time.",
 	inputSchema,
 	annotations: {
 		title: 'Update page',


### PR DESCRIPTION
Blocks the 0.18.0 tag: `npm version` promotes `[Unreleased]` verbatim into the GitHub Release body, so whatever is in it ships.

I audited all sixteen entries against the `v0.17.0` tag rather than against master. **Ten were wrong or overstated, and three changes had no entry at all.** For scale, the 0.17.0 pre-release pass found four of eleven, so this is the same failure mode at a larger size — most of these have been wrong since the day their PR merged.

## Claimed behaviour this release did not change

- **`get-site-info` lists a wiki's namespace IDs**, under `Added`. `git diff v0.17.0..master -- src/tools/get-site-info.ts` is empty; it has been keyed by namespace ID since 0.10.0. It is a leftover: 7fb48a0 wrote it as the tail of a sentence whose first half 3ce019e then deleted.
- **"documents that a delta can be scoped with `section`"**, under `Changed`. It described documentation internal to the `operation` argument announced two entries above, and closed by saying nothing about where content lands had changed. Deleted; its one non-derivable fact — a `prepend` scoped to a section lands *above* the heading — moves into the `operation` entry where it belongs.

## Overstated scope

- The **mid-character cut** is fixed in `truncateByBytes`, the shared cutter, so it reaches `compare-pages` and `parse-wikitext` too. A `compare-pages` user reading "page or section read" would have concluded they were unaffected.
- The **namespace-ID misclassification** never affected `search-page`: its `namespaces` argument does not exist at v0.17.0, so nobody upgrading was ever misclassified there.
- The **section-list change** reaches `get-page`'s metadata outline alone. `get-pages` has no `sections` field on its entries at all — its only outline is inside a truncation marker.

## False as written

- **"Operators who set `MCP_CONTENT_MAX_BYTES` are unaffected."** They are not: the per-response budget applies whatever their number is, and `get-revision` newly caps against it. In this changelog "unaffected" means "skip this entry", which is the opposite of what those operators need.
- **"no longer hangs a tool call for minutes."** `WIKI_CALL_TIMEOUT_MS = 150_000` — 150 seconds *is* minutes, and the error says so. Only a first call, on the 30-second connect budget, fails quickly. The entry also called the old path "unbounded" when it was 255 seconds. Both entries now carry the numbers.

## Shipped with no entry

- **`get-page` reports `latestRevisionId` on any read that returns wikitext.** Added in the same commit as the guard that needs it, and never recorded.
- **`removeSubsections` outside a section replace is now refused.** At v0.17.0 the subsection guard returned early whenever `mode` was set, so `{mode:'append', section:2, removeSubsections:true}` was accepted; on master it is `invalid_input`. A working call that now errors, so it is filed under `Breaking changes`. Narrow exposure, but it was invisible.
- **Discovery normalises a protocol-relative `$wgServer`** (#584, closing #573). A user-visible fix by another contributor that landed with no entry.

## Code corrected alongside

`update-page` told callers in three places — the `latestId` schema description, the tool description, and the message the section guard actually emits — to get the revision ID from `get-page` with `metadata=true`. This release made every wikitext read carry it, so all three sent callers to a heavier call than they need. The refusal message is the one that matters, since it is read at the moment of failure.

2291 tests, `typecheck`, `lint` and `fmt:check` green.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; raised while cutting 0.18.0 at @alistair3149's request; not human-reviewed; every claim above was checked against `git show v0.17.0:<file>` and the code at master, and the audit that produced them ran one agent per pair of entries rather than in one pass.</sub>