### PR TITLE
Split the release into jobs so a failed target can be re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,49 @@ on:
       - 'v*'
 
 jobs:
-  build-and-publish:
+  # Split into three jobs so that a publish target failing on its own can be
+  # re-run on its own: `gh run rerun --failed` works per job, and as one job a
+  # registry failure could only be retried by replaying the npm publish, which
+  # refuses to republish a version it already has.
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      name: ${{ steps.meta.outputs.name }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Read package metadata
+        id: meta
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Run preversion checks
+        run: npm run preversion
+
+      - name: Build MCP Bundle
+        run: npm run bundle
+
+      - name: Upload MCP Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcpb-bundle
+          path: '*.mcpb'
+          if-no-files-found: error
+
+  publish:
+    needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write # For creating release
-      id-token: write # For npm provenance and MCP registry OIDC
+      contents: write # For creating the release and pushing the server.json sync
+      id-token: write # For npm provenance
     env:
       LEFTHOOK: '0' # Skip lefthook hooks; this job commits and pushes from CI
     steps:
@@ -23,11 +61,10 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Run preversion checks
-        run: npm run preversion
-
-      - name: Build MCP Bundle
-        run: npm run bundle
+      - name: Download MCP Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: mcpb-bundle
 
       - name: Update server.json (MCP Bundle)
         run: node scripts/update-server-json-mcpb.cjs
@@ -52,10 +89,9 @@ jobs:
 
       - name: Extract release notes from CHANGELOG
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node scripts/extract-changelog-section.cjs "$VERSION" > release-notes.md
+          node scripts/extract-changelog-section.cjs "${{ needs.build.outputs.version }}" > release-notes.md
           if [ ! -s release-notes.md ]; then
-            echo "::error::Empty CHANGELOG section for $VERSION"
+            echo "::error::Empty CHANGELOG section for ${{ needs.build.outputs.version }}"
             exit 1
           fi
 
@@ -65,12 +101,59 @@ jobs:
           files: '*.mcpb'
           body_path: release-notes.md
 
+      # server.json is rewritten twice above, and the registry publishes the
+      # rewritten file rather than the one at the tag.
+      - name: Upload server.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-json
+          path: server.json
+          if-no-files-found: error
+
+  registry:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For MCP registry OIDC
+    steps:
+      - name: Download server.json
+        uses: actions/download-artifact@v4
+        with:
+          name: server-json
+
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # The registry validates server.json by fetching the npm version it names,
+      # and a publish takes a moment to become readable, so without this the
+      # registry 404s on a package uploaded seconds earlier.
+      - name: Wait for npm to serve the new version
+        run: |
+          NAME='${{ needs.build.outputs.name }}'
+          VERSION='${{ needs.build.outputs.version }}'
+          for attempt in $(seq 1 30); do
+            if curl -sfo /dev/null "https://registry.npmjs.org/$NAME/$VERSION"; then
+              echo "npm is serving $NAME@$VERSION"
+              exit 0
+            fi
+            echo "waiting for npm to serve $NAME@$VERSION ($attempt/30)"
+            sleep 10
+          done
+          echo "::error::npm did not serve $NAME@$VERSION within five minutes"
+          exit 1
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        run: |
+          for attempt in 1 2 3; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            echo "publish attempt $attempt failed; retrying in 30s"
+            sleep 30
+          done
+          echo "::error::MCP registry publish failed three times"
+          exit 1


### PR DESCRIPTION
0.18.0 published to npm and created its GitHub Release, then failed on the MCP registry:

> `NPM package '@professional-wiki/mediawiki-mcp-server' exists, but version '0.18.0' was not found (status: 404). A newly published release can take a moment to appear on the registry. Wait and retry`

The registry validates `server.json` by fetching the npm version it names, and a publish takes a moment to become readable. The race is inherent to the step order and will recur.

**Re-running could not recover it**, which is the worse half. Re-running failed jobs works *per job*, and this was one job, so the retry replayed every step: `npm publish` refused to republish a version it already had, and the run died there without reaching the registry. A partial failure was unfixable except by cutting another version.

## Three jobs instead of one

`build` → `publish` → `registry`, so the platform's own recovery does the work: a registry failure re-runs the registry job alone and npm is never touched.

That deletes the machinery an earlier draft of this PR needed — a `workflow_dispatch` trigger, an existence check before `npm publish`, and an `if: github.event_name == 'push'` guard on the `server.json` push. All three existed only because one job meant all-or-nothing, and each was a place to get idempotence subtly wrong. The draft did: the guard was added after noticing that a dispatch checks out the tag, so `git push HEAD:master` would be a non-fast-forward and fail *before* the registry, reproducing the bug one layer down.

## Two hand-offs that were implicit are now explicit

- **The bundle** travels as an artifact, so the file whose sha256 goes into `server.json` and the file attached to the release are the same *bytes*, not merely the same path in a shared working directory.
- **`server.json`** travels too, because it is rewritten twice during publish — the bundle URL and hash, then the npm version — and the registry publishes the rewritten file, not the one at the tag.

Permissions also narrow: `build` needs none, `publish` needs `contents: write` and `id-token`, `registry` needs `id-token` alone, where previously every step ran with all of them.

## The race is removed, not retried through

Before logging in, the registry job polls npm until it serves the version, for up to five minutes. The publish itself keeps three attempts for anything else transient, rather than a long blind retry that would mask a genuinely bad `server.json`.

## Verifying it

There is nothing here a unit test can reach, and this workflow only runs at release time. The real test is 0.18.0's outstanding registry entry: once merged, re-running the failed run should execute the `registry` job alone.

> <sub>AI-authored — Claude Code, `Opus 5 1M (ultracode)`; written after the 0.18.0 release failed its registry step, then rewritten from a dispatch-and-guards design to this one when @alistair3149 asked whether there was a cleaner alternative; not human-reviewed; the failure and both recovery attempts are from the actual run logs, and the artifact hand-off was confirmed necessary by reading `update-server-json-mcpb.cjs`, which sha256s the bundle and errors if it is absent.</sub>