### PR TITLE
Add a workflow to publish the registry entry on demand

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,0 +1,27 @@
+name: Publish to MCP Registry
+
+# The release workflow already publishes the registry entry on a tag. This runs
+# that step on its own, for when the tagged run cannot do it: re-running a job
+# replays the workflow file as it stood at the tagged commit, so a fix that
+# landed afterwards is not applied. It publishes `server.json` as committed on
+# the ref selected when dispatching.
+on: workflow_dispatch
+
+jobs:
+  registry:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For MCP registry OIDC
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,3 +43,7 @@ The `release` GitHub workflow triggers automatically on the tag and:
 - Builds the `.mcpb` bundle and attaches it to a new [GitHub Release](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server/releases), using the new `CHANGELOG.md` section as the release body.
 - Publishes the package to [NPM](https://www.npmjs.com/package/@professional-wiki/mediawiki-mcp-server).
 - Publishes to the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.professionalwiki/mediawiki-mcp-server).
+
+If one of those steps fails, re-run its job on its own from the failed run. A re-run replays the workflow file as it
+stood at the tagged commit, so when the fix landed after the tag, dispatch the **Publish to MCP Registry** workflow
+instead. It publishes `server.json` as committed on the ref you select.


### PR DESCRIPTION
The release workflow publishes the MCP Registry entry on a tag. When that step fails, the recovery is to re-run its job, and a re-run replays the workflow file as it stood at the tagged commit. A fix to the release workflow therefore never reaches the release that needed it, which is where v0.18.0 sits: on npm and GitHub, still listed at 0.17.0 in the registry.

This adds a single-purpose workflow that runs the same publish on demand, under the same OIDC identity, on `server.json` as committed on the ref selected when dispatching. It needs no idempotence guards because it touches neither npm nor the GitHub Release.

Dispatching the release workflow itself would need them: it would replay `npm publish` and the release creation, each requiring an existence check, and each check a place to get idempotence subtly wrong.

`docs/releasing.md` gains the recovery path.

## Verifying it

`workflow_dispatch` is only offered once the file is on the default branch, so this cannot run before merging. The test is v0.18.0: dispatching it from `master` should publish the committed `server.json`, which already carries version 0.18.0, the npm package at 0.18.0, and a `.mcpb` URL that resolves.

> <sub>AI-authored — Claude Code, `Opus 5 1M`; asked for by @alistair3149 after the v0.18.0 registry entry could not be published by hand, with one round of steering on the approach; not human-reviewed; unverified beyond a YAML parse, since the workflow cannot run until it is on the default branch, and its four steps are the release workflow's own registry steps unchanged.</sub>